### PR TITLE
feat: plot biomarker data in Simulation tab

### DIFF
--- a/frontend-v2/src/app/backendApi.ts
+++ b/frontend-v2/src/app/backendApi.ts
@@ -2041,6 +2041,7 @@ export type DatasetRead = {
   subjects: number[];
   protocols: ProtocolRead[];
   groups: SubjectGroupRead[];
+  biomarkers: BiomarkerTypeRead[];
   name: string;
   datetime?: string | null;
   description?: string;
@@ -2058,6 +2059,7 @@ export type PatchedDatasetRead = {
   subjects?: number[];
   protocols?: ProtocolRead[];
   groups?: SubjectGroupRead[];
+  biomarkers?: BiomarkerTypeRead[];
   name?: string;
   datetime?: string | null;
   description?: string;

--- a/frontend-v2/src/features/data/Data.tsx
+++ b/frontend-v2/src/features/data/Data.tsx
@@ -1,8 +1,25 @@
 import { FC, useState } from "react";
-import { Button } from "@mui/material";
+import { useSelector } from "react-redux";
+import { useProjectRetrieveQuery, useUnitListQuery } from "../../app/backendApi";
+import { RootState } from "../../app/store";
+import { Button, Typography } from "@mui/material";
+import { DataGrid } from '@mui/x-data-grid';
 import LoadDataStepper from "./LoadDataStepper";
+import useDataset from "../../hooks/useDataset";
 
 const Data:FC = () => {
+  const projectId = useSelector(
+    (state: RootState) => state.main.selectedProject,
+  );
+  const projectIdOrZero = projectId || 0;
+  const { data: project, isLoading: isProjectLoading } =
+    useProjectRetrieveQuery({ id: projectIdOrZero }, { skip: !projectId }
+  );
+  const { data: units, isLoading: isUnitsLoading } = useUnitListQuery(
+    { compoundId: project?.compound || 0 },
+    { skip: !project?.compound },
+  );
+  const { dataset, subjectBiomarkers } = useDataset(projectIdOrZero);
   const [isLoading, setIsLoading] = useState(false);
   function handleNewUpload() {
     setIsLoading(true);
@@ -10,12 +27,59 @@ const Data:FC = () => {
   function onUploadComplete() {
     setIsLoading(false);
   }
+  const protocols = dataset?.protocols || [];
+  const dosingRows = protocols.flatMap(protocol => {
+    const amountUnit = units?.find(unit => unit.id === protocol.amount_unit)?.symbol || '';
+    const timeUnit = units?.find(unit => unit.id === protocol.time_unit)?.symbol || '';
+    const qname = protocol.mapped_qname;
+    return protocol.doses.map(dose => ({
+      id: protocol.id,
+      amount: dose.amount,
+      amountUnit,
+      startTime: dose.start_time,
+      timeUnit,
+      duration: dose.duration,
+      repeats: dose.repeats,
+      repeatInterval: dose.repeat_interval,
+      qname
+    }))
+  });
+  const dosingColumns = dosingRows[0] ? Object.keys(dosingRows[0]).map((field) => ({ field, headerName: field })) : [];
+  const observations = subjectBiomarkers?.flatMap(biomarkerRows => biomarkerRows.map((row) => {
+    const group = dataset?.groups?.find(group => group.subjects.includes(row.subjectId));
+    return  ({
+      ...row,
+      unit: row.unit?.symbol,
+      timeUnit: row.timeUnit?.symbol,
+      group: group?.name
+    })
+  })) || [];
+  const [firstRow] = observations;
+  const columns = firstRow ? Object.keys(firstRow).map((field) => ({ field, headerName: field })) : [];
 
   return isLoading ?
     <LoadDataStepper onFinish={onUploadComplete}  /> :
-    <Button variant="outlined" onClick={handleNewUpload}>
-      Upload new dataset
-    </Button>;
+    <>
+      <Button variant="outlined" onClick={handleNewUpload}>
+        Upload new dataset
+      </Button>
+      <Typography variant="h6" component="h2" gutterBottom>
+        Protocols
+      </Typography>
+      <DataGrid
+        rows={dosingRows}
+        columns={dosingColumns}
+        autoHeight
+      />
+      <Typography variant="h6" component="h2" gutterBottom>
+        Observations
+      </Typography>
+      <DataGrid
+        rows={observations}
+        columns={columns}
+        autoHeight
+      />
+    </>;
 }
 
 export default Data;

--- a/pkpdapp/pkpdapp/api/serializers/dataset.py
+++ b/pkpdapp/pkpdapp/api/serializers/dataset.py
@@ -10,7 +10,9 @@ from drf_spectacular.utils import extend_schema_field
 from pkpdapp.models import (
     Dataset, Protocol, SubjectGroup
 )
-from pkpdapp.api.serializers import ProtocolSerializer, SubjectGroupSerializer
+from pkpdapp.api.serializers import (
+    BiomarkerTypeSerializer, ProtocolSerializer, SubjectGroupSerializer
+)
 
 
 class DatasetSerializer(serializers.ModelSerializer):
@@ -22,10 +24,15 @@ class DatasetSerializer(serializers.ModelSerializer):
     )
     protocols = serializers.SerializerMethodField('get_protocols')
     groups = serializers.SerializerMethodField('get_subject_groups')
+    biomarkers = serializers.SerializerMethodField('get_biomarkers')
 
     class Meta:
         model = Dataset
         fields = '__all__'
+
+    @extend_schema_field(BiomarkerTypeSerializer(many=True))
+    def get_biomarkers(self, dataset):
+        return BiomarkerTypeSerializer(dataset.biomarker_types.all(), many=True).data
 
     @extend_schema_field(SubjectGroupSerializer(many=True))
     def get_subject_groups(self, dataset):

--- a/pkpdapp/pkpdapp/utils/data_parser.py
+++ b/pkpdapp/pkpdapp/utils/data_parser.py
@@ -47,7 +47,7 @@ class DataParser:
             "OBSERVATIONUNIT"
         ],
         "OBSERVATION_VARIABLE": [
-            "Observbation Variable", "OBSERVATION_VARIABLE"
+            "Observation Variable", "OBSERVATION_VARIABLE"
         ],
         "COMPOUND": [
             "Compound", "COMPOUND"

--- a/pkpdapp/schema.yml
+++ b/pkpdapp/schema.yml
@@ -3411,6 +3411,11 @@ components:
           items:
             $ref: '#/components/schemas/SubjectGroup'
           readOnly: true
+        biomarkers:
+          type: array
+          items:
+            $ref: '#/components/schemas/BiomarkerType'
+          readOnly: true
         name:
           type: string
           description: name of the dataset
@@ -3431,6 +3436,7 @@ components:
           description: Project that "owns" this model
       required:
       - biomarker_types
+      - biomarkers
       - groups
       - id
       - name
@@ -4101,6 +4107,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SubjectGroup'
+          readOnly: true
+        biomarkers:
+          type: array
+          items:
+            $ref: '#/components/schemas/BiomarkerType'
           readOnly: true
         name:
           type: string


### PR DESCRIPTION
- add biomarker data to the dataset serialiser.
- add biomarker data to the `useDataset` hook.
- display the dataset as data grids in the Data tab.
- show biomarkers as scatter plots on simulation plots.