### PR TITLE
refactor(frontend): derive errors and warnings from state

### DIFF
--- a/frontend-v2/src/features/data/CreateDosingProtocols.tsx
+++ b/frontend-v2/src/features/data/CreateDosingProtocols.tsx
@@ -37,7 +37,7 @@ const CreateDosingProtocols: FC<IDosingProtocols> = ({
   variables
 }: IDosingProtocols) => {
   const amountField = state.fields.find(
-    (field, i) => state.normalisedFields[i] === 'Amount'
+    (field, i) => field === 'Amount' || state.normalisedFields[i] === 'Amount'
   );
   if (!amountField) {
     const newFields = [...state.fields, 'Amount'];

--- a/frontend-v2/src/features/data/DosingProtocols.tsx
+++ b/frontend-v2/src/features/data/DosingProtocols.tsx
@@ -19,6 +19,7 @@ import {
   UnitRead,
   VariableRead
 } from "../../app/backendApi";
+import { validateState } from './normaliseDataHeaders';
 
 interface IDosingProtocols {
   administrationIdField: string;
@@ -79,6 +80,15 @@ const DosingProtocols: FC<IDosingProtocols> = ({
         row[amountUnitField] = value;
       })
     state.setData(nextData);
+    const{ errors, warnings } = validateState(
+      { 
+        ...state,
+        data: nextData,
+        normalisedFields: [...state.normalisedFields, 'Amount Unit']
+      }
+    );
+    state.setErrors(errors);
+    state.setWarnings(warnings);
   }
   return (
     <>

--- a/frontend-v2/src/features/data/LoadData.tsx
+++ b/frontend-v2/src/features/data/LoadData.tsx
@@ -3,7 +3,7 @@ import Papa from 'papaparse'
 import { FC, useCallback, useState} from 'react'
 import {useDropzone} from 'react-dropzone'
 import MapHeaders from './MapHeaders';
-import { normaliseHeader, validateNormalisedFields } from './normaliseDataHeaders';
+import { normaliseHeader, validateState } from './normaliseDataHeaders';
 import { StepperState } from './LoadDataStepper';
 import SetUnits from './SetUnits';
 
@@ -128,7 +128,12 @@ const LoadData: FC<ILoadDataProps> = ({state, firstTime}) => {
         const csvData = Papa.parse(rawCsv.trim(), { header: true });
         const fields = csvData.meta.fields || [];
         const normalisedFields = fields.map(normaliseHeader);
-        const fieldValidation = validateNormalisedFields(normalisedFields);
+        const fieldValidation = validateState({
+          ...state,
+          data: csvData.data as Data,
+          fields,
+          normalisedFields
+        });
         const primaryCohort = fields.find(
           (field, index) => normalisedFields[index] === 'Cat Covariate'
         ) || 'Group';
@@ -150,9 +155,12 @@ const LoadData: FC<ILoadDataProps> = ({state, firstTime}) => {
   }, [state])
   const {getRootProps, getInputProps} = useDropzone({onDrop})
 
-  const setNormalisedFields = (fields: Field[]) => {
-    state.setNormalisedFields(fields);
-    const { errors, warnings } = validateNormalisedFields(fields);
+  const setNormalisedFields = (normalisedFields: Field[]) => {
+    state.setNormalisedFields(normalisedFields);
+    const { errors, warnings } = validateState({
+      ...state,
+      normalisedFields,
+    });
     state.setErrors(errors);
     state.setWarnings(warnings);
   }

--- a/frontend-v2/src/features/data/LoadDataStepper.tsx
+++ b/frontend-v2/src/features/data/LoadDataStepper.tsx
@@ -164,7 +164,7 @@ const LoadDataStepper: FC<IStepper> = ({ csv = '', onCancel, onFinish }) => {
         {errors.map(error => <Alert key={error} severity="error">{error}</Alert>)}
         {warnings.map(warning => <Alert key={warning} severity="warning">{warning}</Alert>)}
         {isFinished ?
-          <Typography>'The process is completed'</Typography> :
+          <Typography>Saving data…</Typography> :
           <StepComponent state={state} firstTime={stepState.activeStep === stepState.maxStep} />
         }
       </Box>

--- a/frontend-v2/src/features/data/MapObservations.tsx
+++ b/frontend-v2/src/features/data/MapObservations.tsx
@@ -25,6 +25,7 @@ import {
   useVariableListQuery
 } from "../../app/backendApi";
 import useObservationRows from './useObservationRows';
+import { validateState } from './normaliseDataHeaders';
 
 interface IMapObservations {
   state: StepperState;
@@ -100,6 +101,15 @@ const MapObservations: FC<IMapObservations> = ({state}: IMapObservations) => {
         row[observationUnitField] = value;
       });
     state.setData(nextData);
+    const{ errors, warnings } = validateState(
+      {
+        ...state,
+        data: nextData,
+        normalisedFields: [...state.normalisedFields, 'Observation Unit']
+      }
+    );
+    state.setErrors(errors);
+    state.setWarnings(warnings);
   }
   return (
     <>

--- a/frontend-v2/src/features/data/SetUnits.tsx
+++ b/frontend-v2/src/features/data/SetUnits.tsx
@@ -12,7 +12,7 @@ import { StepperState } from "./LoadDataStepper";
 import { useProjectRetrieveQuery, useUnitListQuery } from "../../app/backendApi";
 import { useSelector } from "react-redux";
 import { RootState } from "../../app/store";
-import { validateNormalisedFields } from "./normaliseDataHeaders";
+import { validateState } from "./normaliseDataHeaders";
 
 interface IMapObservations {
   state: StepperState;
@@ -45,7 +45,8 @@ const SetUnits: React.FC<IMapObservations> = ({state, firstTime}: IMapObservatio
       'Time_unit': event.target?.value
     }));
     state.setData(newData);
-    const { errors, warnings } = validateNormalisedFields([...state.normalisedFields, 'Time Unit']);
+    const { errors, warnings } = validateState(
+      { ...state, normalisedFields: [...state.normalisedFields, 'Time Unit'] });
     state.setErrors(errors);
     state.setWarnings(warnings);
   }


### PR DESCRIPTION
Refactor `validateNormalisedHeaders(headers)` as `validateState(state)`, so that we can generate errors and warnings from the uploaded data. Fixes a small bug where the warning for missing observation units persists, even after you've set observation units.