### PR TITLE
refactor: useSubjectGroups custom hook

### DIFF
--- a/frontend-v2/src/features/main/Sidebar.tsx
+++ b/frontend-v2/src/features/main/Sidebar.tsx
@@ -40,7 +40,7 @@ import SsidChartIcon from "@mui/icons-material/SsidChart";
 import ContactSupportIcon from "@mui/icons-material/ContactSupport";
 import TableViewIcon from "@mui/icons-material/TableView";
 import "@fontsource/comfortaa"; // Defaults to weight 400
-import useDataset from "../../hooks/useDataset";
+import useSubjectGroups from "../../hooks/useSubjectGroups";
 
 
 const drawerWidth = 240;
@@ -54,7 +54,7 @@ export default function Sidebar() {
   const selectedProject = useSelector(
     (state: RootState) => state.main.selectedProject,
   );
-  const { groups: subjectGroups } = useDataset(selectedProject);
+  const { groups } = useSubjectGroups();
   const dirtyCount = useSelector((state: RootState) => state.main.dirtyCount);
   const projectId = useSelector(
     (state: RootState) => state.main.selectedProject,
@@ -96,7 +96,7 @@ export default function Sidebar() {
     );
   };
 
-  const doses = subjectGroups?.flatMap(group => group.protocols.map(p => p.doses));
+  const doses = groups?.flatMap(group => group.protocols.map(p => p.doses));
   const groupsAreIncomplete = doses?.some(dosing => dosing.length === 0);
 
   const errors: { [key: string]: string } = {};

--- a/frontend-v2/src/features/simulation/Simulations.tsx
+++ b/frontend-v2/src/features/simulation/Simulations.tsx
@@ -45,7 +45,7 @@ import paramPriority from "../model/paramPriority";
 import HelpButton from "../../components/HelpButton";
 import { selectIsProjectShared } from "../login/loginSlice";
 import { getConstVariables } from "../model/resetToSpeciesDefaults";
-import useDataset from "../../hooks/useDataset";
+import useSubjectGroups from "../../hooks/useSubjectGroups";
 import useExportSimulation from "./useExportSimulation";
 
 type SliderValues = { [key: number]: number };
@@ -78,17 +78,13 @@ const Simulations: FC = () => {
   const projectId = useSelector(
     (state: RootState) => state.main.selectedProject,
   );
-  const { groups: subjectGroups } = useDataset(projectId);
-  const { data: projectGroups } = useSubjectGroupListQuery(
-    { projectId: projectId || 0},
-    { skip: !projectId }
-  );
-  const groups = useMemo(() => subjectGroups.concat(projectGroups || []), [subjectGroups, projectGroups]);
+  const { groups } = useSubjectGroups();
   const [visibleGroups, setVisibleGroups] =
     useState<string[]>(['Project']);
   useEffect(() => {
     // display groups by default, when they are loaded or deleted.
-    setVisibleGroups(['Project', ...groups.map(group => group.name)]);
+    const groupData = groups || [];
+    setVisibleGroups(['Project', ...groupData.map(group => group.name)]);
   }, [groups])
   const projectIdOrZero = projectId || 0;
   const { data: project, isLoading: isProjectLoading } =
@@ -484,7 +480,7 @@ const Simulations: FC = () => {
         }
       >
         <Stack direction="column">
-          {!!groups.length && (
+          {!!groups?.length && (
             <>
               <Typography
                 sx={{
@@ -505,7 +501,7 @@ const Simulations: FC = () => {
                   }
                   label='Project'
                 />
-                {groups.map((group) => (
+                {groups?.map((group) => (
                   <FormControlLabel
                     key={group.name}
                     control={

--- a/frontend-v2/src/features/simulation/useProtocols.ts
+++ b/frontend-v2/src/features/simulation/useProtocols.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { useSelector } from "react-redux";
 import { RootState } from "../../app/store";
-import useDataset from "../../hooks/useDataset";
+import useSubjectGroups from "../../hooks/useSubjectGroups";
 import {
   ProtocolRead,
   useCompoundRetrieveQuery,
@@ -31,13 +31,8 @@ export default function useProtocols() {
     { projectId: projectIdOrZero },
     { skip: !projectId },
   );
-  const { groups: subjectGroups } = useDataset(projectIdOrZero);
-  const { data: projectGroups } = useSubjectGroupListQuery(
-    { projectId: projectIdOrZero },
-    { skip: !projectId }
-  );
-  const groups = useMemo(() => subjectGroups.concat(projectGroups || []), [subjectGroups, projectGroups]);
-  
+  const { groups } = useSubjectGroups();
+
   const protocols = useMemo(() => {
     const datasetProtocols = groups?.flatMap(group => group.protocols) || [];
     if (projectProtocols && datasetProtocols) {

--- a/frontend-v2/src/hooks/useDataset.ts
+++ b/frontend-v2/src/hooks/useDataset.ts
@@ -6,11 +6,11 @@ import {
   useDatasetRetrieveQuery,
   useDatasetCreateMutation,
   useProjectRetrieveQuery,
-  useSubjectGroupListQuery,
   useSubjectListQuery,
   useUnitListQuery,
   useBiomarkerTypeListQuery,
 } from '../app/backendApi';
+import useSubjectGroups from './useSubjectGroups';
 
 const DEFAULT_GROUPS: SubjectGroupListApiResponse = [];
 const DEFAULT_BIOMARKERS: BiomarkerTypeListApiResponse = [];
@@ -34,11 +34,8 @@ export default function useDataset(selectedProject: number | null) {
     { datasetId: datasetIdOrZero },
     { skip: !datasetIdOrZero }
   );
-  const { data: subjectGroupData, refetch: refetchSubjectGroups } = useSubjectGroupListQuery(
-    { datasetId: datasetIdOrZero },
-    { skip: !datasetIdOrZero }
-  );
-  const subjectGroups = subjectGroupData || DEFAULT_GROUPS;
+  const { datasetGroups: datasetGroupData, refetchDatasetGroups } = useSubjectGroups();
+  const subjectGroups = datasetGroupData || DEFAULT_GROUPS;
   const { data: biomarkerTypeData, refetch: refetchBiomarkerTypes } = useBiomarkerTypeListQuery(
     { datasetId: datasetIdOrZero },
     { skip: !datasetIdOrZero }
@@ -64,9 +61,9 @@ export default function useDataset(selectedProject: number | null) {
     console.log('updating dataset', newDataset)
     refetch();
     refetchSubjects();
-    refetchSubjectGroups();
+    refetchDatasetGroups();
     refetchBiomarkerTypes();
-  }, [refetch, refetchSubjects, refetchSubjectGroups, refetchBiomarkerTypes]);
+  }, [refetch, refetchSubjects, refetchDatasetGroups, refetchBiomarkerTypes]);
 
   const subjectBiomarkers = biomarkerTypes.filter(b => b.is_continuous)
       .map(b => {

--- a/frontend-v2/src/hooks/useSubjectGroups.ts
+++ b/frontend-v2/src/hooks/useSubjectGroups.ts
@@ -1,0 +1,45 @@
+import { useMemo } from "react";
+import { useSelector } from "react-redux";
+import {
+  useProjectRetrieveQuery,
+  useSubjectGroupListQuery
+} from "../app/backendApi";
+import { RootState } from "../app/store";
+
+export default function useSubjectGroups() {
+  const selectedProject = useSelector(
+    (state: RootState) => state.main.selectedProject,
+  );
+  const selectedProjectOrZero = selectedProject || 0;
+  const { data: project } =
+    useProjectRetrieveQuery(
+      { id: selectedProjectOrZero },
+      { skip: !selectedProject }
+  );
+  const { data: datasetGroups, refetch: refetchDatasetGroups } = useSubjectGroupListQuery(
+    { datasetId: project?.datasets[0] || 0 },
+    { skip: !project }
+  );
+  const { data: projectGroups, refetch: refetchProjectGroups } = useSubjectGroupListQuery(
+    { projectId: selectedProjectOrZero},
+    { skip: !selectedProject }
+  );
+  const groups = useMemo(
+    () => datasetGroups?.concat(projectGroups || []),
+    [datasetGroups, projectGroups]
+  );
+
+  function refetchGroups() {
+    refetchDatasetGroups();
+    refetchProjectGroups();
+  }
+
+  return {
+    groups,
+    datasetGroups,
+    projectGroups,
+    refetchGroups,
+    refetchDatasetGroups,
+    refetchProjectGroups
+  }
+}


### PR DESCRIPTION
`useSubjectGroups`, a custom hook that provides a simple API for fetching and refetching project and dataset groups, either individually or combined.