### PR TITLE
fix(frontend): normalise all upload column names to English

### DIFF
--- a/frontend-v2/src/features/data/PreviewData.tsx
+++ b/frontend-v2/src/features/data/PreviewData.tsx
@@ -38,9 +38,18 @@ function useNormalisedColumn(state: StepperState, type: string) {
 
 const PreviewData: FC<IPreviewData> = ({ state, firstTime }: IPreviewData) => {
   useNormalisedColumn(state, 'Time');
+  useNormalisedColumn(state, 'Time Unit');
   useNormalisedColumn(state, 'ID');
   useNormalisedColumn(state, 'Observation');
+  useNormalisedColumn(state, 'Observation Unit');
+  useNormalisedColumn(state, 'Observation ID');
   useNormalisedColumn(state, 'Amount');
+  useNormalisedColumn(state, 'Amount Unit');
+  useNormalisedColumn(state, 'Administration ID');
+  useNormalisedColumn(state, 'Additional Doses');
+  useNormalisedColumn(state, 'Infusion Duration');
+  useNormalisedColumn(state, 'Infusion Rate');
+  useNormalisedColumn(state, 'Interdose Interval');
   const { data } = state;
   const fields = [
     ...state.fields

--- a/pkpdapp/pkpdapp/utils/data_parser.py
+++ b/pkpdapp/pkpdapp/utils/data_parser.py
@@ -21,13 +21,14 @@ class DataParser:
             "time", "timepoint", "t"
         ],
         "TIME_UNIT": [
-            "time_unit", "time_units", "timeunit", "units_time"
+            "time unit", "time_unit", "time_units", "timeunit", "units_time"
         ],
         "AMOUNT": [
-            "amt", "amount", "amount"
+            "amt", "amount"
         ],
         "AMOUNT_UNIT": [
-            "amt_unit", "amt_units", "amtunit", "unit", "amount_unit", "units_amt"
+            "amount unit", "amt_unit", "amt_units", "amtunit", "unit",
+            "amount_unit", "units_amt"
         ],
         "AMOUNT_VARIABLE": [
             "amount variable", "amount_variable", "amount_var",
@@ -38,12 +39,12 @@ class DataParser:
             "observation_value", "observationvalue"
         ],
         "OBSERVATION_NAME": [
-            "observation_id", "ydesc", "yname", "ytype",
+            "observation id", "observation_id", "ydesc", "yname", "ytype",
             "observation_name", "observationid", "observationname"
         ],
         "OBSERVATION_UNIT": [
-            "dv_units", "observation_unit", "yunit", "unit", "units_conc",
-            "observationunit"
+            "observation unit", "dv_units", "observation_unit", "yunit", "unit",
+            "units_conc", "observationunit"
         ],
         "OBSERVATION_VARIABLE": [
             "observation variable", "observation_variable", "observation_var"
@@ -55,16 +56,16 @@ class DataParser:
             "route"
         ],
         "INFUSION_TIME": [
-            "tinf", "infusion_time", "infusiontime"
+            "infusion duration", "tinf", "infusion_time", "infusiontime"
         ],
         "GROUP_ID": [
             "group id", "group_id", "group", "cohort"
         ],
         "ADDITIONAL_DOSES": [
-            "addl", "additional_doses"
+            "additional doses", "addl", "additional_doses"
         ],
         "INTERDOSE_INTERVAL": [
-            "ii", "infusion_interval"
+            "interdose interval", "ii", "infusion_interval"
         ]
     }
 


### PR DESCRIPTION
`utils/data_parser.py`, in the Django backend, expects column names to be in English. Normalise all column names to their English equivalents (chosen from the Column Type dropdown during step 1 of an upload.)