### PR TITLE
refactor: dimensionless observation units

### DIFF
--- a/frontend-v2/src/features/data/Data.tsx
+++ b/frontend-v2/src/features/data/Data.tsx
@@ -7,6 +7,10 @@ import { DataGrid } from '@mui/x-data-grid';
 import LoadDataStepper from "./LoadDataStepper";
 import useDataset from "../../hooks/useDataset";
 
+function displayUnitSymbol(symbol: string | undefined) {
+  return symbol === '' ? 'dimensionless' : symbol;
+}
+
 const Data:FC = () => {
   const [tab, setTab] = useState(0);
   const projectId = useSelector(
@@ -82,7 +86,7 @@ const Data:FC = () => {
       'Time': row.time,
       'Time Unit': row.timeUnit?.symbol,
       'Observation': row.value,
-      'Observation Unit': row.unit?.symbol,
+      'Observation Unit': displayUnitSymbol(row.unit?.symbol),
       'Observation ID': row.label,
       'Observation Variable': row.qname,
       Group: groupId,

--- a/frontend-v2/src/features/data/MapObservations.tsx
+++ b/frontend-v2/src/features/data/MapObservations.tsx
@@ -29,6 +29,10 @@ interface IMapObservations {
   firstTime: boolean;
 }
 
+function displayUnitSymbol(symbol: string | undefined) {
+  return symbol === '' ? 'dimensionless' : symbol;
+}
+
 const MapObservations: FC<IMapObservations> = ({state}: IMapObservations) => {
   const [unitsAreFixed, setUnitsAreFixed] = useState(true);
   const projectId = useSelector(
@@ -172,25 +176,35 @@ const MapObservations: FC<IMapObservations> = ({state}: IMapObservations) => {
                         onChange={handleObservationChange(obsId)}
                       >
                         {compatibleVariables?.map((variable) => (
-                          <MenuItem key={variable.name} value={variable.qname}>{variable.name}</MenuItem>
+                          <MenuItem
+                            key={variable.name}
+                            value={variable.qname}
+                          >
+                            {variable.name}
+                          </MenuItem>
                         ))}
                       </Select>
                     </FormControl>
                   </TableCell>
                   <TableCell>
                     {unitsAreFixed ?
-                      selectedUnitSymbol :
+                      displayUnitSymbol(selectedUnitSymbol) :
                       <FormControl fullWidth>
                         <InputLabel id={`select-unit-${obsId}-label`}>Units</InputLabel>
                         <Select
                           labelId={`select-unit-${obsId}-label`}
                           id={`select-unit-${obsId}`}
                           label='Units'
-                          value={selectedUnitSymbol || ''}
+                          value={displayUnitSymbol(selectedUnitSymbol)}
                           onChange={handleUnitChange(obsId)}
                         >
                           {compatibleUnits?.map((unit) => (
-                            <MenuItem key={unit.symbol} value={unit.symbol}>{unit.symbol}</MenuItem>
+                            <MenuItem
+                              key={unit.id}
+                              value={displayUnitSymbol(unit.symbol)}
+                            >
+                              {displayUnitSymbol(unit.symbol)}
+                            </MenuItem>
                           ))}
                         </Select>
                       </FormControl>
@@ -235,7 +249,7 @@ const MapObservations: FC<IMapObservations> = ({state}: IMapObservations) => {
                 <TableRow key={index}>
                   <TableCell>{obsId}</TableCell>
                   <TableCell>{observation}</TableCell>
-                  <TableCell>{obsUnit}</TableCell>
+                  <TableCell>{displayUnitSymbol(obsUnit)}</TableCell>
                   <TableCell>{obsVariable}</TableCell>
                 </TableRow>
               )

--- a/pkpdapp/pkpdapp/utils/data_parser.py
+++ b/pkpdapp/pkpdapp/utils/data_parser.py
@@ -216,7 +216,8 @@ class DataParser:
                         "percent" in xl or
                         "fraction" in xl or
                         "ratio" in xl or
-                        "%" in xl
+                        "%" in xl or
+                        "dimensionless" in xl
                     ):
                         return ""
                     else:


### PR DESCRIPTION
When an observation variable is dimensionless, display the units as 'dimensionless', rather than an empty string. Convert 'dimensionless' back to an empty string when we parse the uploaded CSV.