### PR TITLE
refactor: simplify data fetching

### DIFF
--- a/frontend-v2/src/features/data/LoadDataStepper.tsx
+++ b/frontend-v2/src/features/data/LoadDataStepper.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect } from 'react';
+import { FC } from 'react';
 import { useSelector } from "react-redux";
 import Papa from 'papaparse'
 import Box from '@mui/material/Box';
@@ -73,8 +73,20 @@ const LoadDataStepper: FC<IStepper> = ({ onCancel, onFinish }) => {
   const StepComponent = stepComponents[stepState.activeStep];
   const isFinished = stepState.activeStep === stepLabels.length;
 
-  useEffect(function onFinished() {
-    if (isFinished && dataset?.id) {
+  const handleNext = () => {
+    setStepState((prevActiveStep) => ({ 
+      activeStep: prevActiveStep.activeStep + 1, 
+      maxStep: Math.max(prevActiveStep.maxStep, prevActiveStep.activeStep + 1)
+    }));
+  };
+
+  const handleBack = () => {
+    setStepState((prevActiveStep) => ({ ...prevActiveStep, activeStep: prevActiveStep.activeStep - 1 }));
+  };
+
+  const handleFinish = () => {
+    handleNext();
+    if (dataset?.id) {
       try {
         const csv = Papa.unparse(data);
         updateDatasetCsv({
@@ -92,18 +104,7 @@ const LoadDataStepper: FC<IStepper> = ({ onCancel, onFinish }) => {
         console.error(e);
       }
     }
-  }, [isFinished, onFinish, updateDatasetCsv, updateDataset, dataset?.id, data])
-
-  const handleNext = () => {
-    setStepState((prevActiveStep) => ({ 
-      activeStep: prevActiveStep.activeStep + 1, 
-      maxStep: Math.max(prevActiveStep.maxStep, prevActiveStep.activeStep + 1)
-    }));
-  };
-
-  const handleBack = () => {
-    setStepState((prevActiveStep) => ({ ...prevActiveStep, activeStep: prevActiveStep.activeStep - 1 }));
-  };
+  }
 
   return (
     <Box sx={{ width: '100%' }}>
@@ -125,7 +126,12 @@ const LoadDataStepper: FC<IStepper> = ({ onCancel, onFinish }) => {
           <Button onClick={onCancel}>Cancel</Button> :
           <Button onClick={handleBack}>Back</Button>
         }
-        <Button disabled={isFinished} variant="contained" color="primary" onClick={handleNext}>
+        <Button
+          disabled={isFinished}
+          variant="contained"
+          color="primary"
+          onClick={stepState.activeStep === stepLabels.length - 1 ? handleFinish : handleNext}
+        >
           {stepState.activeStep === stepLabels.length - 1 ? 'Finish' : 'Next'}
         </Button>
       </Box>

--- a/frontend-v2/src/features/projects/Projects.tsx
+++ b/frontend-v2/src/features/projects/Projects.tsx
@@ -32,6 +32,7 @@ import { useCustomToast } from "../../hooks/useCustomToast";
 import { notificationTypes } from "../../components/Notification/notificationTypes";
 import { ReactComponent as FolderLogo } from "../../shared/assets/svg/folder.svg";
 import { defaultHeaderSx } from "../../shared/tableHeadersSx";
+import useDataset from "../../hooks/useDataset";
 
 enum SortOptions {
   CREATED = "created",
@@ -76,6 +77,7 @@ const ProjectTable: React.FC = () => {
   const [addCombinedModel] = useCombinedModelCreateMutation();
   const [addCompound] = useCompoundCreateMutation();
   const [addSimulation] = useSimulationCreateMutation();
+  const { addDataset } = useDataset(selectedProject);
 
   if (isLoading || unitsLoading || compoundsLoading) {
     return <div>Loading...</div>;
@@ -166,6 +168,7 @@ const ProjectTable: React.FC = () => {
       })
       .then((newProject) => {
         if ("data" in newProject) {
+          addDataset(newProject.data.id);
           addCombinedModel({
             combinedModel: {
               name: `model for project ${newProject.data.id}`,

--- a/frontend-v2/src/features/simulation/Simulations.tsx
+++ b/frontend-v2/src/features/simulation/Simulations.tsx
@@ -78,7 +78,7 @@ const Simulations: FC = () => {
   const projectId = useSelector(
     (state: RootState) => state.main.selectedProject,
   );
-  const { dataset, groups } = useDataset(projectId);
+  const { groups } = useDataset(projectId);
   const [visibleGroups, setVisibleGroups] =
     useState<string[]>(groups.map(group => group.name) || []);
   const projectIdOrZero = projectId || 0;
@@ -174,8 +174,7 @@ const Simulations: FC = () => {
     protocols,
     variables,
     compound,
-    timeMax,
-    dataset,
+    timeMax
   );
 
   const {

--- a/frontend-v2/src/features/simulation/useSimulation.ts
+++ b/frontend-v2/src/features/simulation/useSimulation.ts
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import {
   CompoundRead,
   CombinedModelRead,
-  DatasetRead,
   ProtocolListApiResponse,
   Simulate,
   SimulationRead,
@@ -93,8 +92,7 @@ export default function useSimulation(
   protocols: ProtocolListApiResponse | undefined,
   variables: VariableListApiResponse | undefined,
   compound: CompoundRead | undefined,
-  timeMax: number | undefined,
-  dataset: DatasetRead | null,
+  timeMax: number | undefined
 ) {
   const [loadingSimulate, setLoadingSimulate] = useState<boolean>(false);
   const [data, setData] = useState<SimulateResponse[]>([]);
@@ -134,15 +132,14 @@ export default function useSimulation(
       });
     }
   }, [
-    simulation,
-    simulate,
-    sliderValues,
+    compound,
     model,
     protocols,
-    variables,
-    compound,
+    simulate,
+    simulation,
+    sliderValues,
     timeMax,
-    dataset,
+    variables,
   ]);
 
   return {

--- a/frontend-v2/src/hooks/useDataset.ts
+++ b/frontend-v2/src/hooks/useDataset.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect } from 'react';
 import {
   DatasetRead,
   useDatasetListQuery,
@@ -9,11 +9,7 @@ import {
   useBiomarkerTypeListQuery
 } from '../app/backendApi';
 
-// assume only one dataset per project for the time being.
-let appDataset: DatasetRead | null = null;
-
 export default function useDataset(selectedProject: number | null) {
-  const [dataset, setDataset] = useState<null | DatasetRead>(appDataset);
   const selectedProjectOrZero = selectedProject || 0;
   const { data: project } =
     useProjectRetrieveQuery({ id: selectedProjectOrZero }, { skip: !selectedProject }
@@ -22,10 +18,11 @@ export default function useDataset(selectedProject: number | null) {
     { compoundId: project?.compound || 0 },
     { skip: !project?.compound },
   );
-  const { data: datasets = [], isLoading: isDatasetLoading } = useDatasetListQuery(
+  const { data: datasets = [], refetch } = useDatasetListQuery(
     { projectId: selectedProjectOrZero },
     { skip: !selectedProject },
   );
+  const [dataset] = datasets;
   const { data: subjectGroups, refetch: refetchSubjectGroups } = useSubjectGroupListQuery(
     { datasetId: dataset?.id || 0 },
     { skip: !dataset }
@@ -39,43 +36,30 @@ export default function useDataset(selectedProject: number | null) {
     createDataset
   ] = useDatasetCreateMutation();
 
-  if (dataset !== appDataset) {
-    setDataset(appDataset);
-  }
-
   useEffect(() => {
     if (dataset?.id) {
+      console.log('refetching groups and observations')
       refetchSubjectGroups();
       refetchBiomarkerTypes();
     }
   }, [dataset, refetchBiomarkerTypes, refetchSubjectGroups]);
 
-  useEffect(function onDataLoad() {
-    async function addDataset() {
-      let [newDataset] = datasets;
-      if (!newDataset) {
-        const response = await createDataset({
-          dataset: {
-            name: 'New Dataset',
-            project: selectedProjectOrZero,
-          }
-        });
-        if ('data' in response && response.data) {
-          newDataset = response.data;
-        }
+  
+  async function addDataset(projectId: number) {
+    const response = await createDataset({
+      dataset: {
+        name: 'New Dataset',
+        project: projectId,
       }
-      appDataset = newDataset;
-      setDataset(appDataset);
-    }
-    if (selectedProjectOrZero && !isDatasetLoading) {
-      addDataset();
-    }
-  }, [datasets, createDataset, isDatasetLoading, selectedProjectOrZero]);
+    });
+    console.log('created a new dataset')
+    return response;
+  }
 
   const updateDataset = useCallback((newDataset: DatasetRead) => {
-    appDataset = newDataset;
-    setDataset(appDataset);
-  }, []);
+    console.log('updating dataset', newDataset)
+    refetch();
+  }, [refetch]);
 
   const subjectBiomarkers = biomarkerTypes?.filter(b => b.is_continuous)
     .map(b => {
@@ -101,6 +85,7 @@ export default function useDataset(selectedProject: number | null) {
     dataset,
     groups: subjectGroups || [],
     subjectBiomarkers: subjectBiomarkers || [],
+    addDataset,
     updateDataset
   };
 }


### PR DESCRIPTION
Replace `useEffect` with event handlers for adding new datasets and finishing uploads. Refetch datasets rather than storing them in a global variable, so that the database is always the source of truth.