### PR TITLE
fix(frontend): CSV headers should be case-insensitive

### DIFF
--- a/frontend-v2/src/features/data/PreviewData.tsx
+++ b/frontend-v2/src/features/data/PreviewData.tsx
@@ -13,7 +13,7 @@ function useNormalisedColumn(state: StepperState, type: string) {
   const field = state.fields[fieldIndex];
   const normalisedField = type;
   const newData = [...state.data];
-  if (fieldIndex > -1 && field !== normalisedField) {
+  if (fieldIndex > -1 && field.toLowerCase() !== normalisedField.toLowerCase()) {
     const newFields = [...state.fields];
     const newNormalisedFields = [...state.normalisedFields];
     newNormalisedFields[fieldIndex] = "Ignore";


### PR DESCRIPTION
Compare lowercase field names during normalisation, so that we don't accidentally create a CSV with eg. both TIME and Time as columns.