### PR TITLE
refactor: custom hooks for simulations

### DIFF
--- a/frontend-v2/src/features/simulation/Simulations.tsx
+++ b/frontend-v2/src/features/simulation/Simulations.tsx
@@ -12,7 +12,6 @@ import {
 import { useSelector } from "react-redux";
 import { RootState } from "../../app/store";
 import {
-  Simulate,
   Simulation,
   SimulationPlotRead,
   SimulationRead,
@@ -34,6 +33,8 @@ import { FC, useCallback, useEffect, useMemo, useState, useRef } from "react";
 import SimulationPlotView from "./SimulationPlotView";
 import SimulationSliderView from "./SimulationSliderView";
 import useSimulation from "./useSimulation";
+import useSimulationInputs from "./useSimulationInputs";
+import useSimulatedVariables from "./useSimulatedVariables";
 import DropdownButton from "../../components/DropdownButton";
 import SettingsIcon from "@mui/icons-material/Settings";
 import FloatField from "../../components/FloatField";
@@ -45,7 +46,6 @@ import { selectIsProjectShared } from "../login/loginSlice";
 import { getConstVariables } from "../model/resetToSpeciesDefaults";
 import useDataset from "../../hooks/useDataset";
 import useExportSimulation from "./useExportSimulation";
-import { getSimulateInput, getVariablesSimulated } from "./useSimulation";
 
 type SliderValues = { [key: number]: number };
 
@@ -149,19 +149,8 @@ const Simulations: FC = () => {
   };
   const timeMax = simulation?.id && getTimeMax(simulation);
 
-  const simInputs = useMemo(() => simulation && sliderValues ?
-    getSimulateInput(
-      simulation,
-      sliderValues,
-      variables,
-      timeMax,
-    ) :
-    {} as Simulate,
-  [simulation, sliderValues, variables, timeMax]);
-  const simulatedVariables = useMemo(() => variables && sliderValues ?
-    getVariablesSimulated(variables, sliderValues) : 
-    [],
-  [variables, sliderValues]);
+  const simInputs = useSimulationInputs(simulation, sliderValues, variables, timeMax);
+  const simulatedVariables = useSimulatedVariables(variables, sliderValues);
   const { loadingSimulate, data } = useSimulation(
     simInputs,
     simulatedVariables,

--- a/frontend-v2/src/features/simulation/useSimulatedVariables.ts
+++ b/frontend-v2/src/features/simulation/useSimulatedVariables.ts
@@ -1,0 +1,31 @@
+import { useMemo } from 'react';
+import { VariableRead } from '../../app/backendApi';
+
+type SliderValues = { [key: number]: number };
+
+const DEFAULT_VARS: { qname: string, value: number | undefined }[] = [];
+
+const getVariablesSimulated = (
+  variables?: VariableRead[],
+  sliderValues?: SliderValues,
+) => {
+  const constantVariables = variables?.filter((v) => v.constant) || [];
+  const merged = constantVariables.map((v: VariableRead) => {
+    const result = { qname: v.qname, value: v.default_value };
+    if (sliderValues && sliderValues[v.id]) {
+      result.value = sliderValues[v.id];
+    }
+    return result;
+  });
+  return merged;
+};
+
+export default function useSimulatedVariables(
+  variables: VariableRead[] | undefined,
+  sliderValues: SliderValues | undefined
+) {
+  return useMemo(() => variables && sliderValues ?
+    getVariablesSimulated(variables, sliderValues) :
+    DEFAULT_VARS,
+  [variables, sliderValues]);
+}

--- a/frontend-v2/src/features/simulation/useSimulation.ts
+++ b/frontend-v2/src/features/simulation/useSimulation.ts
@@ -3,85 +3,12 @@ import useProtocols from "./useProtocols";
 import {
   CombinedModelRead,
   Simulate,
-  SimulationRead,
   SimulateResponse,
-  VariableRead,
   useCombinedModelSimulateCreateMutation
 } from "../../app/backendApi";
-
-type SliderValues = { [key: number]: number };
 interface ErrorObject {
   error: string;
 }
-
-export const getSimulateInput = (
-  simulation: SimulationRead,
-  sliderValues: SliderValues,
-  variables?: VariableRead[],
-  timeMax?: number,
-  allOutputs: boolean = false,
-): Simulate => {
-  const outputs: string[] = [];
-  const simulateVariables: { [key: string]: number } = {};
-  for (const slider of simulation?.sliders || []) {
-    if (sliderValues[slider.variable]) {
-      const variable = variables?.find((v) => v.id === slider.variable);
-      if (variable) {
-        simulateVariables[variable.qname] = sliderValues[slider.variable];
-      }
-    }
-  }
-  if (allOutputs) {
-    for (const v of variables || []) {
-      if (!v.constant) {
-        outputs.push(v.qname);
-      }
-    }
-  } else {
-    for (const plot of simulation?.plots || []) {
-      for (const y_axis of plot.y_axes) {
-        const variable = variables?.find((v) => v.id === y_axis.variable);
-        if (variable && !outputs.includes(variable.qname)) {
-          outputs.push(variable.qname);
-        }
-      }
-    }
-  }
-  // add time as an output
-  const timeVariable = variables?.find(
-    (v) => v.name === "time" || v.name === "t",
-  );
-  outputs.push(timeVariable?.qname || "time");
-
-  // for some reason we need to ask for concentration or myokit produces a kink in the output
-  const alwaysAsk = ["PKCompartment.C1"];
-  for (const v of alwaysAsk) {
-    const variable = variables?.find((vv) => vv.qname === v);
-    if (variable && !outputs.includes(variable.qname)) {
-      outputs.push(variable.qname);
-    }
-  }
-  return {
-    variables: simulateVariables,
-    outputs,
-    time_max: timeMax || undefined,
-  };
-};
-
-export const getVariablesSimulated = (
-  variables?: VariableRead[],
-  sliderValues?: SliderValues,
-) => {
-  const constantVariables = variables?.filter((v) => v.constant) || [];
-  const merged = constantVariables.map((v: VariableRead) => {
-    const result = { qname: v.qname, value: v.default_value };
-    if (sliderValues && sliderValues[v.id]) {
-      result.value = sliderValues[v.id];
-    }
-    return result;
-  });
-  return merged;
-};
 
 export default function useSimulation(
   simInputs: Simulate,

--- a/frontend-v2/src/features/simulation/useSimulationInputs.ts
+++ b/frontend-v2/src/features/simulation/useSimulationInputs.ts
@@ -1,0 +1,85 @@
+import { useMemo } from 'react';
+import {
+  Simulate,
+  SimulationRead,
+  VariableRead,
+} from '../../app/backendApi';
+
+type SliderValues = { [key: number]: number };
+
+const DEFAULT_INPUTS = {
+  variables: {},
+  outputs: [],
+  time_max: 0,
+};
+
+const getSimulateInput = (
+  simulation: SimulationRead,
+  sliderValues: SliderValues,
+  variables?: VariableRead[],
+  timeMax?: number,
+  allOutputs: boolean = false,
+): Simulate => {
+  const outputs: string[] = [];
+  const simulateVariables: { [key: string]: number } = {};
+  for (const slider of simulation?.sliders || []) {
+    if (sliderValues[slider.variable]) {
+      const variable = variables?.find((v) => v.id === slider.variable);
+      if (variable) {
+        simulateVariables[variable.qname] = sliderValues[slider.variable];
+      }
+    }
+  }
+  if (allOutputs) {
+    for (const v of variables || []) {
+      if (!v.constant) {
+        outputs.push(v.qname);
+      }
+    }
+  } else {
+    for (const plot of simulation?.plots || []) {
+      for (const y_axis of plot.y_axes) {
+        const variable = variables?.find((v) => v.id === y_axis.variable);
+        if (variable && !outputs.includes(variable.qname)) {
+          outputs.push(variable.qname);
+        }
+      }
+    }
+  }
+  // add time as an output
+  const timeVariable = variables?.find(
+    (v) => v.name === "time" || v.name === "t",
+  );
+  outputs.push(timeVariable?.qname || "time");
+
+  // for some reason we need to ask for concentration or myokit produces a kink in the output
+  const alwaysAsk = ["PKCompartment.C1"];
+  for (const v of alwaysAsk) {
+    const variable = variables?.find((vv) => vv.qname === v);
+    if (variable && !outputs.includes(variable.qname)) {
+      outputs.push(variable.qname);
+    }
+  }
+  return {
+    variables: simulateVariables,
+    outputs,
+    time_max: timeMax || undefined,
+  };
+};
+
+export default function useSimulationInputs(
+  simulation: SimulationRead | undefined,
+  sliderValues: SliderValues | undefined,
+  variables: VariableRead[] | undefined,
+  timeMax: number | undefined,
+) {
+  return useMemo(() => simulation && sliderValues ?
+    getSimulateInput(
+      simulation,
+      sliderValues,
+      variables,
+      timeMax,
+    ) :
+    DEFAULT_INPUTS,
+  [simulation, sliderValues, variables, timeMax]);
+}

--- a/frontend-v2/src/hooks/useDataset.ts
+++ b/frontend-v2/src/hooks/useDataset.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import {
   DatasetRead,
   BiomarkerTypeListApiResponse,
@@ -32,31 +32,22 @@ export default function useDataset(selectedProject: number | null) {
   );
   const { data: subjects } = useSubjectListQuery(
     { datasetId: datasetIdOrZero },
-    { skip: !dataset }
+    { skip: !datasetIdOrZero }
   );
   const { data: subjectGroupData, refetch: refetchSubjectGroups } = useSubjectGroupListQuery(
     { datasetId: datasetIdOrZero },
-    { skip: !dataset }
+    { skip: !datasetIdOrZero }
   );
   const subjectGroups = subjectGroupData || DEFAULT_GROUPS;
   const { data: biomarkerTypeData, refetch: refetchBiomarkerTypes } = useBiomarkerTypeListQuery(
     { datasetId: datasetIdOrZero },
-    { skip: !dataset }
+    { skip: !datasetIdOrZero }
   );
   const biomarkerTypes = biomarkerTypeData || DEFAULT_BIOMARKERS;
 
   const [
     createDataset
   ] = useDatasetCreateMutation();
-
-  useEffect(() => {
-    if (dataset?.id) {
-      console.log('refetching groups and observations')
-      refetchSubjectGroups();
-      refetchBiomarkerTypes();
-    }
-  }, [dataset, refetchBiomarkerTypes, refetchSubjectGroups]);
-
   
   async function addDataset(projectId: number) {
     const response = await createDataset({
@@ -72,7 +63,9 @@ export default function useDataset(selectedProject: number | null) {
   const updateDataset = useCallback((newDataset: DatasetRead) => {
     console.log('updating dataset', newDataset)
     refetch();
-  }, [refetch]);
+    refetchSubjectGroups();
+    refetchBiomarkerTypes();
+  }, [refetch, refetchSubjectGroups, refetchBiomarkerTypes]);
 
   const subjectBiomarkers = biomarkerTypes.filter(b => b.is_continuous)
       .map(b => {


### PR DESCRIPTION
- Wrap `getSimulateInput` and `getVariablesSimulated` in memo-ised custom hooks.`
- run dataset data-fetching requests as soon as the dataset ID is ready, not the dataset itself.