### PR TITLE
feat: support multiple observation columns

### DIFF
--- a/frontend-v2/src/features/data/MapObservations.tsx
+++ b/frontend-v2/src/features/data/MapObservations.tsx
@@ -23,6 +23,7 @@ import {
   useUnitListQuery,
   useVariableListQuery
 } from "../../app/backendApi";
+import useObservationRows from './useObservationRows';
 
 interface IMapObservations {
   state: StepperState;
@@ -55,29 +56,18 @@ const MapObservations: FC<IMapObservations> = ({state}: IMapObservations) => {
     { skip: !project || !project.compound },
   );
 
-  const observationField = state.fields.find(
-    (field, i) => state.normalisedFields[i] === 'Observation'
-  ) || '';
-  const observationIdField = state.fields.find(
-    (field, i) => state.normalisedFields[i] === 'Observation ID'
-  );
-  const observationVariableField = state.fields.find(
-    (field, i) => state.normalisedFields[i] === 'Observation Variable'
-  );
-  const observationRows = observationField ? state.data.filter(row => row[observationField] !== '.') : [];
-  const observationIds = observationIdField ?
-    observationRows.map(row => row[observationIdField]) :
-    [observationField];
-  const uniqueObservationIds = [...new Set(observationIds)];
-  const observationValues = observationField ?
-    observationRows.map(row => row[observationField]) :
-    [];
-  const observationUnitField = state.fields.find(
-    (field, i) => ['Observation Unit', 'Unit'].includes(state.normalisedFields[i])
-  );
-  const observationUnits = observationRows.map(row => row[observationUnitField || 'Observation_unit']);
-  const observationVariables = observationRows.map(row => row[observationVariableField || 'Observation Variable']);
-
+  const {
+    observationRows,
+    observationIdField,
+    observationUnitField,
+    observationVariableField,
+    observationIds,
+    uniqueObservationIds,
+    observationUnits,
+    observationValues,
+    observationVariables
+  } = useObservationRows(state);
+  
   const filterOutputs = model?.is_library_model
     ? ["environment.t", "PDCompartment.C_Drug"]
     : [];

--- a/frontend-v2/src/features/data/useObservationRows.ts
+++ b/frontend-v2/src/features/data/useObservationRows.ts
@@ -1,0 +1,73 @@
+import { StepperState } from "./LoadDataStepper";
+import { normaliseHeader } from "./normaliseDataHeaders";
+import { Row } from "./LoadData";
+
+function mergeObservationColumns(state: StepperState, observationFields: string[]) {
+  const rows: Row[] = [];
+  observationFields.forEach((field, i) => {
+    const observationId = `${i + 1}`;
+    state.data.forEach(row => {
+      const value = row[field];
+      const newRow = { ...row, Observation: value, Observation_id: observationId };
+      rows.push(newRow);
+    });
+  });
+  rows.forEach(row => {
+    observationFields.forEach(field => {
+      delete row[field];
+    });
+  });
+  return rows;
+}
+
+export default function useObservationRows(state: StepperState) {
+  let fields = [...state.fields];
+  let normalisedFields = [...state.normalisedFields];
+  const observationFields = fields.filter(
+    (field, i) => normalisedFields[i] === 'Observation'
+  ) || [];
+  let [observationField] = observationFields;
+  let observationIdField = fields.find(
+    (field, i) => state.normalisedFields[i] === 'Observation ID'
+  );
+  let rows = state.data;
+  if (observationFields.length > 1) {
+    rows = mergeObservationColumns(state, observationFields);
+    observationField = 'Observation';
+    observationIdField = 'Observation_id';
+    fields = Object.keys(rows[0]);
+    normalisedFields = fields.map(normaliseHeader);
+    state.setFields(fields);
+    state.setNormalisedFields(normalisedFields);
+    state.setData(rows);
+  }
+  const observationRows = observationField ? rows.filter(row => row[observationField] !== '.') : [];
+  const observationIds = observationIdField ?
+    observationRows.map(row => row[observationIdField || 'Observation_id']) :
+    [observationField];
+  const uniqueObservationIds = [...new Set(observationIds)];
+  const observationValues = observationField ?
+    observationRows.map(row => row[observationField]) :
+    [];
+  const observationUnitField = fields.find(
+    (field, i) => ['Observation Unit', 'Unit'].includes(normalisedFields[i])
+  );
+  const observationVariableField = fields.find(
+    (field, i) => normalisedFields[i] === 'Observation Variable'
+  );
+  const observationUnits = observationRows.map(row => row[observationUnitField || 'Observation_unit']);
+  const observationVariables = observationRows.map(row => row[observationVariableField || 'Observation Variable']);
+
+  return {
+    observationRows,
+    observationField,
+    observationIdField,
+    observationUnitField,
+    observationVariableField,
+    observationIds,
+    uniqueObservationIds,
+    observationUnits,
+    observationValues,
+    observationVariables
+  }
+}

--- a/frontend-v2/src/features/data/useObservationRows.ts
+++ b/frontend-v2/src/features/data/useObservationRows.ts
@@ -4,11 +4,16 @@ import { Row } from "./LoadData";
 
 function mergeObservationColumns(state: StepperState, observationFields: string[]) {
   const rows: Row[] = [];
+  const amountIndex = state.normalisedFields.indexOf('Amount');
+  const amountField = state.fields[amountIndex];
   observationFields.forEach((field, i) => {
     const observationId = `${i + 1}`;
     state.data.forEach(row => {
       const value = row[field];
-      const newRow = { ...row, Observation: value, Observation_id: observationId };
+      const newRow: Row = { ...row, Observation: value, Observation_id: observationId };
+      if (i > 0) {
+        newRow[amountField] = '.';
+      }
       rows.push(newRow);
     });
   });


### PR DESCRIPTION
When multiple columns are selected as observation columns:
- ignore any observation IDs and units.
- merge the observations into a single Observation column.
- assign a unique Observation ID to each observation column.
- replace the dataset with the merged data. Let the user choose observation units and mapped variables.