### PR TITLE
feat(frontend): grouped column types menu

### DIFF
--- a/frontend-v2/src/features/data/MapHeaders.tsx
+++ b/frontend-v2/src/features/data/MapHeaders.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react";
-import { Table, TableHead, TableRow, TableCell, TableBody, Select, FormControl, MenuItem, InputLabel, Typography } from "@mui/material";
+import { Table, TableHead, TableRow, TableCell, TableBody, Select, FormControl, ListSubheader, MenuItem, InputLabel, Typography, Menu } from "@mui/material";
 import { Data, Field } from "./LoadData";
-import { normalisedHeaders } from "./normaliseDataHeaders";
+import { groupedHeaders } from "./normaliseDataHeaders";
 
 interface IMapHeaders {
   data: Data;
@@ -11,8 +11,6 @@ interface IMapHeaders {
 }
 
 const MapHeaders: FC<IMapHeaders> = ({data, fields, normalisedFields, setNormalisedFields}: IMapHeaders) => {
-
-  const normalisedHeadersOptions = normalisedHeaders.map((header) => ({value: header, label: header}));
   
   const handleFieldChange = (index: number) => (event: any) => {
     const newFields = [...normalisedFields];
@@ -38,9 +36,15 @@ const MapHeaders: FC<IMapHeaders> = ({data, fields, normalisedFields, setNormali
                   label="Column Type"
                   onChange={handleFieldChange(index)}
                 >
-                  {normalisedHeadersOptions.map((option) => (
-                    <MenuItem key={option.value} value={option.value}>{option.label}</MenuItem>
-                  ))}
+                  {Object.entries(groupedHeaders).map(([group, headers]) => {
+                    const groupHeaders = headers.map(header => (
+                      <MenuItem key={header} value={header}>{header}</MenuItem>
+                    ));
+                    return [
+                      <ListSubheader key={group}>{group}</ListSubheader>,
+                      ...groupHeaders
+                    ]
+                  })}
                 </Select>
               </FormControl>
             </TableCell>

--- a/frontend-v2/src/features/data/MapHeaders.tsx
+++ b/frontend-v2/src/features/data/MapHeaders.tsx
@@ -36,15 +36,14 @@ const MapHeaders: FC<IMapHeaders> = ({data, fields, normalisedFields, setNormali
                   label="Column Type"
                   onChange={handleFieldChange(index)}
                 >
-                  {Object.entries(groupedHeaders).map(([group, headers]) => {
-                    const groupHeaders = headers.map(header => (
-                      <MenuItem key={header} value={header}>{header}</MenuItem>
-                    ));
-                    return [
+                  {Object.entries(groupedHeaders).map(([group, headers]) => (
+                    [
                       <ListSubheader key={group}>{group}</ListSubheader>,
-                      ...groupHeaders
+                      ...headers.map(header => (
+                        <MenuItem key={header} value={header}>{header}</MenuItem>
+                      ))
                     ]
-                  })}
+                  ))}
                 </Select>
               </FormControl>
             </TableCell>

--- a/frontend-v2/src/features/data/normaliseDataHeaders.ts
+++ b/frontend-v2/src/features/data/normaliseDataHeaders.ts
@@ -26,6 +26,24 @@ const normalisation = {
   'Time Unit': ['time unit', 'time_unit', 'time_units', 't_units', 'tunit', 'units_time'],
 }
 
+export const groupedHeaders = {
+  'Frequently Used': [
+    'Ignore', 'ID', 'Time', 'Time Unit', 'Observation', 'Observation Unit', 'Amount', 'Amount Unit'
+  ],
+  'Dosing': [
+    'Administration ID', 'Additional Doses', 'Infusion Rate', 'Infusion Duration', 'Interdose Interval'
+  ],
+  'Observation': [
+    'Observation ID', 'Censoring', 'Ignored Observation'
+  ],
+  'PKPD Model': [
+    'Amount Variable', 'Observation Variable'
+  ],
+  'Other': [
+    'Cat Covariate', 'Cont Covariate', 'Event ID', 'Occasion', 'Regressor'
+  ],
+}
+
 export const manditoryHeaders = ['Time', 'Observation']
 
 export const normalisedHeaders = Object.keys(normalisation)


### PR DESCRIPTION
Organise the column types, for uploaded data CSVs, into groups so that the drop down menu is easier to navigate.


https://github.com/pkpdapp-team/pkpdapp/assets/59547/0fab0d8a-0c2a-4b6f-a4a8-de8d38e366b9

