### PR TITLE
refactor: error handling for data uploads

### DIFF
--- a/frontend-v2/src/features/data/CreateDosingProtocols.tsx
+++ b/frontend-v2/src/features/data/CreateDosingProtocols.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react';
 import {
+  Alert,
   Box,
   Select,
   FormControl,
@@ -30,7 +31,6 @@ interface IDosingProtocols {
 
 const CreateDosingProtocols: FC<IDosingProtocols> = ({
   administrationIdField,
-  amountUnitField = 'Amount Unit',
   amountUnit,
   state,
   units,
@@ -74,21 +74,12 @@ const CreateDosingProtocols: FC<IDosingProtocols> = ({
       })
     state.setData(nextData);
   }
-  const handleAmountUnitChange = (id: string) => (event: SelectChangeEvent) => {
-    const nextData = [...state.data];
-    const { value } = event.target;
-    nextData.filter(row => administrationIdField ? row[administrationIdField] === id : true)
-      .forEach(row => {
-        row[amountUnitField || 'Amt_unit'] = value;
-      })
-    state.setData(nextData);
-  }
   return (
     <>
-      <p>
+      <Alert severity="info">
         Map dosing compartments to your subject groups here.
-        You can set dose amounts and intervals under Trial Design, once you have uploaded your data.
-      </p>
+        You can set dose amounts, units and intervals under Trial Design, once you have uploaded your data.
+      </Alert>
       <Box component="div" sx={{ maxHeight: "40vh", overflow: 'auto', overflowX: 'auto' }}>
         <Table>
           <TableHead>
@@ -103,19 +94,12 @@ const CreateDosingProtocols: FC<IDosingProtocols> = ({
                   Dosing Compartment
                 </Typography>
               </TableCell>
-              <TableCell>
-                <Typography>
-                  Unit
-                </Typography>
-              </TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
             {uniqueAdministrationIds.map((adminId, index) => {
               const currentRow = state.data.find(row => administrationIdField ? row[administrationIdField] === adminId : true);
               const selectedVariable = variables?.find(variable => variable.qname === currentRow?.['Amount Variable']);
-              const compatibleUnits = units?.find(unit => unit.id === selectedVariable?.unit)?.compatible_units;
-              const adminUnit = amountUnitField && currentRow && currentRow[amountUnitField];
               return (
                 <TableRow>
                   <TableCell>
@@ -136,25 +120,6 @@ const CreateDosingProtocols: FC<IDosingProtocols> = ({
                         ))}
                       </Select>
                     </FormControl>
-                  </TableCell>
-                  <TableCell>
-                    {adminUnit ?
-                      adminUnit :
-                      <FormControl fullWidth>
-                        <InputLabel id={`select-unit-${adminId}-label`}>Units</InputLabel>
-                        <Select
-                          labelId={`select-unit-${adminId}-label`}
-                          id={`select-unit-${adminId}`}
-                          label='Units'
-                          value={currentRow?.[amountUnitField || 'Amt_unit']}
-                          onChange={handleAmountUnitChange(adminId)}
-                        >
-                          {compatibleUnits?.map((unit) => (
-                            <MenuItem key={unit.symbol} value={unit.symbol}>{unit.symbol}</MenuItem>
-                          ))}
-                        </Select>
-                      </FormControl>
-                    }
                   </TableCell>
                 </TableRow>
               )

--- a/frontend-v2/src/features/data/DosingProtocols.tsx
+++ b/frontend-v2/src/features/data/DosingProtocols.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react';
 import {
+  Alert,
   Box,
   Select,
   FormControl,
@@ -78,7 +79,9 @@ const DosingProtocols: FC<IDosingProtocols> = ({
   }
   return (
     <>
-      <p>Map dose amounts to dosing compartments in the model.</p>
+      <Alert severity="info">
+        Set a dosing compartment and unit for each of your subject groups here.
+      </Alert>
       <Box component="div" sx={{ maxHeight: "40vh", overflow: 'auto', overflowX: 'auto' }}>
         <Table>
           <TableHead>

--- a/frontend-v2/src/features/data/MapObservations.tsx
+++ b/frontend-v2/src/features/data/MapObservations.tsx
@@ -1,5 +1,19 @@
 import { FC, useState } from 'react';
-import { Box, Select, FormControl, MenuItem, InputLabel, Table, TableHead, TableRow, TableCell, TableBody, Typography, SelectChangeEvent } from "@mui/material";
+import {
+  Alert,
+  Box,
+  Select,
+  FormControl,
+  MenuItem,
+  InputLabel,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  Typography,
+  SelectChangeEvent
+} from "@mui/material";
 import { StepperState } from "./LoadDataStepper";
 import { useSelector } from "react-redux";
 import { RootState } from "../../app/store";
@@ -93,7 +107,9 @@ const MapObservations: FC<IMapObservations> = ({state}: IMapObservations) => {
   }
   return (
     <>
-      <p>Map observations to variables in the model.</p>
+      <Alert severity='info'>
+        Map observations to variables in the model.
+      </Alert>
       <Box component="div" sx={{ maxHeight: "40vh", overflow: 'auto', overflowX: 'auto' }}>
         <Table>
           <TableHead>

--- a/frontend-v2/src/features/data/SetUnits.tsx
+++ b/frontend-v2/src/features/data/SetUnits.tsx
@@ -12,6 +12,7 @@ import { StepperState } from "./LoadDataStepper";
 import { useProjectRetrieveQuery, useUnitListQuery } from "../../app/backendApi";
 import { useSelector } from "react-redux";
 import { RootState } from "../../app/store";
+import { validateNormalisedFields } from "./normaliseDataHeaders";
 
 interface IMapObservations {
   state: StepperState;
@@ -44,11 +45,14 @@ const SetUnits: React.FC<IMapObservations> = ({state, firstTime}: IMapObservatio
       'Time_unit': event.target?.value
     }));
     state.setData(newData);
+    const { errors, warnings } = validateNormalisedFields([...state.normalisedFields, 'Time Unit']);
+    state.setErrors(errors);
+    state.setWarnings(warnings);
   }
   return (
     <div>
       {noTimeUnit && (
-        <Alert severity="error">
+        <Alert severity='info'>
           <Stack direction='row' spacing='1rem'>
             <Typography>Please select a unit for all time values.</Typography>
             <FormControl sx={{ minWidth: '10rem' }}>

--- a/frontend-v2/src/features/data/normaliseDataHeaders.ts
+++ b/frontend-v2/src/features/data/normaliseDataHeaders.ts
@@ -24,11 +24,30 @@ const normalisation = {
     'Unit': ['unit', 'units'],
 }
 
-export const manditoryHeaders = ['ID', 'Time', 'Observation', 'Administration ID', 'Amount']
+export const manditoryHeaders = ['Time', 'Observation', 'Time Unit']
 
 export const normalisedHeaders = Object.keys(normalisation)
 
-
+export const validateNormalisedFields = (fields: string[]) => {
+    const errors: string[] = [];
+    // check for mandatory fields
+    for (const field of manditoryHeaders) {
+        if (!fields.includes(field)) {
+        errors.push(`${field} has not been defined`);
+        }
+    }
+    const warnings: string[] = [];
+    if (!fields.includes('ID')) {
+        warnings.push('ID has not been defined. IDs will be generated automatically.');
+    }
+    if (!fields.includes('Amount')) {
+        warnings.push('Amount has not been defined. Dosing amounts can be set in Trial Design.');
+    }
+    if (!fields.includes('Amount Unit')) {
+        warnings.push('Amount Unit has not been defined. Dosing units can be set in Trial Design.');
+    }
+    return { errors, warnings };
+}
 export const normaliseHeader = (header: string) => {
     for (const [key, value] of Object.entries(normalisation)) {
         if (value.includes(header.toLowerCase())) {


### PR DESCRIPTION
- missing data columns should be warnings, with info about defaults.
- missing time units should only error when the time unit is undefined.
- a CSV without a header row should error and prevent you from continuing.
- 'Next' should be disabled for errors eg. no time unit set.
- CSV upload errors should be displayed in the UI.

<img width="800" alt="A screenshot of the data upload view, showing an error for missing time units, warnings for missing subject and amount columns, and a dropdown to set a time unit for the dataset." src="https://github.com/pkpdapp-team/pkpdapp/assets/59547/40bfe009-0170-4e26-bf5a-bbc87978ab57">
