### PR TITLE
REST API for dataset

### DIFF
--- a/pkpdapp/pkpdapp/api/__init__.py
+++ b/pkpdapp/pkpdapp/api/__init__.py
@@ -1,0 +1,8 @@
+#
+# This file is part of PKPDApp (https://github.com/pkpdapp-team/pkpdapp) which
+# is released under the BSD 3-clause license. See accompanying LICENSE.md for
+# copyright notice and full license details.
+#
+# flake8: noqa F401
+
+from .views import DatasetView

--- a/pkpdapp/pkpdapp/api/serializers.py
+++ b/pkpdapp/pkpdapp/api/serializers.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+from pkpdapp.models import Dataset
+
+
+class DatasetSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Dataset
+        fields = ('name', 'datetime', 'description')

--- a/pkpdapp/pkpdapp/api/serializers.py
+++ b/pkpdapp/pkpdapp/api/serializers.py
@@ -1,21 +1,44 @@
 from rest_framework import serializers
-from pkpdapp.models import (Dataset, BiomarkerType, Subject)
+from pkpdapp.models import (Dataset, BiomarkerType, Subject, Protocol)
+
+
+# all serializers that get used by the dataset serializer
+class BiomarkerTypeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = BiomarkerType
+        fields = ('name', 'unit', 'description', 'dataset')
+
+
+class ProtocolSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Protocol
+        fields = ('name', 'compound', 'subject', 'dose_type')
+
+
+class SubjectSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Subject
+        fields = ('id_in_dataset', 'dose_group', 'group', 'metadata')
 
 
 class DatasetSerializer(serializers.ModelSerializer):
     biomarkertypes = serializers.SerializerMethodField('find_biomarkertypes')
-    subject_dosegroup = serializers.SerializerMethodField(
-        'find_subject_dosegroup')
+    subjects = serializers.SerializerMethodField('find_subjects')
+    protocols = serializers.SerializerMethodField('find_protocols')
 
     def find_biomarkertypes(self, dataset):
         biomarkers = BiomarkerType.objects.filter(dataset=dataset)
-        return [bm.name for bm in biomarkers]
+        return [BiomarkerTypeSerializer(bm).data for bm in biomarkers]
 
-    def find_subject_dosegroup(self, dataset):
+    def find_protocols(self, dataset):
+        protocols = Protocol.objects.filter(dataset=dataset)
+        return [ProtocolSerializer(pc).data for pc in protocols]
+
+    def find_subjects(self, dataset):
         subjects = Subject.objects.filter(dataset=dataset)
-        return [sj.dose_group for sj in subjects]
+        return [SubjectSerializer(sj).data for sj in subjects]
 
     class Meta:
         model = Dataset
-        fields = ('name', 'datetime', 'description',
-                  'biomarkertypes', 'subject_dosegroup')
+        fields = ('name', 'datetime', 'description', 'subjects',
+                  'biomarkertypes', 'protocols')

--- a/pkpdapp/pkpdapp/api/serializers.py
+++ b/pkpdapp/pkpdapp/api/serializers.py
@@ -1,3 +1,8 @@
+#
+# This file is part of PKPDApp (https://github.com/pkpdapp-team/pkpdapp) which
+# is released under the BSD 3-clause license. See accompanying LICENSE.md for
+# copyright notice and full license details.
+#
 from rest_framework import serializers
 from pkpdapp.models import (Dataset, BiomarkerType, Subject, Protocol)
 

--- a/pkpdapp/pkpdapp/api/serializers.py
+++ b/pkpdapp/pkpdapp/api/serializers.py
@@ -1,8 +1,21 @@
 from rest_framework import serializers
-from pkpdapp.models import Dataset
+from pkpdapp.models import (Dataset, BiomarkerType, Subject)
 
 
 class DatasetSerializer(serializers.ModelSerializer):
+    biomarkertypes = serializers.SerializerMethodField('find_biomarkertypes')
+    subject_dosegroup = serializers.SerializerMethodField(
+        'find_subject_dosegroup')
+
+    def find_biomarkertypes(self, dataset):
+        biomarkers = BiomarkerType.objects.filter(dataset=dataset)
+        return [bm.name for bm in biomarkers]
+
+    def find_subject_dosegroup(self, dataset):
+        subjects = Subject.objects.filter(dataset=dataset)
+        return [sj.dose_group for sj in subjects]
+
     class Meta:
         model = Dataset
-        fields = ('name', 'datetime', 'description')
+        fields = ('name', 'datetime', 'description',
+                  'biomarkertypes', 'subject_dosegroup')

--- a/pkpdapp/pkpdapp/api/views.py
+++ b/pkpdapp/pkpdapp/api/views.py
@@ -1,4 +1,8 @@
-from django.shortcuts import render
+#
+# This file is part of PKPDApp (https://github.com/pkpdapp-team/pkpdapp) which
+# is released under the BSD 3-clause license. See accompanying LICENSE.md for
+# copyright notice and full license details.
+#
 from rest_framework import viewsets
 from .serializers import DatasetSerializer
 from pkpdapp.models import Dataset

