### PR TITLE
refactor: Clean up useEffect build warnings

### DIFF
--- a/frontend-v2/src/features/model/MapVariablesTab.tsx
+++ b/frontend-v2/src/features/model/MapVariablesTab.tsx
@@ -1,4 +1,4 @@
-import { FC, useRef, useState } from "react";
+import { FC, useCallback, useRef, useState } from "react";
 import {
   CombinedModelRead,
   CompoundRead,
@@ -49,6 +49,27 @@ const MapVariablesTab: FC<Props> = ({
     { key: number; hasLagTimeSelected: boolean; projectId: number, species: ProjectSpeciesEnum | undefined }[]
   >([]);
 
+  const updateDosings = useCallback((key: number, value: boolean) => {
+    setDosing((prevDosings) => [
+      ...prevDosings.filter(({ key: dosingKey, species, projectId }) => key !== dosingKey && species === project.species && projectId === project.id),
+      { key, hasDosingSelected: value, projectId: project?.id, species: project?.species },
+    ]);
+  }, [project?.id, project?.species]);
+
+  const updateLinksToPd = useCallback((key: number, value: boolean) => {
+    setLinkToPd((prevLinks) => [
+      ...prevLinks.filter(({ key: linkKey, species, projectId }) => key !== linkKey && species === project.species && projectId === project.id),
+      { key, hasPdSelected: value, projectId: project?.id, species: project?.species },
+    ]);
+  }, [project?.id, project?.species]);
+
+  const updateLagTimes = useCallback((key: number, value: boolean) => {
+    setLagTimes((prevLags) => [
+      ...prevLags.filter(({ key: lagKey, species, projectId }) => key !== lagKey && species === project.species && projectId === project.id),
+      { key, hasLagTimeSelected: value, projectId: project?.id, species: project?.species },
+    ]);
+  }, [project?.id, project?.species]);
+  
   const iconRef = useRef<HTMLDivElement | null>(null);
   const isAnyDosingSelected = dosings
     .filter(({ projectId }) => projectId === project?.id)
@@ -168,27 +189,6 @@ const MapVariablesTab: FC<Props> = ({
   const timeVariable = variables.find(
     (variable) => variable.binding === "time",
   );
-
-  const updateDosings = (key: number, value: boolean) => {
-    setDosing((prevDosings) => [
-      ...prevDosings.filter(({ key: dosingKey, species, projectId }) => key !== dosingKey && species === project.species && projectId === project.id),
-      { key, hasDosingSelected: value, projectId: project?.id, species: project?.species },
-    ]);
-  };
-
-  const updateLinksToPd = (key: number, value: boolean) => {
-    setLinkToPd((prevLinks) => [
-      ...prevLinks.filter(({ key: linkKey, species, projectId }) => key !== linkKey && species === project.species && projectId === project.id),
-      { key, hasPdSelected: value, projectId: project?.id, species: project?.species },
-    ]);
-  };
-
-  const updateLagTimes = (key: number, value: boolean) => {
-    setLagTimes((prevLags) => [
-      ...prevLags.filter(({ key: lagKey, species, projectId }) => key !== lagKey && species === project.species && projectId === project.id),
-      { key, hasLagTimeSelected: value, projectId: project?.id, species: project?.species },
-    ]);
-  };
 
   const sortVariables = (variable1: VariableRead, variable2: VariableRead) => {
     if (variable1.name.startsWith('C') && variable2.name.startsWith('A')) {

--- a/frontend-v2/src/features/model/VariableRow.tsx
+++ b/frontend-v2/src/features/model/VariableRow.tsx
@@ -124,7 +124,7 @@ const VariableRow: FC<Props> = ({
       }
     }, 1000);
     return () => clearInterval(intervalId);
-  }, [handleSubmit, isDirty, updateVariable]);
+  }, [handleSubmit, isDirty, updateVariable, variable.id]);
 
   const isPD = variable.qname.startsWith("PD");
   const hasProtocol: boolean = watchProtocolId != null;
@@ -150,15 +150,16 @@ const VariableRow: FC<Props> = ({
 
   useEffect(() => {
     updateDosings(variable.id, hasProtocol);
-  }, [hasProtocol]);
+  }, [variable.id, hasProtocol]);
 
   useEffect(() => {
     updateLinksToPd(variable.id, linkToPD);
-  }, [linkToPD]);
+  }, [variable.id, linkToPD]);
 
