### PR TITLE
fix(backend): catch missing time values during CSV validation

### DIFF
--- a/pkpdapp/pkpdapp/utils/data_parser.py
+++ b/pkpdapp/pkpdapp/utils/data_parser.py
@@ -224,6 +224,15 @@ class DataParser:
                         return x
                 data[unit_col] = data[unit_col].map(convert_percent_to_dim)
 
+        # check that time ise set for all rows
+        if (data["TIME"].apply(pd.to_numeric, errors='coerce')).isna().any():
+            raise RuntimeError(
+                (
+                    'Error parsing file, '
+                    'contains missing time values'
+                )
+            )
+ 
         # put in default infusion time if not present
         delta_time = data.sort_values(by=["TIME"]).groupby(
             ["SUBJECT_ID"]

--- a/pkpdapp/pkpdapp/utils/data_parser.py
+++ b/pkpdapp/pkpdapp/utils/data_parser.py
@@ -224,7 +224,7 @@ class DataParser:
                         return x
                 data[unit_col] = data[unit_col].map(convert_percent_to_dim)
 
-        # check that time ise set for all rows
+        # check that time is set for all rows
         if (data["TIME"].apply(pd.to_numeric, errors='coerce')).isna().any():
             raise RuntimeError(
                 (
@@ -232,7 +232,7 @@ class DataParser:
                     'contains missing time values'
                 )
             )
- 
+
         # put in default infusion time if not present
         delta_time = data.sort_values(by=["TIME"]).groupby(
             ["SUBJECT_ID"]


### PR DESCRIPTION
- Add a check for missing time values in the CSV validator.
- Reset the upload stepper state to the first step, after upload errors.