### PR TITLE
refactor(frontend): allow free choice of mapped observation variables

### DIFF
--- a/frontend-v2/src/features/data/MapObservations.tsx
+++ b/frontend-v2/src/features/data/MapObservations.tsx
@@ -161,17 +161,6 @@ const MapObservations: FC<IMapObservations> = ({ state }: IMapObservations) => {
                     selectedUnitSymbol = "";
                   }
                 });
-                const compatibleVariables = modelOutputs.filter((variable) => {
-                  const variableUnit = units?.find(
-                    (unit) => unit.id === variable.unit,
-                  );
-                  const compatibleSymbols = variableUnit?.compatible_units.map(
-                    (u) => u.symbol,
-                  );
-                  return observationUnitField && selectedUnitSymbol
-                    ? compatibleSymbols?.includes(selectedUnitSymbol)
-                    : true;
-                });
                 return (
                   <TableRow key={obsId}>
                     <TableCell>{obsId}</TableCell>
@@ -187,7 +176,7 @@ const MapObservations: FC<IMapObservations> = ({ state }: IMapObservations) => {
                           value={selectedVariable?.qname}
                           onChange={handleObservationChange(obsId)}
                         >
-                          {compatibleVariables?.map((variable) => (
+                          {modelOutputs?.map((variable) => (
                             <MenuItem
                               key={variable.name}
                               value={variable.qname}


### PR DESCRIPTION
During the Map Observations step of a data upload, always show the full menu of model variables. Otherwise, it's impossible to change variable after selecting a unit.