### PR TITLE
fix: fix React errors and warnings

### DIFF
--- a/frontend-v2/src/features/model/PKPDModelTab.tsx
+++ b/frontend-v2/src/features/model/PKPDModelTab.tsx
@@ -154,7 +154,7 @@ const PKPDModelTab: FC<Props> = ({ model, project, control }: Props) => {
   }
 
   return (
-    <Grid xs={12} container spacing={2}>
+    <Grid container spacing={2}>
       <Grid item xl={5} md={8} xs={10}>
         <Stack direction="row" alignItems="center" spacing={1}>
           <SelectField

--- a/frontend-v2/src/features/projects/Project.tsx
+++ b/frontend-v2/src/features/projects/Project.tsx
@@ -225,7 +225,7 @@ const ProjectRow: FC<Props> = ({
           />
         </TableCell>
         <TableCell>
-          <Typography>
+          <Typography component='span'>
             {speciesOptions.find((s) => s.value === project.species)?.label}
           </Typography>
         </TableCell>
@@ -245,7 +245,7 @@ const ProjectRow: FC<Props> = ({
           }
         </TableCell>
         <TableCell>
-          <Stack direction="row" spacing={0.0}>
+          <Stack component='span' direction="row" spacing={0.0}>
             <Tooltip title={deleteTooltip}>
               <IconButton onClick={() => setShowConfirmDelete(true)}>
                 <Delete />
@@ -265,11 +265,9 @@ const ProjectRow: FC<Props> = ({
             </Tooltip>
 
             <Tooltip title="Share Project">
-            <div>
               <IconButton onClick={() => setUserAccessOpen(true)} disabled={isSharedWithMe}>
                 <PersonAdd />
               </IconButton>
-            </div>
             </Tooltip>
             <UserAccess
               open={userAccessOpen}


### PR DESCRIPTION
- fix a stray `xs` prop on a Grid container.
- replace `div` with `span` inside table cells.
- closes #400.