### PR TITLE
refactor: fix HelpButton build warning

### DIFF
--- a/frontend-v2/src/components/HelpButton.tsx
+++ b/frontend-v2/src/components/HelpButton.tsx
@@ -25,9 +25,7 @@ const HelpButton: FC<HelpButtonProps> = ({ title, children }) => {
   );
 
   useEffect(() => {
-    if (open) {
-      setOpen(false);
-    }
+    setOpen(false);
   }, [selectedPage, selectedSubPage]);
 
   const handleOpen = () => {


### PR DESCRIPTION
Remove a reference to `open`, which was triggering a 'missing dependency' warning.