### PR TITLE
feat: user visit logging

### DIFF
--- a/pkpdapp/pkpdapp/settings.py
+++ b/pkpdapp/pkpdapp/settings.py
@@ -99,6 +99,7 @@ INSTALLED_APPS = [
     "rest_framework.authtoken",
     "corsheaders",
     "drf_spectacular",
+    "user_visit",
     # internal apps
     "pkpdapp",
 ]
@@ -242,6 +243,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "user_visit.middleware.UserVisitMiddleware",
 ]
 
 CORS_ALLOWED_ORIGINS = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ django-auth-ldap>=4.1.0
 pyyaml>=6.0.0
 drf-spectacular>=0.26.2
 openpyxl>=3.1.2
+django-user-visit>=2.0.0


### PR DESCRIPTION
Install `django-user-visit`, which logs user visits.

You can find the log in the Django admin panel:
http://127.0.0.1:8000/admin/user_visit/uservisit/