### PR TITLE
fix(frontend): normalise the Observation column

### DIFF
--- a/frontend-v2/src/features/data/PreviewData.tsx
+++ b/frontend-v2/src/features/data/PreviewData.tsx
@@ -39,6 +39,7 @@ function useNormalisedColumn(state: StepperState, type: string) {
 const PreviewData: FC<IPreviewData> = ({ state, firstTime }: IPreviewData) => {
   useNormalisedColumn(state, 'Time');
   useNormalisedColumn(state, 'ID');
+  useNormalisedColumn(state, 'Observation');
   const { data } = state;
   const fields = [
     ...state.fields

--- a/frontend-v2/src/features/data/normaliseDataHeaders.ts
+++ b/frontend-v2/src/features/data/normaliseDataHeaders.ts
@@ -14,7 +14,7 @@ const normalisation = {
   'Infusion Duration': ['infusion time', 'infusion duration', 'infusion_time', 'dur', 'tinf', 'infusiontime'],
   'Infusion Rate': ['infusion rate', 'rate'],
   'Interdose Interval': ['interdose interval', 'ii', 'tau', 'dosing interval'],
-  'Observation': ['observation', 'dv', 'c', 'y', 'conc', 'cobs', 'obs'],
+  'Observation': ['observation', 'dv', 'c', 'y', 'conc', 'cobs', 'obs', 'concentration'],
   'Observation Unit': ['observation unit', 'observation_unit', 'dv_units', 'c_units', 'y_units', 'yunit', 'cunit', 'obs_units', 'obs_unit', 'obsunit', 'units_conc'],
   'Observation ID': ['observation id', 'observation_id', 'ytype', 'dvid'],
   'Observation Variable': ['observation variable', 'observation_var'],


### PR DESCRIPTION
If the Observation column isn't automatically mapped, make sure that the final upload maps the column name to 'Observation'. Otherwise the upload will error with  missing column 'Observation'.