### PR TITLE
build: Docker updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 # Using a 2-stage build. This is the builder for javascript frontend
 
-FROM node:19 as build
+FROM node:20 as build
 RUN mkdir -p /app/frontend
 WORKDIR /app/frontend
 COPY frontend-v2/package.json /app/frontend
+COPY frontend-v2/yarn.lock /app/frontend/
 
-RUN npm install --ignore-scripts
+RUN yarn install --ignore-scripts --frozen-lockfile
 
 COPY frontend-v2 /app/frontend/
 COPY .env.prod /app/


### PR DESCRIPTION
- build the frontend from the Node 20 image.
- copy `yarn.lock` into the image before running `yarn install`.
- freeze the lockfile. Installs that change the Yarn version, or introduce new dependencies, should break the build.