+  const isLinkedToTLG = derivedIndex("TLG") >= 0;
   useEffect(() => {
-    updateLagTimes(variable.id, isLinkedTo("TLG"));
-  }, [isLinkedTo("TLG")]);
+    updateLagTimes(variable.id, isLinkedToTLG);
+  }, [variable.id, isLinkedToTLG]);
 
   if (
     variable.constant ||

--- a/frontend-v2/src/features/model/VariableRow.tsx
+++ b/frontend-v2/src/features/model/VariableRow.tsx
@@ -150,16 +150,16 @@ const VariableRow: FC<Props> = ({
 
   useEffect(() => {
     updateDosings(variable.id, hasProtocol);
-  }, [variable.id, hasProtocol]);
+  }, [variable.id, hasProtocol, updateDosings]);
 
   useEffect(() => {
     updateLinksToPd(variable.id, linkToPD);
-  }, [variable.id, linkToPD]);
+  }, [variable.id, linkToPD, updateLinksToPd]);
 
   const isLinkedToTLG = derivedIndex("TLG") >= 0;
   useEffect(() => {
     updateLagTimes(variable.id, isLinkedToTLG);
-  }, [variable.id, isLinkedToTLG]);
+  }, [variable.id, isLinkedToTLG, updateLagTimes]);
 
   if (
     variable.constant ||

--- a/frontend-v2/src/features/simulation/SimulationSliderView.tsx
+++ b/frontend-v2/src/features/simulation/SimulationSliderView.tsx
@@ -34,14 +34,13 @@ import { selectIsProjectShared } from "../login/loginSlice";
 interface SimulationSliderProps {
   index: number;
   slider: SimulationSlider;
-  onChange: (value: number) => void;
+  onChange: (variable: number, value: number) => void;
   onSave: (value: number) => void;
   onRemove: () => void;
   units: UnitRead[];
 }
 
 const SimulationSliderView: FC<SimulationSliderProps> = ({
-  index,
   slider,
   onChange,
   onRemove,
@@ -72,8 +71,8 @@ const SimulationSliderView: FC<SimulationSliderProps> = ({
 
   useEffect(() => {
     setValue(defaultValue);
-    onChange(defaultValue);
-  }, [defaultValue]);
+    onChange(slider.variable, defaultValue);
+  }, [defaultValue, onChange, slider.variable]);
 
   const handleSliderChange = (
     event: Event | SyntheticEvent<Element, Event>,
@@ -86,7 +85,7 @@ const SimulationSliderView: FC<SimulationSliderProps> = ({
 
   const handleReset = () => {
     setValue(defaultValue);
-    onChange(defaultValue);
+    onChange(slider.variable, defaultValue);
   };
 
   const handleSave = () => {
@@ -130,7 +129,7 @@ const SimulationSliderView: FC<SimulationSliderProps> = ({
       setValue(maxValue);
       truncatedValue = maxValue;
     }
-    onChange(truncatedValue);
+    onChange(slider.variable, truncatedValue);
   };
 
   if (isLoading) {

--- a/frontend-v2/src/features/simulation/SimulationSliderView.tsx
+++ b/frontend-v2/src/features/simulation/SimulationSliderView.tsx
@@ -1,4 +1,10 @@
-import React, { SyntheticEvent, useEffect } from "react";
+import {
+  ChangeEvent,
+  FC, 
+  SyntheticEvent,
+  useEffect,
+  useState,
+} from "react";
 import {
   SimulationSlider,
   UnitRead,
@@ -34,7 +40,7 @@ interface SimulationSliderProps {
   units: UnitRead[];
 }
 
-const SimulationSliderView: React.FC<SimulationSliderProps> = ({
+const SimulationSliderView: FC<SimulationSliderProps> = ({
   index,
   slider,
   onChange,
@@ -58,16 +64,16 @@ const SimulationSliderView: React.FC<SimulationSliderProps> = ({
 
   const unit = units.find((u) => u.id === variable?.unit);
 
-  const [value, setValue] = React.useState<number>(
-    variable?.default_value || 1.0,
-  );
+  const [range, setRange] = useState<number>(10.0);
 
-  const [range, setRange] = React.useState<number>(10.0);
+  // update the slider value if the variable default value changes
+  const defaultValue = variable?.default_value || 1.0;
+  const [value, setValue] = useState<number>(defaultValue);
 
   useEffect(() => {
-    setValue(variable?.default_value || 1.0);
-    onChange(variable?.default_value || 1.0);
-  }, [variable]);
+    setValue(defaultValue);
+    onChange(defaultValue);
+  }, [defaultValue]);
 
   const handleSliderChange = (
     event: Event | SyntheticEvent<Element, Event>,
@@ -79,8 +85,8 @@ const SimulationSliderView: React.FC<SimulationSliderProps> = ({
   };
 
   const handleReset = () => {
-    setValue(variable?.default_value || 1.0);
-    onChange(variable?.default_value || 1.0);
+    setValue(defaultValue);
+    onChange(defaultValue);
   };
 
   const handleSave = () => {
@@ -100,7 +106,7 @@ const SimulationSliderView: React.FC<SimulationSliderProps> = ({
     setRange(Math.max(range - 10.0, 10.0));
   };
 
-  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     setValue(Number(event.target.value));
   };
 

--- a/frontend-v2/src/features/simulation/Simulations.tsx
+++ b/frontend-v2/src/features/simulation/Simulations.tsx
@@ -30,7 +30,7 @@ import {
   useVariableUpdateMutation,
 } from "../../app/backendApi";
 import { useFieldArray, useForm } from "react-hook-form";
-import { FC, useEffect, useMemo, useState, useRef } from "react";
+import { FC, useCallback, useEffect, useMemo, useState, useRef } from "react";
 import SimulationPlotView from "./SimulationPlotView";
 import SimulationSliderView from "./SimulationSliderView";
 import DropdownButton from "../../components/DropdownButton";
@@ -191,6 +191,10 @@ const Simulations: FC = () => {
   const [sliderValues, setSliderValues] = useState<
     SliderValues | undefined
   >(undefined);
+  const handleChangeSlider = useCallback((variable: number, value: number) => {
+    setSliderValues(prevSliderValues => ({ ...prevSliderValues, [variable]: value }));
+    setLoadingSimulate(true);
+  }, []);
   const [loadingSimulate, setLoadingSimulate] = useState<boolean>(false);
 
   const isSharedWithMe = useSelector((state: RootState) => selectIsProjectShared(state, project));
@@ -521,11 +525,6 @@ const Simulations: FC = () => {
     };
     addSimulationSlider(defaultSlider);
   };
-
-  const handleChangeSlider = (slider: SimulationSlider) => (value: number) => {
-    setSliderValues({ ...sliderValues, [slider.variable]: value });
-    setLoadingSimulate(true);
-  };
   
   const handleRemoveSlider = (index: number) => () => {
     removeSlider(index);
@@ -681,7 +680,7 @@ const Simulations: FC = () => {
               <SimulationSliderView
                 index={index}
                 slider={slider}
-                onChange={handleChangeSlider(slider)}
+                onChange={handleChangeSlider}
                 onRemove={handleRemoveSlider(slider.fieldArrayIndex)}
                 onSave={handleSaveSlider(slider)}
                 units={units}

--- a/frontend-v2/src/features/simulation/Simulations.tsx
+++ b/frontend-v2/src/features/simulation/Simulations.tsx
@@ -275,6 +275,7 @@ const Simulations: FC = () => {
     const timeMax = (sim?.time_max || 0) * timeMaxConversionFactor;
     return timeMax;
   };
+  const timeMax = simulation?.id && getTimeMax(simulation);
 
   // generate a simulation if slider values change
   useEffect(() => {
@@ -286,7 +287,6 @@ const Simulations: FC = () => {
       protocols &&
       compound
     ) {
-      const timeMax = getTimeMax(simulation);
       console.log("Simulating with params", getVariablesSimulated(variables, sliderValues));
       simulate({
         id: model.id,
@@ -312,6 +312,7 @@ const Simulations: FC = () => {
     protocols,
     variables,
     compound,
+    timeMax,
   ]);
 
   const exportSimulation = () => {
@@ -324,7 +325,6 @@ const Simulations: FC = () => {
       sliderValues &&
       project
     ) {
-      const timeMax = getTimeMax(simulation);
       const allParams = getVariablesSimulated(variables, sliderValues);
       console.log("Export to CSV: simulating with params", allParams);
       simulate({
@@ -391,31 +391,31 @@ const Simulations: FC = () => {
     }
   };
 
-  const onSubmit = (dta: Simulation) => {
-    // empty string keeps getting in, so convert to null
-    for (let i = 0; i < dta.plots.length; i++) {
-      // @ts-ignore
-      if (dta.plots[i].min === "") {
-        dta.plots[i].min = null;
-      }
-      // @ts-ignore
-      if (dta.plots[i].max === "") {
-        dta.plots[i].max = null;
-      }
-      // @ts-ignore
-      if (dta.plots[i].min2 === "") {
-        dta.plots[i].min2 = null;
-      }
-      // @ts-ignore
-      if (dta.plots[i].max2 === "") {
-        dta.plots[i].max2 = null;
-      }
-    }
-    updateSimulation({ id: simulation?.id || 0, simulation: dta });
-  };
-
   // save simulation every second if dirty
   useEffect(() => {
+    const onSubmit = (dta: Simulation) => {
+      // empty string keeps getting in, so convert to null
+      for (let i = 0; i < dta.plots.length; i++) {
+        // @ts-ignore
+        if (dta.plots[i].min === "") {
+          dta.plots[i].min = null;
+        }
+        // @ts-ignore
+        if (dta.plots[i].max === "") {
+          dta.plots[i].max = null;
+        }
+        // @ts-ignore
+        if (dta.plots[i].min2 === "") {
+          dta.plots[i].min2 = null;
+        }
+        // @ts-ignore
+        if (dta.plots[i].max2 === "") {
+          dta.plots[i].max2 = null;
+        }
+      }
+      updateSimulation({ id: simulation?.id || 0, simulation: dta });
+    };
+
     const intervalId = setInterval(() => {
       if (!isDirty || !simulation) {
         return;
@@ -424,7 +424,7 @@ const Simulations: FC = () => {
     }, 1000);
 
     return () => clearInterval(intervalId);
-  }, [handleSubmit, isDirty, updateSimulation]);
+  }, [handleSubmit, isDirty, simulation, updateSimulation]);
 
   const loading = [
     isProjectLoading,

--- a/frontend-v2/src/features/trial/Doses.tsx
+++ b/frontend-v2/src/features/trial/Doses.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { FC, useEffect } from "react";
 import { TableCell, TableRow, IconButton, Button, Stack, Typography } from "@mui/material";
 import {
   ProjectRead,
@@ -25,7 +25,7 @@ interface Props {
   units: UnitRead[];
 }
 
-const Doses: React.FC<Props> = ({ project, protocol, units }) => {
+const Doses: FC<Props> = ({ project, protocol, units }) => {
   const { data: variable, isLoading: isVariableLoading } =
     useVariableRetrieveQuery(
       { id: protocol.variables[0] || 0 },

--- a/frontend-v2/src/hooks/useDirty.ts
+++ b/frontend-v2/src/hooks/useDirty.ts
@@ -15,7 +15,7 @@ function useDirty(isDirty: boolean) {
       };
     }
     return undefined;
-  }, [isDirty]);
+  }, [isDirty, dispatch]);
 }
 
 export default useDirty;


### PR DESCRIPTION
Fix build warnings in the frontend. Either remove effect hooks, where they can be
replaced, or add the missing dependencies to the effect hook.
See https://react.dev/learn/you-might-not-need-an-effect

Wrap callbacks in `useCallback`, to minimise re-rendering.