### PR TITLE
refactor: handle missing units in CSV

### DIFF
--- a/frontend-v2/src/features/data/LoadData.tsx
+++ b/frontend-v2/src/features/data/LoadData.tsx
@@ -5,6 +5,7 @@ import {useDropzone} from 'react-dropzone'
 import MapHeaders from './MapHeaders';
 import { manditoryHeaders, normaliseHeader } from './normaliseDataHeaders';
 import { StepperState } from './LoadDataStepper';
+import SetUnits from './SetUnits';
 
 export type Row = {[key: string]: string};
 export type Data = Row[];
@@ -97,6 +98,9 @@ const LoadData: FC<ILoadDataProps> = ({state, firstTime}) => {
         {errors.map((error, index) => (
           <Alert severity="error" key={index}>{error}</Alert>
         ))}
+      </Box>
+      <Box sx={{ width: '100%', maxHeight: "20vh", overflow: 'auto', whiteSpace: 'nowrap'}}>
+        {showData && <SetUnits state={state} firstTime={firstTime} />} 
       </Box>
       <Box component="div" sx={{ maxHeight: "40vh", overflow: 'auto', overflowX: 'auto' }}>
         {showData && <MapHeaders data={state.data} fields={state.fields} setNormalisedFields={setNormalisedFields} normalisedFields={state.normalisedFields}/>}

--- a/frontend-v2/src/features/data/MapObservations.tsx
+++ b/frontend-v2/src/features/data/MapObservations.tsx
@@ -54,7 +54,7 @@ const MapObservations: FC<IMapObservations> = ({state}: IMapObservations) => {
   const observationUnitField = state.fields.find(
     (field, i) => ['Observation Unit', 'Unit'].includes(state.normalisedFields[i])
   );
-  const observationUnits = observationRows.map(row => row[observationUnitField || 'Observation Unit']);
+  const observationUnits = observationRows.map(row => row[observationUnitField || 'Observation_unit']);
   const observationVariables = observationRows.map(row => row['Observation Variable']);
 
   const filterOutputs = model?.is_library_model
@@ -74,9 +74,9 @@ const MapObservations: FC<IMapObservations> = ({state}: IMapObservations) => {
     nextData.filter(row => observationIdField ? row[observationIdField] === id : true)
       .forEach(row => {
         row['Observation Variable'] = value;
-        const selectedUnitSymbol = row[observationUnitField || 'Observation Unit'];
+        const selectedUnitSymbol = row[observationUnitField || 'Observation_unit'];
         if (!selectedUnitSymbol && defaultUnit) {
-          row['Observation Unit'] = defaultUnit?.symbol
+          row['Observation_unit'] = defaultUnit?.symbol
         }
       });
     state.setData(nextData);
@@ -86,7 +86,7 @@ const MapObservations: FC<IMapObservations> = ({state}: IMapObservations) => {
     const { value } = event.target;
     nextData.filter(row => observationIdField ? row[observationIdField] === id : true)
       .forEach(row => {
-        row[observationUnitField || 'Observation Unit'] = value;
+        row[observationUnitField || 'Observation_unit'] = value;
       });
     state.setData(nextData);
   }
@@ -118,7 +118,7 @@ const MapObservations: FC<IMapObservations> = ({state}: IMapObservations) => {
             {uniqueObservationIds.map((obsId) => {
               const currentRow = observationRows.find(row => observationIdField ? row[observationIdField] === obsId : true);
               const selectedVariable = variables?.find(variable => variable.qname === currentRow?.['Observation Variable']);
-              let selectedUnitSymbol = currentRow?.[observationUnitField || 'Observation Unit'];
+              let selectedUnitSymbol = currentRow?.[observationUnitField || 'Observation_unit'];
               const compatibleUnits = selectedVariable
                 ? units?.find(unit => unit.id === selectedVariable?.unit)?.compatible_units
                 : units;

--- a/frontend-v2/src/features/data/PreviewData.tsx
+++ b/frontend-v2/src/features/data/PreviewData.tsx
@@ -15,11 +15,14 @@ const PreviewData: FC<IPreviewData> = ({ state, firstTime }: IPreviewData) => {
     'Amount Variable',
     'Observation Variable'
   ];
+  if (!state.normalisedFields.find(field => field === 'Time Unit')) {
+    fields.push('Time_unit')
+  }
   if (!state.normalisedFields.find(field => field === 'Amount Unit')) {
-    fields.push('Amount Unit')
+    fields.push('Amt_unit')
   }
   if (!state.normalisedFields.find(field => field === 'Observation Unit')) {
-    fields.push('Observation Unit')
+    fields.push('Observation_unit')
   }
 
   return (

--- a/frontend-v2/src/features/data/SetUnits.tsx
+++ b/frontend-v2/src/features/data/SetUnits.tsx
@@ -1,3 +1,4 @@
+import { FormControl, InputLabel, SelectChangeEvent } from "@mui/material";
 import { MenuItem, Select, Typography } from "@mui/material";
 import { Field, Data } from "./LoadData";
 import { StepperState } from "./LoadDataStepper";
@@ -26,34 +27,35 @@ const SetUnits: React.FC<IMapObservations> = ({state, firstTime}: IMapObservatio
   const secondUnit = units.find((unit) => unit.symbol === "s");
   const timeUnits = secondUnit?.compatible_units.map((unit) => unit.symbol);
   const timeUnitOptions = timeUnits?.map((unit) => ({ value: unit, label: unit })) || [];
-  const isPreclinical = project.species !== 'H';
-  const amountUnit = isPreclinical ? units.find((unit) => unit.symbol === "pmol/kg") : units.find((unit) => unit.symbol === "pmol");
-  const amountUnits = amountUnit?.compatible_units.map((unit) => unit.symbol);
-  const amountUnitOptions = amountUnits?.map((unit) => ({ value: unit, label: unit })) || [];
 
-  const noTimeUnit = state.normalisedFields.filter((field) => field === "Time Unit").length === 0;
-  const noAmountUnit = state.normalisedFields.filter((field) => field === "Amount Unit").length === 0;
+  const noTimeUnit = !state.normalisedFields.find((field) => field === "Time Unit");
+
+  function setTimeUnit(event: SelectChangeEvent) {
+    state.setTimeUnit(event.target?.value);
+    const newData = state.data.map(row => ({
+      ...row,
+      'Time_unit': event.target?.value
+    }));
+    state.setData(newData);
+  }
   return (
     <div>
       {noTimeUnit && (
-        <div>
-          <Typography variant="h5">Set Time Unit</Typography>
-          <Select value={state.timeUnit} onChange={(event) => state.setTimeUnit(event.target.value)}>
-            {timeUnitOptions.map((option) => (
-              <MenuItem key={option.value} value={option.value}>{option.label}</MenuItem>
-            ))}
-          </Select>
-        </div>
-      )}
-      { noAmountUnit && (
-        <div>
-          <Typography variant="h5">Set Amount Unit</Typography>
-          <Select value={state.amountUnit} onChange={(event) => state.setAmountUnit(event.target.value)}>
-            {amountUnitOptions.map((option) => (
-              <MenuItem key={option.value} value={option.value}>{option.label}</MenuItem>
-            ))}
-          </Select>
-          </div>
+        <>
+          <Typography>Please select a unit for all time values.</Typography>
+          <FormControl>
+            <InputLabel id='select-time-unit-label'>Set Time Unit</InputLabel>
+            <Select
+              labelId='select-time-unit-label'
+              value={state.timeUnit}
+              onChange={setTimeUnit}
+            >
+              {timeUnitOptions.map((option) => (
+                <MenuItem key={option.value} value={option.value}>{option.label}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </>
       )}
     </div>
 

--- a/frontend-v2/src/features/data/Stratification.tsx
+++ b/frontend-v2/src/features/data/Stratification.tsx
@@ -47,13 +47,8 @@ const Stratification: FC<IStratification> = ({ state, firstTime }: IStratificati
 
   if (!firstRow['Group ID']) {
     const newData = [ ...state.data ];
-    protocols.forEach((protocol, index) => {
-      protocol.subjects.forEach(subject => {
-        const subjectRows = newData.filter(row => idField ? row[idField] === subject : false);
-        subjectRows.forEach(row => {
-          row['Group ID'] = `${index + 1}`;
-        });
-      });
+    newData.forEach(row => {
+      row['Group ID'] = row['Group'] || '1';
     });
     state.setData(newData);
   }

--- a/frontend-v2/src/features/data/protocolUtils.ts
+++ b/frontend-v2/src/features/data/protocolUtils.ts
@@ -69,13 +69,13 @@ export function getProtocols(subjectDoses: SubjectDoses[] = []): IProtocol[] {
   return uniqueDoses(subjectDoses).map(doses => {
     const subjects: string[] = [];
     subjectDoses.forEach(subjectDosing => {
-      const subjectId = subjectDosing[0].subject;
+      const subjectId = subjectDosing[0]?.subject;
       if (subjectUsesProtocol(subjectDosing, doses)) {
           subjects.push(subjectId);
       }
     });
     return {
-      label: doses[0].label,
+      label: doses[0]?.label,
       doses,
       subjects
     };

--- a/pkpdapp/pkpdapp/utils/data_parser.py
+++ b/pkpdapp/pkpdapp/utils/data_parser.py
@@ -196,8 +196,9 @@ class DataParser:
                 data[unit_col] = ""
             else:
                 def convert_percent_to_dim(x):
-                    xl = x.lower()
+                    xl = str(x).lower()
                     if (
+                        "nan" in xl or
                         "percent" in xl or
                         "fraction" in xl or
                         "ratio" in xl or


### PR DESCRIPTION
Better handling of missing unit columns in the CSV.
- When time units are missing, prompt to choose a time unit.
- Change the column headings in the submitted CSV to match headings that are expected by the Python data parser utility.
- Add a preclinical flag to the dosing step during uploads.