### PR TITLE
feat: snapshot tests for model simulations

### DIFF
--- a/pkpdapp/.coveragerc
+++ b/pkpdapp/.coveragerc
@@ -2,6 +2,7 @@
 source = .
 omit =
     */apps.py
+    */management/*
     */tests/*
     manage.py
     pkpdapp/asgi.py

--- a/pkpdapp/pkpdapp/management/__init__.py
+++ b/pkpdapp/pkpdapp/management/__init__.py
@@ -1,0 +1,5 @@
+#
+# This file is part of PKPDApp (https://github.com/pkpdapp-team/pkpdapp) which
+# is released under the BSD 3-clause license. See accompanying LICENSE.md for
+# copyright notice and full license details.
+#

--- a/pkpdapp/pkpdapp/management/commands/__init__.py
+++ b/pkpdapp/pkpdapp/management/commands/__init__.py
@@ -1,0 +1,5 @@
+#
+# This file is part of PKPDApp (https://github.com/pkpdapp-team/pkpdapp) which
+# is released under the BSD 3-clause license. See accompanying LICENSE.md for
+# copyright notice and full license details.
+#

--- a/pkpdapp/pkpdapp/management/commands/test_snapshots.py
+++ b/pkpdapp/pkpdapp/management/commands/test_snapshots.py
@@ -1,0 +1,36 @@
+#
+# This file is part of PKPDApp (https://github.com/pkpdapp-team/pkpdapp) which
+# is released under the BSD 3-clause license. See accompanying LICENSE.md for
+# copyright notice and full license details.
+#
+from django.core.management.base import BaseCommand
+import unittest
+from snapshottest.django import TestCase
+from pkpdapp.models import CombinedModel
+
+
+class Command(BaseCommand):
+    help = """
+    If you need Arguments, please check other modules in
+    django/core/management/commands.
+    """
+
+    def handle(self, **options):
+        suite = unittest.TestLoader().loadTestsFromTestCase(TestSimulations)
+        unittest.TextTestRunner().run(suite)
+
+
+class TestSimulations(TestCase):
+    def setUp(self):
+        self.models = CombinedModel.objects.all()
+
+    def test_snapshots(self):
+        for model in self.models:
+            outputs = [
+                variable.qname for variable in model.variables.filter(constant=False)
+            ]
+            sim = model.simulate(
+                outputs=outputs,
+                time_max=672
+            )
+            self.assertMatchSnapshot(sim)

--- a/pkpdapp/pkpdapp/settings.py
+++ b/pkpdapp/pkpdapp/settings.py
@@ -408,3 +408,5 @@ CELERY_BROKER_TRANSPORT_OPTIONS = {
     "interval_step": 0.2,
     "interval_max": 0.5,
 }
+
+TEST_RUNNER = 'snapshottest.django.TestRunner'

--- a/pkpdapp/sonar-project.properties
+++ b/pkpdapp/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=pkpdapp-team_pkpdapp
 sonar.organization=pkpdapp-team
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.sources=pkpdapp/
-sonar.exclusions=pkpdapp/tests/**
+sonar.exclusions=pkpdapp/tests/**, pkpdapp/management/**
 sonar.tests=pkpdapp/tests/
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ django-auth-ldap>=4.1.0
 pyyaml>=6.0.0
 drf-spectacular>=0.26.2
 openpyxl>=3.1.2
+snapshottest>=0.6.0


### PR DESCRIPTION
Add a custom managment command:
```sh
python manage.py test_snapshots
```

This runs simulations for all combined PKPD models, and saves snapshots of the output logs.
Use it to check for regressions in the model simulations across branches.

```sh
git checkout master
python manage.py test_snapshots
git checkout development
python manage.py test_snapshots
git clean -df
````