### PR TITLE
refactor(frontend): normalise unit headers for CSVs

### DIFF
--- a/frontend-v2/src/features/data/DosingProtocols.tsx
+++ b/frontend-v2/src/features/data/DosingProtocols.tsx
@@ -29,7 +29,7 @@ interface IDosingProtocols {
 
 const DosingProtocols: FC<IDosingProtocols> = ({
   administrationIdField,
-  amountUnitField = "Amt_unit",
+  amountUnitField = "Amount Unit",
   amountUnit,
   state,
   units,

--- a/frontend-v2/src/features/data/PreviewData.tsx
+++ b/frontend-v2/src/features/data/PreviewData.tsx
@@ -68,16 +68,16 @@ const PreviewData: FC<IPreviewData> = ({ state, firstTime }: IPreviewData) => {
     fields.push("Amount");
   }
   if (!state.normalisedFields.find((field) => field === "Time Unit")) {
-    fields.push("Time_unit");
+    fields.push("Time Unit");
   }
   if (!state.normalisedFields.find((field) => field === "Amount Unit")) {
-    fields.push("Amt_unit");
+    fields.push("Amount Unit");
   }
   if (
     !state.normalisedFields.find((field) => field === "Observation Unit") &&
-    !state.fields.find((field) => field === "Observation_unit")
+    !state.fields.find((field) => field === "Observation Unit")
   ) {
-    fields.push("Observation_unit");
+    fields.push("Observation Unit");
   }
   const visibleFields = fields.filter(
     (field, index) => state.normalisedFields[index] !== "Ignore",

--- a/frontend-v2/src/features/data/SetUnits.tsx
+++ b/frontend-v2/src/features/data/SetUnits.tsx
@@ -58,7 +58,7 @@ const SetUnits: FC<IMapObservations> = ({
     state.setTimeUnit(event.target?.value);
     const newData = state.data.map((row) => ({
       ...row,
-      Time_unit: event.target?.value,
+      'Time Unit': event.target?.value,
     }));
     state.setData(newData);
     const { errors, warnings } = validateState({

--- a/frontend-v2/src/features/data/useObservationRows.ts
+++ b/frontend-v2/src/features/data/useObservationRows.ts
@@ -3,7 +3,7 @@ import { normaliseHeader } from "./normaliseDataHeaders";
 import { Row } from "./LoadData";
 
 const DEFAULT_VARIABLE_FIELD = "Observation Variable";
-const DEFAULT_UNIT_FIELD = "Observation_unit";
+const DEFAULT_UNIT_FIELD = "Observation Unit";
 
 function mergeObservationColumns(
   state: StepperState,


### PR DESCRIPTION
Normalise unit headers as Time Unit, Amount Unit, and Observation Unit.