### PR TITLE
refactor: make Stratification the second upload step

### DIFF
--- a/frontend-v2/src/features/data/LoadDataStepper.tsx
+++ b/frontend-v2/src/features/data/LoadDataStepper.tsx
@@ -23,8 +23,8 @@ interface IStepper {
   onFinish: () => void
 }
 
-const stepLabels = ['Upload Data', 'Map Dosing', 'Map Observations', 'Stratification', 'Preview Dataset'];
-const stepComponents = [LoadData, MapDosing, MapObservations, Stratification, PreviewData];
+const stepLabels = ['Upload Data', 'Stratification', 'Map Dosing', 'Map Observations', 'Preview Dataset'];
+const stepComponents = [LoadData, Stratification, MapDosing, MapObservations, PreviewData];
 
 type Row = {[key: string]: string};
 type Data = Row[];


### PR DESCRIPTION
Create subject groups before setting dosing compartments or mapping model variables to observations.