### PR TITLE
refactor: default subject groups

### DIFF
--- a/frontend-v2/src/features/data/LoadData.tsx
+++ b/frontend-v2/src/features/data/LoadData.tsx
@@ -71,6 +71,15 @@ const LoadData: FC<ILoadDataProps> = ({state, firstTime}) => {
     });
     state.setData(newData);
   }
+  if (!state.fields.includes('Group')) {
+    state.setNormalisedFields([...state.normalisedFields, 'Cat Covariate']);
+    state.setFields([...state.fields, 'Group']);
+    const newData = [ ...state.data ];
+    newData.forEach(row => {
+      row['Group'] = '1';
+    });
+    state.setData(newData);
+  }
 
   const onDrop = useCallback((acceptedFiles: File[]) => {
     acceptedFiles.forEach((file) => {

--- a/frontend-v2/src/features/data/ProtocolDataGrid.tsx
+++ b/frontend-v2/src/features/data/ProtocolDataGrid.tsx
@@ -1,8 +1,10 @@
-import { FC } from 'react';
-import { DataGrid } from '@mui/x-data-grid';
+import { FC, useState } from 'react';
+import { DataGrid, GridRowId } from '@mui/x-data-grid';
 import { StepperState } from './LoadDataStepper';
+import SubjectGroupForm from './SubjectGroupForm';
 
 type SubjectGroup = {
+  id: string,
   name: string,
   subjects: string[]
 }
@@ -13,24 +15,30 @@ interface IProtocolDataGrid {
 }
 
 const ProtocolDataGrid: FC<IProtocolDataGrid> = ({ group, state }) => {
+  const [selected, setSelected] = useState<GridRowId[]>([]);
   const idField = state.fields.find((field, index) => state.normalisedFields[index] === 'ID');
-  const amountField = state.fields.find((field, index) => state.normalisedFields[index] === 'Amount');
   const { subjects } = group;
-  const protocolRows = state.data.filter(row => {
-    const subjectId = idField && row[idField];
-    const amount = amountField && +row[amountField];
-    return subjects.includes(subjectId || '') && amount;
-  }).map(row => {
-    const subjectId = (idField && +row[idField]) || 0;
-    return { id: +subjectId, ...row };
-  });
-  const protocolColumns = state.fields.map((field) => ({ field, headerName: field }));
+  const subjectRows = subjects.map(subject => {
+    const row = state.data.find(row => idField && row[idField] === subject);
+    return { id: subject, ...row };
+  }).filter(Boolean);
+  const subjectColumns = state.fields.map((field) => ({ field, headerName: field }));
+
+  function onRowSelectionModelChange(selection: GridRowId[]) {
+    setSelected(selection);
+  }
   return (
-    <DataGrid
-      rows={protocolRows}
-      columns={protocolColumns}
-      checkboxSelection
-    />
+    <>
+      <DataGrid
+        rows={subjectRows}
+        columns={subjectColumns}
+        checkboxSelection
+        onRowSelectionModelChange={onRowSelectionModelChange}
+      />
+      {selected.length > 0 &&
+        <SubjectGroupForm group={group} state={state} selected={selected} />
+      }
+    </>
   );
 }
 

--- a/frontend-v2/src/features/data/Stratification.tsx
+++ b/frontend-v2/src/features/data/Stratification.tsx
@@ -40,9 +40,11 @@ const Stratification: FC<IStratification> = ({ state, firstTime }: IStratificati
   const primaryCohortIndex = catCovariates.indexOf(primaryCohort);
   const groupColumnValues = uniqueCovariateValues[primaryCohortIndex] || [];
   const groups = groupColumnValues.map((value, index) => {
+    const subjects = state.data.filter(row => row[primaryCohort] === value).map(row => idField ? row[idField] : '');
     return {
+      id: value,
       name: `Group ${index + 1}`,
-      subjects: state.data.filter(row => row[primaryCohort] === value).map(row => idField ? row[idField] : ''),
+      subjects: [...new Set(subjects)],
     };
   });
 

--- a/frontend-v2/src/features/data/SubjectGroupForm.tsx
+++ b/frontend-v2/src/features/data/SubjectGroupForm.tsx
@@ -1,0 +1,68 @@
+import { Box, Input, InputLabel } from '@mui/material';
+import { GridRowId } from '@mui/x-data-grid';
+import { FC, FormEvent, useRef } from 'react';
+import { StepperState } from './LoadDataStepper';
+
+type SubjectGroup = {
+  id: string,
+  name: string,
+  subjects: string[]
+}
+
+interface ISubjectGroupForm {
+  group: SubjectGroup,
+  state: StepperState,
+  selected: GridRowId[]
+}
+
+const SubjectGroupForm: FC<ISubjectGroupForm> = ({ group, selected, state }) => {
+  const selectedGroupInput = useRef<HTMLInputElement>(null);
+  const idField = state.fields.find((field, index) => state.normalisedFields[index] === 'ID');
+
+  function onSubmitGroupIDForm(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const newValue = selectedGroupInput.current?.value || group.id;
+    const newData = [...state.data];
+    selected.forEach((id) => {
+      newData.filter(row => idField ? row[idField] === id : false)
+      .forEach(row => {
+        row['Group'] = newValue;
+        row['Group ID'] = newValue;
+      });
+    });
+    state.setData(newData);
+  }
+
+  return (
+    <Box
+      component='form'
+      onSubmit={onSubmitGroupIDForm}
+      padding='1rem'
+      sx={{
+        border: '1px solid',
+        borderColor: 'primary.light',
+        width: 'fit-content',
+      }}
+    >
+      <InputLabel
+        htmlFor='selected-group'
+        sx={{
+          fontSize: '0.75rem',
+        }}
+      >
+        Change the group ID for selected rows
+      </InputLabel>
+      <Input
+        inputRef={selectedGroupInput}
+        type='number'
+        id='selected-group'
+        defaultValue={group.id}
+        sx={{
+          fontSize: '0.75rem',
+        }}
+      />
+    </Box>
+  )
+}
+
+export default SubjectGroupForm;


### PR DESCRIPTION
- Set a default subject group column after uploading a CSV, if none is present.
- List the members of this group in the Stratification view, one row per subject ID.
- Allow users to create groups by editing the group IDs of selected rows in the Stratification view.