### PR TITLE
refactor: simplify simulation hook parameters

### DIFF
--- a/frontend-v2/src/app/backendApi.ts
+++ b/frontend-v2/src/app/backendApi.ts
@@ -2463,6 +2463,7 @@ export type Project = {
 export type ProjectRead = {
   id: number;
   user_access: ProjectAccessRead[];
+  datasets: number[];
   protocols: number[];
   name: string;
   description?: string;
@@ -2481,6 +2482,7 @@ export type PatchedProject = {
 export type PatchedProjectRead = {
   id?: number;
   user_access?: ProjectAccessRead[];
+  datasets?: number[];
   protocols?: number[];
   name?: string;
   description?: string;

--- a/frontend-v2/src/features/model/Model.tsx
+++ b/frontend-v2/src/features/model/Model.tsx
@@ -100,6 +100,7 @@ const Model: FC = () => {
     compound: 0,
     users: [],
     protocols: [],
+    datasets: [],
   };
 
   const defaultValues: FormData = {

--- a/frontend-v2/src/features/simulation/Simulations.tsx
+++ b/frontend-v2/src/features/simulation/Simulations.tsx
@@ -163,7 +163,6 @@ const Simulations: FC = () => {
     [],
   [variables, sliderValues]);
   const { loadingSimulate, data } = useSimulation(
-    project,
     simInputs,
     simulatedVariables,
     model

--- a/frontend-v2/src/features/simulation/useExportSimulation.ts
+++ b/frontend-v2/src/features/simulation/useExportSimulation.ts
@@ -1,12 +1,9 @@
-import { useMemo } from "react";
+import useProtocols from "./useProtocols";
 import useDataset from "../../hooks/useDataset";
 import {
   CombinedModelRead,
-  ProtocolListApiResponse,
   Simulate,
   useCombinedModelSimulateCreateMutation,
-  useCompoundRetrieveQuery,
-  useProtocolListQuery,
   useUnitListQuery,
   useVariableListQuery,
   ProjectRead
@@ -18,8 +15,6 @@ interface iExportSimulation {
   model: CombinedModelRead | undefined;
   project: ProjectRead | undefined;
 }
-
-const DEFAULT_PROTOCOLS: ProtocolListApiResponse = [];
 
 const parseResponse = (
   data: any,
@@ -55,23 +50,8 @@ export default function useExportSimulation({
   model,
   project
 }: iExportSimulation): [() => void, { error: any }] {
-  const { data: compound } =
-    useCompoundRetrieveQuery(
-      { id: project?.compound || 0 },
-      { skip: !project?.compound },
-    );
-  const { data: projectProtocols } = useProtocolListQuery(
-    { projectId: project?.id || 0 },
-    { skip: !project?.id },
-  );
   const { groups } = useDataset(project?.id || 0);
-  const protocols = useMemo(() => {
-    const datasetProtocols = groups?.flatMap(group => group.protocols) || [];
-    if (projectProtocols && datasetProtocols) {
-      return [...projectProtocols, ...datasetProtocols];
-    }
-    return DEFAULT_PROTOCOLS;
-  }, [projectProtocols, groups])
+  const { compound, protocols } = useProtocols();
   const { data: variables } = useVariableListQuery(
     { dosedPkModelId: model?.id || 0 },
     { skip: !model?.id },

--- a/frontend-v2/src/features/simulation/useProtocols.ts
+++ b/frontend-v2/src/features/simulation/useProtocols.ts
@@ -1,0 +1,49 @@
+import { useMemo } from "react";
+import { useSelector } from "react-redux";
+import { RootState } from "../../app/store";
+import useDataset from "../../hooks/useDataset";
+import {
+  ProtocolRead,
+  useCompoundRetrieveQuery,
+  useProjectRetrieveQuery,
+  useProtocolListQuery,
+} from "../../app/backendApi";
+
+const DEFAULT_PROTOCOLS: ProtocolRead[] = [];
+
+export default function useProtocols() {
+  const projectId = useSelector(
+    (state: RootState) => state.main.selectedProject,
+  );
+  const projectIdOrZero = projectId || 0;
+  const { data: project, isLoading: isProjectLoading } =
+    useProjectRetrieveQuery(
+      { id: projectIdOrZero },
+      { skip: !projectId }
+  );
+  const { data: compound } =
+    useCompoundRetrieveQuery(
+      { id: project?.compound || 0 },
+      { skip: !project?.compound },
+    );
+  const { data: projectProtocols } = useProtocolListQuery(
+    { projectId: projectIdOrZero },
+    { skip: !project?.id },
+  );
+  const { groups } = useDataset(projectIdOrZero);
+  
+  const protocols = useMemo(() => {
+    const datasetProtocols = groups?.flatMap(group => group.protocols) || [];
+    if (projectProtocols && datasetProtocols) {
+      return [...projectProtocols, ...datasetProtocols];
+    }
+    return DEFAULT_PROTOCOLS;
+  }, [projectProtocols, groups]);
+
+  return {
+    project,
+    compound,
+    protocols,
+    isProjectLoading
+  }
+}

--- a/frontend-v2/src/features/simulation/useSimulation.ts
+++ b/frontend-v2/src/features/simulation/useSimulation.ts
@@ -1,24 +1,18 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
+import useProtocols from "./useProtocols";
 import {
   CombinedModelRead,
-  ProtocolRead,
   Simulate,
   SimulationRead,
   SimulateResponse,
   VariableRead,
-  useCombinedModelSimulateCreateMutation,
-  useCompoundRetrieveQuery,
-  useProtocolListQuery,
-  ProjectRead
+  useCombinedModelSimulateCreateMutation
 } from "../../app/backendApi";
-import useDataset from "../../hooks/useDataset";
 
 type SliderValues = { [key: number]: number };
 interface ErrorObject {
   error: string;
 }
-
-const DEFAULT_PROTOCOLS: ProtocolRead[] = [];
 
 export const getSimulateInput = (
   simulation: SimulationRead,
@@ -90,28 +84,11 @@ export const getVariablesSimulated = (
 };
 
 export default function useSimulation(
-  project: ProjectRead | undefined,
   simInputs: Simulate,
   simulatedVariables: { qname: string; value: number | undefined }[],
   model: CombinedModelRead | undefined
 ) {
-  const { data: compound } =
-    useCompoundRetrieveQuery(
-      { id: project?.compound || 0 },
-      { skip: !project?.compound },
-    );
-  const { data: projectProtocols } = useProtocolListQuery(
-    { projectId: project?.id || 0 },
-    { skip: !project?.id },
-  );
-  const { groups } = useDataset(project?.id || 0);
-  const protocols = useMemo(() => {
-    const datasetProtocols = groups?.flatMap(group => group.protocols) || [];
-    if (projectProtocols && datasetProtocols) {
-      return [...projectProtocols, ...datasetProtocols];
-    }
-    return DEFAULT_PROTOCOLS;
-  }, [projectProtocols, groups])
+  const { compound, protocols } = useProtocols();
   const [loadingSimulate, setLoadingSimulate] = useState<boolean>(false);
   const [data, setData] = useState<SimulateResponse[]>([]);
   const [simulate, { error: simulateErrorBase }] =

--- a/frontend-v2/src/hooks/useDataset.ts
+++ b/frontend-v2/src/hooks/useDataset.ts
@@ -3,16 +3,15 @@ import {
   DatasetRead,
   BiomarkerTypeListApiResponse,
   SubjectGroupListApiResponse,
-  useDatasetListQuery,
+  useDatasetRetrieveQuery,
   useDatasetCreateMutation,
   useProjectRetrieveQuery,
   useSubjectGroupListQuery,
   useSubjectListQuery,
   useUnitListQuery,
-  useBiomarkerTypeListQuery
+  useBiomarkerTypeListQuery,
 } from '../app/backendApi';
 
-const DEFAULT_DATASETS: DatasetRead[] = [];
 const DEFAULT_GROUPS: SubjectGroupListApiResponse = [];
 const DEFAULT_BIOMARKERS: BiomarkerTypeListApiResponse = [];
 
@@ -25,23 +24,23 @@ export default function useDataset(selectedProject: number | null) {
     { compoundId: project?.compound || 0 },
     { skip: !project?.compound },
   );
-  const { data: datasetData, refetch } = useDatasetListQuery(
-    { projectId: selectedProjectOrZero },
-    { skip: !selectedProject },
+  const datasetIdOrZero = project?.datasets[0] || 0;
+
+  const { data: dataset, refetch } = useDatasetRetrieveQuery(
+    { id: datasetIdOrZero },
+    { skip: !datasetIdOrZero }
   );
-  const datasets = datasetData || DEFAULT_DATASETS;
-  const [dataset] = datasets;
   const { data: subjects } = useSubjectListQuery(
-    { datasetId: dataset?.id || 0 },
+    { datasetId: datasetIdOrZero },
     { skip: !dataset }
   );
   const { data: subjectGroupData, refetch: refetchSubjectGroups } = useSubjectGroupListQuery(
-    { datasetId: dataset?.id || 0 },
+    { datasetId: datasetIdOrZero },
     { skip: !dataset }
   );
   const subjectGroups = subjectGroupData || DEFAULT_GROUPS;
   const { data: biomarkerTypeData, refetch: refetchBiomarkerTypes } = useBiomarkerTypeListQuery(
-    { datasetId: dataset?.id || 0 },
+    { datasetId: datasetIdOrZero },
     { skip: !dataset }
   );
   const biomarkerTypes = biomarkerTypeData || DEFAULT_BIOMARKERS;

--- a/pkpdapp/pkpdapp/api/serializers/project.py
+++ b/pkpdapp/pkpdapp/api/serializers/project.py
@@ -26,6 +26,9 @@ class ProjectSerializer(serializers.ModelSerializer):
     user_access = ProjectAccessSerializer(
         source='projectaccess_set', many=True
     )
+    datasets = serializers.PrimaryKeyRelatedField(
+        many=True, read_only=True
+    )
     protocols = serializers.PrimaryKeyRelatedField(
         many=True, read_only=True
     )

--- a/pkpdapp/schema.yml
+++ b/pkpdapp/schema.yml
@@ -4492,6 +4492,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ProjectAccess'
+        datasets:
+          type: array
+          items:
+            type: integer
+          readOnly: true
         protocols:
           type: array
           items:
@@ -5028,6 +5033,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ProjectAccess'
+        datasets:
+          type: array
+          items:
+            type: integer
+          readOnly: true
         protocols:
           type: array
           items:
@@ -5066,6 +5076,7 @@ components:
       required:
       - compound
       - created
+      - datasets
       - id
       - name
       - protocols


### PR DESCRIPTION
Calculate the input parameters for simulations, then pass the calculated parameters to hooks as arguments. This should reduce the number of dependencies for the useEffect hook, and reduce or remove redundant API calls that run simulations in the Django app.