### PR TITLE
chore(deps): bump Django to 3.2.24 (#359)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 gunicorn
-Django==3.2.23
+Django==3.2.24
 setuptools<=65.5.1
 django-cors-headers>=3.7.0
 dpd-static-support>=0.0.5


### PR DESCRIPTION
3.2.24 is a small security patch.