### PR TITLE
refactor(frontend): optimise imports

### DIFF
--- a/frontend-v2/src/App.tsx
+++ b/frontend-v2/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import "./App.css";
 
 import {

--- a/frontend-v2/src/components/Checkbox.tsx
+++ b/frontend-v2/src/components/Checkbox.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { Control, Controller, FieldPath, FieldValues } from "react-hook-form";
-import * as material from "@mui/material";
+import { Checkbox as MaterialCheckbox, CheckboxProps, FormControlLabel } from "@mui/material";
 
 type Props<T extends FieldValues> = {
   label: string;
   name: FieldPath<T>;
   control: Control<T>;
   rules?: Object;
-  checkboxFieldProps?: material.CheckboxProps;
+  checkboxFieldProps?: CheckboxProps;
 };
 
 function Checkbox<T extends FieldValues>({
@@ -27,9 +27,9 @@ function Checkbox<T extends FieldValues>({
         fieldState: { error },
       }) => {
         return (
-          <material.FormControlLabel
+          <FormControlLabel
             control={
-              <material.Checkbox
+              <MaterialCheckbox
                 name={name}
                 id={name}
                 checked={value === undefined ? false : value}

--- a/frontend-v2/src/components/Checkbox.tsx
+++ b/frontend-v2/src/components/Checkbox.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { ReactElement } from "react";
 import { Control, Controller, FieldPath, FieldValues } from "react-hook-form";
 import { Checkbox as MaterialCheckbox, CheckboxProps, FormControlLabel } from "@mui/material";
 
@@ -16,7 +16,7 @@ function Checkbox<T extends FieldValues>({
   control,
   rules,
   checkboxFieldProps,
-}: Props<T>): React.ReactElement {
+}: Props<T>): ReactElement {
   return (
     <Controller
       name={name}

--- a/frontend-v2/src/components/ConfirmationDialog.tsx
+++ b/frontend-v2/src/components/ConfirmationDialog.tsx
@@ -1,3 +1,4 @@
+import { FC } from "react";
 import {
   Dialog,
   DialogTitle,
@@ -5,7 +6,6 @@ import {
   DialogActions,
   Button,
 } from "@mui/material";
-import React from "react";
 
 interface ConfirmationDialogProps {
   open: boolean;
@@ -15,7 +15,7 @@ interface ConfirmationDialogProps {
   onCancel: () => void;
 }
 
-const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
+const ConfirmationDialog: FC<ConfirmationDialogProps> = ({
   open,
   title,
   message,

--- a/frontend-v2/src/components/DropdownButton.tsx
+++ b/frontend-v2/src/components/DropdownButton.tsx
@@ -5,7 +5,7 @@ import {
   ListItemText,
   Popover,
 } from "@mui/material";
-import React, { useState } from "react";
+import { FC, MouseEvent, ReactNode, useState } from "react";
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 
 type Option = {
@@ -16,13 +16,13 @@ type Option = {
 type Props = {
   options: Option[];
   onOptionSelected: (value: any) => void;
-  children?: React.ReactNode;
+  children?: ReactNode;
   disabled?: boolean;
   data_cy?: string;
   useIcon?: boolean;
 };
 
-const DropdownButton: React.FC<Props> = ({
+const DropdownButton: FC<Props> = ({
   data_cy,
   options,
   onOptionSelected,
@@ -36,7 +36,7 @@ const DropdownButton: React.FC<Props> = ({
     useIcon = true;
   }
 
-  const handleButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const handleButtonClick = (event: MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
   };
 

--- a/frontend-v2/src/components/DynamicTabs.tsx
+++ b/frontend-v2/src/components/DynamicTabs.tsx
@@ -128,7 +128,7 @@ export const DynamicTabs: FC<PropsWithChildren<DynamicTabsProps>> = ({
         </Box>
         <Box sx={{ margin: 2 }}>
           {Children.map(children, (child, index) => {
-            return cloneElement(child as React.ReactElement<any>, {
+            return cloneElement(child as ReactElement<any>, {
               index,
             });
           })}

--- a/frontend-v2/src/components/FloatField.tsx
+++ b/frontend-v2/src/components/FloatField.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { ChangeEvent, FocusEvent, ReactElement } from "react";
 import { Control, Controller, FieldPath, FieldValues } from "react-hook-form";
 import { TextField, TextFieldProps } from "@mui/material";
 import { useFieldState } from "../app/hooks";
@@ -34,7 +34,7 @@ function FloatField<T extends FieldValues>({
   textFieldProps,
   data_cy,
   sx
-}: Props<T>): React.ReactElement {
+}: Props<T>): ReactElement {
   const [fieldValue, setFieldValue] = useFieldState({ name, control });
 
   return (
@@ -46,7 +46,7 @@ function FloatField<T extends FieldValues>({
         field: { onChange, onBlur, value },
         fieldState: { error, isDirty, isTouched },
       }) => {
-        const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+        const handleBlur = (e: FocusEvent<HTMLInputElement>) => {
           const updatedValue = convert(e.target.value);
           if (updatedValue !== value) {
             e.target.value = updatedValue as any;
@@ -55,7 +55,7 @@ function FloatField<T extends FieldValues>({
           onBlur();
         };
 
-        const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
           setFieldValue(convert(e.target.value));
         };
         return (

--- a/frontend-v2/src/components/FloatField.tsx
+++ b/frontend-v2/src/components/FloatField.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Control, Controller, FieldPath, FieldValues } from "react-hook-form";
-import * as material from "@mui/material";
+import { TextField, TextFieldProps } from "@mui/material";
 import { useFieldState } from "../app/hooks";
 import { getLabel } from "../shared/getRequiredLabel";
 
@@ -9,7 +9,7 @@ type Props<T extends FieldValues> = {
   name: FieldPath<T>;
   control: Control<T>;
   rules?: Record<string, unknown>;
-  textFieldProps?: material.TextFieldProps;
+  textFieldProps?: TextFieldProps;
   data_cy?: string;
   sx?: Record<string, string>
 };
@@ -59,7 +59,7 @@ function FloatField<T extends FieldValues>({
           setFieldValue(convert(e.target.value));
         };
         return (
-          <material.TextField
+          <TextField
             label={
               !error
                 ? getLabel(label || '', Boolean(rules?.required))

--- a/frontend-v2/src/components/HelpDialog.tsx
+++ b/frontend-v2/src/components/HelpDialog.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { FC, ReactNode } from "react";
 import {
   Dialog,
   DialogTitle,
@@ -11,10 +11,10 @@ interface HelpDialogProps {
   open: boolean;
   title: string;
   onClose: () => void;
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
-const HelpDialog: React.FC<HelpDialogProps> = ({
+const HelpDialog: FC<HelpDialogProps> = ({
   open,
   title,
   onClose,

--- a/frontend-v2/src/components/IntegerField.tsx
+++ b/frontend-v2/src/components/IntegerField.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { ChangeEvent, FocusEvent, ReactElement } from "react";
 import { Control, Controller, FieldPath, FieldValues } from "react-hook-form";
 import { TextField, TextFieldProps } from "@mui/material";
 import { useFieldState } from "../app/hooks";
@@ -25,7 +25,7 @@ function IntegerField<T extends FieldValues>({
   control,
   rules,
   textFieldProps,
-}: Props<T>): React.ReactElement {
+}: Props<T>): ReactElement {
   const [fieldValue, setFieldValue] = useFieldState({ name, control });
   return (
     <Controller
@@ -36,7 +36,7 @@ function IntegerField<T extends FieldValues>({
         field: { onChange, onBlur, value },
         fieldState: { error, isDirty, isTouched },
       }) => {
-        const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+        const handleBlur = (e: FocusEvent<HTMLInputElement>) => {
           const updatedValue = convert(e.target.value);
           if (updatedValue !== value) {
             e.target.value = updatedValue;
@@ -45,7 +45,7 @@ function IntegerField<T extends FieldValues>({
           onBlur();
         };
 
-        const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
           setFieldValue(convert(e.target.value));
         };
         return (

--- a/frontend-v2/src/components/IntegerField.tsx
+++ b/frontend-v2/src/components/IntegerField.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Control, Controller, FieldPath, FieldValues } from "react-hook-form";
-import * as material from "@mui/material";
+import { TextField, TextFieldProps } from "@mui/material";
 import { useFieldState } from "../app/hooks";
 
 type Props<T extends FieldValues> = {
@@ -8,7 +8,7 @@ type Props<T extends FieldValues> = {
   name: FieldPath<T>;
   control: Control<T>;
   rules?: Object;
-  textFieldProps?: material.TextFieldProps;
+  textFieldProps?: TextFieldProps;
 };
 
 function convert(value: any) {
@@ -49,7 +49,7 @@ function IntegerField<T extends FieldValues>({
           setFieldValue(convert(e.target.value));
         };
         return (
-          <material.TextField
+          <TextField
             label={
               !error
                 ? label

--- a/frontend-v2/src/components/SelectField.tsx
+++ b/frontend-v2/src/components/SelectField.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { ReactElement } from "react";
 import { Control, Controller, FieldPath, FieldValues } from "react-hook-form";
 import {
   Select,
@@ -34,7 +34,7 @@ function SelectField<T extends FieldValues>({
   rules,
   selectProps,
   formControlProps,
-}: Props<T>): React.ReactElement {
+}: Props<T>): ReactElement {
   const labelId = `${name}-label`;
   const displayEmpty = selectProps?.displayEmpty || true;
   const pixelPerChar = 9;

--- a/frontend-v2/src/components/TextField.tsx
+++ b/frontend-v2/src/components/TextField.tsx
@@ -5,7 +5,7 @@ import {
   FieldPath,
   FieldValues
 } from "react-hook-form";
-import * as material from "@mui/material";
+import { SxProps, TextField as MaterialTextField, TextFieldProps } from "@mui/material";
 import { useFieldState } from "../app/hooks";
 import { getLabel } from "../shared/getRequiredLabel";
 
@@ -15,9 +15,9 @@ type Props<T extends FieldValues> = {
   control: Control<T>;
   rules?: Record<string, unknown>;
   mode?: "onChange" | "onBlur";
-  textFieldProps?: material.TextFieldProps;
+  textFieldProps?: TextFieldProps;
   autoShrink?: boolean;
-  sx?: material.SxProps
+  sx?: SxProps
 };
 
 function TextField<T extends FieldValues>({
@@ -59,7 +59,7 @@ function TextField<T extends FieldValues>({
           }
         };
         return (
-          <material.TextField
+          <MaterialTextField
             label={
               !error
                 ? getLabel(label || '', Boolean(rules?.required))

--- a/frontend-v2/src/components/TextField.tsx
+++ b/frontend-v2/src/components/TextField.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { ChangeEvent, FocusEvent, ReactElement } from "react";
 import {
   Control,
   Controller,
@@ -29,7 +29,7 @@ function TextField<T extends FieldValues>({
   textFieldProps,
   autoShrink,
   sx
-}: Props<T>): React.ReactElement {
+}: Props<T>): ReactElement {
   const [fieldValue, setFieldValue] = useFieldState({ name, control });
 
   if (mode === undefined) {
@@ -45,14 +45,14 @@ function TextField<T extends FieldValues>({
         field: { onChange, onBlur, value },
         fieldState: { error, isDirty, isTouched },
       }) => {
-        const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+        const handleBlur = (e: FocusEvent<HTMLInputElement>) => {
           if (mode === "onBlur" && e.target.value !== value) {
             onChange(e);
           }
           onBlur();
         };
 
-        const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
           setFieldValue(e.target.value);
           if (mode === "onChange") {
             onChange(e);

--- a/frontend-v2/src/components/Title.tsx
+++ b/frontend-v2/src/components/Title.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { Typography } from "@mui/material";
 
 interface Props {

--- a/frontend-v2/src/components/UnitField.tsx
+++ b/frontend-v2/src/components/UnitField.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { ReactElement } from "react";
 import { Control, FieldPath, FieldValues } from "react-hook-form";
 import { SelectProps } from "@mui/material";
 import {
@@ -26,7 +26,7 @@ function UnitField<T extends FieldValues>({
   rules,
   selectProps,
   isPreclinicalPerKg,
-}: Props<T>): React.ReactElement {
+}: Props<T>): ReactElement {
   if (!isPreclinicalPerKg) {
     isPreclinicalPerKg = false;
   }

--- a/frontend-v2/src/features/data/Data.tsx
+++ b/frontend-v2/src/features/data/Data.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from "react";
+import { FC, SyntheticEvent, useState } from "react";
 import { useSelector } from "react-redux";
 import { useProjectRetrieveQuery, useUnitListQuery } from "../../app/backendApi";
 import { RootState } from "../../app/store";
@@ -58,7 +58,7 @@ const Data:FC = () => {
     setIsEditing(false);
   }
 
-  function handleTabChange(event: React.SyntheticEvent, newValue: number) {
+  function handleTabChange(event: SyntheticEvent, newValue: number) {
     setTab(newValue);
   }
 

--- a/frontend-v2/src/features/data/SetUnits.tsx
+++ b/frontend-v2/src/features/data/SetUnits.tsx
@@ -1,3 +1,4 @@
+import { FC } from "react";
 import {
   Alert,
   FormControl,
@@ -19,7 +20,7 @@ interface IMapObservations {
   firstTime: boolean;
 }
 
-const SetUnits: React.FC<IMapObservations> = ({state, firstTime}: IMapObservations) => {
+const SetUnits: FC<IMapObservations> = ({state, firstTime}: IMapObservations) => {
   const projectId = useSelector((state: RootState) => state.main.selectedProject);
   const { data: project, isLoading: isProjectLoading } = useProjectRetrieveQuery({id: projectId || 0}, { skip: !projectId })
   const { data: units, isLoading: isLoadingUnits } = useUnitListQuery({ compoundId: project?.compound}, { skip: !project || !project.compound});

--- a/frontend-v2/src/features/help/Help.tsx
+++ b/frontend-v2/src/features/help/Help.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { FC, useEffect, useState } from "react";
 import { DynamicTabs, TabPanel } from "../../components/DynamicTabs";
 import HelpTab from "./HelpTab";
 import { parse } from "papaparse";
@@ -23,8 +23,8 @@ const TYPE_COLUMN = 1;
 const LINK_COLUMN = 2;
 const KEYWORDS_COLUMN = 3;
 
-const Help: React.FC = () => {
-  const [tutorialVideos, setTutorialVideos] = React.useState<TutorialVideo[]>(
+const Help: FC = () => {
+  const [tutorialVideos, setTutorialVideos] = useState<TutorialVideo[]>(
     [],
   );
   useEffect(() => {

--- a/frontend-v2/src/features/help/HelpTab.tsx
+++ b/frontend-v2/src/features/help/HelpTab.tsx
@@ -1,3 +1,4 @@
+import { FC } from "react";
 import {
   Accordion,
   AccordionDetails,
@@ -17,7 +18,7 @@ interface Props {
 }
 
 // tab that lists questions as mui accordian components
-const HelpTab: React.FC<Props> = ({ questions, videos }) => {
+const HelpTab: FC<Props> = ({ questions, videos }) => {
   return (
     <div>
       <Stack spacing={1} sx={{ marginBottom: 2 }}>

--- a/frontend-v2/src/features/main/MainContent.tsx
+++ b/frontend-v2/src/features/main/MainContent.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { FC, ReactNode } from "react";
 import { useSelector } from "react-redux";
 import { RootState } from "../../app/store";
 import { PageName } from "./mainSlice";
@@ -12,10 +12,10 @@ import Help from "../help/Help";
 import Data from '../data/Data';
 
 interface TabPanelProps {
-  children?: React.ReactNode;
+  children?: ReactNode;
   index: PageName;
   value: PageName;
-  error?: React.ReactNode;
+  error?: ReactNode;
 }
 
 function TabPanel(props: TabPanelProps) {
@@ -34,7 +34,7 @@ function TabPanel(props: TabPanelProps) {
   );
 }
 
-const MainContent: React.FC = () => {
+const MainContent: FC = () => {
   const page = useSelector((state: RootState) => state.main.selectedPage);
   const projectId = useSelector(
     (state: RootState) => state.main.selectedProject,

--- a/frontend-v2/src/features/model/ParametersTab.tsx
+++ b/frontend-v2/src/features/model/ParametersTab.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { FC } from "react";
 import {
   CombinedModelRead,
   CompoundRead,
@@ -40,7 +40,7 @@ interface Props {
   units: UnitRead[];
 }
 
-const ParametersTab: React.FC<Props> = ({
+const ParametersTab: FC<Props> = ({
   model,
   project,
   control,

--- a/frontend-v2/src/features/model/TranslationTab.tsx
+++ b/frontend-v2/src/features/model/TranslationTab.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { FC } from "react";
 import { CombinedModel, Project } from "../../app/backendApi";
 import { Control } from "react-hook-form";
 
@@ -8,7 +8,7 @@ interface Props {
   control: Control<CombinedModel>;
 }
 
-const TranslationTab: React.FC<Props> = ({
+const TranslationTab: FC<Props> = ({
   model,
   project,
   control,

--- a/frontend-v2/src/features/projects/Projects.tsx
+++ b/frontend-v2/src/features/projects/Projects.tsx
@@ -1,5 +1,5 @@
 // src/components/ProjectTable.tsx
-import React from "react";
+import { FC, useState } from "react";
 import { useSelector } from "react-redux";
 import {
   Table,
@@ -43,8 +43,8 @@ enum SortOptions {
 
 const SM_SIM_TIME = 48;
 const LM_SIM_TIME = 672;
-const ProjectTable: React.FC = () => {
-  const [sortBy, setSortBy] = React.useState<SortOptions>(SortOptions.CREATED);
+const ProjectTable: FC = () => {
+  const [sortBy, setSortBy] = useState<SortOptions>(SortOptions.CREATED);
   const toast = useCustomToast();
 
   const handleSortBy = (option: SortOptions) => {

--- a/frontend-v2/src/features/simulation/SimulationPlotForm.tsx
+++ b/frontend-v2/src/features/simulation/SimulationPlotForm.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { FC } from "react";
 import {
   Control,
   FieldArrayWithId,
@@ -41,7 +41,7 @@ interface SimulationPlotFormProps {
   compound: CompoundRead;
 }
 
-const SimulationPlotForm: React.FC<SimulationPlotFormProps> = ({
+const SimulationPlotForm: FC<SimulationPlotFormProps> = ({
   index,
   plot,
   variables,

--- a/frontend-v2/src/features/simulation/Simulations.tsx
+++ b/frontend-v2/src/features/simulation/Simulations.tsx
@@ -29,7 +29,7 @@ import {
   useVariableUpdateMutation,
 } from "../../app/backendApi";
 import { useFieldArray, useForm } from "react-hook-form";
-import { FC, useCallback, useEffect, useMemo, useState, useRef } from "react";
+import { ChangeEvent, FC, useCallback, useEffect, useMemo, useState, useRef } from "react";
 import SimulationPlotView from "./SimulationPlotView";
 import SimulationSliderView from "./SimulationSliderView";
 import useSimulation from "./useSimulation";
@@ -378,7 +378,7 @@ const Simulations: FC = () => {
     });
   };
 
-  const handleVisibleGroups = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleVisibleGroups = (event: ChangeEvent<HTMLInputElement>) => {
     if (!event.target.checked) {
       const newState = visibleGroups.filter(name => name !== event.target.value);
       setVisibleGroups(newState);

--- a/frontend-v2/src/hooks/useCustomToast.tsx
+++ b/frontend-v2/src/hooks/useCustomToast.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { toast, ToastOptions } from 'react-toastify';
 import { Notification } from './../components/Notification/Notification';
 import { NotificationTypes } from '../components/Notification/notificationTypes';

--- a/frontend-v2/src/index.tsx
+++ b/frontend-v2/src/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { Provider } from "react-redux";
 import { store } from "./app/store";
@@ -10,11 +10,11 @@ const container = document.getElementById("root")!;
 const root = createRoot(container);
 
 root.render(
-  <React.StrictMode>
+  <StrictMode>
     <Provider store={store}>
       <App />
     </Provider>
-  </React.StrictMode>,
+  </StrictMode>,
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/frontend-v2/src/shared/tooltipWrapper.tsx
+++ b/frontend-v2/src/shared/tooltipWrapper.tsx
@@ -1,7 +1,7 @@
-import React from 'react'
+import { ReactNode } from 'react'
 import CloseIcon from '@mui/icons-material/Close';
 
-export const tooltipWrapper = (children: React.ReactNode, onClose: () => void) => (
+export const tooltipWrapper = (children: ReactNode, onClose: () => void) => (
     <div style={{ display: 'flex'}}>
         <div style={{ display: 'block' }}>
             {children}


### PR DESCRIPTION
Remove some `import * as` declariations, so that we can tree-shake `react` and `@mui/material` imports.

Remove the React global, where it was still being used. 