--- a/pkpdapp/pkpdapp/api/views.py
+++ b/pkpdapp/pkpdapp/api/views.py
@@ -1,0 +1,9 @@
+from django.shortcuts import render
+from rest_framework import viewsets
+from .serializers import DatasetSerializer
+from pkpdapp.models import Dataset
+
+
+class DatasetView(viewsets.ModelViewSet):
+    queryset = Dataset.objects.all()
+    serializer_class = DatasetSerializer

--- a/pkpdapp/pkpdapp/settings.py
+++ b/pkpdapp/pkpdapp/settings.py
@@ -50,6 +50,7 @@ INSTALLED_APPS = [
     'markdownify',
     'django_extensions',
     'crispy_forms',
+    'rest_framework',
 
     # internal apps
     'explore_data.apps.ExploreDataConfig',

--- a/pkpdapp/pkpdapp/tests/test_api.py
+++ b/pkpdapp/pkpdapp/tests/test_api.py
@@ -1,3 +1,8 @@
+#
+# This file is part of PKPDApp (https://github.com/pkpdapp-team/pkpdapp) which
+# is released under the BSD 3-clause license. See accompanying LICENSE.md for
+# copyright notice and full license details.
+#
 from rest_framework import status
 from rest_framework.test import APITestCase, APIClient
 

--- a/pkpdapp/pkpdapp/tests/test_api.py
+++ b/pkpdapp/pkpdapp/tests/test_api.py
@@ -1,0 +1,12 @@
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APITestCase
+from django.urls import reverse
+
+
+class DatasetTestCase(APITestCase):
+
+    def test_dataset_creation(self):
+        data = {"name": "hello", "datatime": "", "description": ""}
+        response = self.client.post("/api/datasets/", data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/pkpdapp/pkpdapp/tests/test_api.py
+++ b/pkpdapp/pkpdapp/tests/test_api.py
@@ -1,12 +1,20 @@
 from rest_framework import status
-from rest_framework.authtoken.models import Token
-from rest_framework.test import APITestCase
-from django.urls import reverse
+from rest_framework.test import APITestCase, APIClient
 
 
 class DatasetTestCase(APITestCase):
+    client = APIClient()
 
     def test_dataset_creation(self):
-        data = {"name": "hello", "datatime": "", "description": ""}
+        data = {"name": "hello", "datatime": "", "description": "bye"}
         response = self.client.post("/api/datasets/", data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        response_data = response.data
+        self.assertEqual(response_data["name"], data["name"])
+        self.assertEqual(response_data["description"], data["description"])
+
+        keys = response_data.keys()
+        present_keys = ['name', 'datetime', 'description', 'subjects',
+                        'biomarkertypes', 'protocols']
+        for k in present_keys:
+            self.assertTrue(k in keys)

--- a/pkpdapp/pkpdapp/urls.py
+++ b/pkpdapp/pkpdapp/urls.py
@@ -24,7 +24,7 @@ urlpatterns = [
     path('', views.IndexView.as_view(), name='index'),
     path('admin/doc/', include('django.contrib.admindocs.urls')),
     path('admin/', admin.site.urls),
-    path('api/', include(router.urls)),
+    path('api/', include(router.urls), name='api-main'),
     path('accounts/', include('django.contrib.auth.urls')),
     path('dataset/<int:pk>/',
          views.DatasetDetailView.as_view(), name='dataset-detail'),

--- a/pkpdapp/pkpdapp/urls.py
+++ b/pkpdapp/pkpdapp/urls.py
@@ -13,12 +13,18 @@ https://docs.djangoproject.com/en/3.0/topics/http/urls/.
 from django.urls import include, path
 from django.contrib import admin
 from . import views
+from . import api
+from rest_framework import routers
+
+router = routers.DefaultRouter()
+router.register('datasets', api.DatasetView, 'user')
 
 # TODO: Move django_plotly_dash to the app that is actually using it!
 urlpatterns = [
     path('', views.IndexView.as_view(), name='index'),
     path('admin/doc/', include('django.contrib.admindocs.urls')),
     path('admin/', admin.site.urls),
+    path('api/', include(router.urls)),
     path('accounts/', include('django.contrib.auth.urls')),
     path('dataset/<int:pk>/',
          views.DatasetDetailView.as_view(), name='dataset-detail'),

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         'django-extensions==3.1.1',
         'jsonfield==3.1.0',
         'django-crispy-forms==1.11.2',
+        'djangorestframework>=3.12.4',
     ],
     dependency_links=[
         "git+git://github.com/DavAug/erlotinib.git#egg=erlotinib-latest",


### PR DESCRIPTION
Serializes the dataset model class and nestedly (not a word) serializers the following associated with the dataset within the same class:

- biomarkertypes
- subjects
- protocols

It uses a standard precanned view for the serializer. Using a router, this provides a range of urls in api/datasets/ that allows listing all datasets or via api/datasets/1 giving information about a particular dataset.