### PR TITLE
refactor(frontend): refactor data CSV row headers

### DIFF
--- a/frontend-v2/src/features/data/MapObservations.tsx
+++ b/frontend-v2/src/features/data/MapObservations.tsx
@@ -96,6 +96,11 @@ const MapObservations: FC<IMapObservations> = ({ state }: IMapObservations) => {
         (unit) => unit.id === selectedVariable?.unit,
       );
       nextData
+        .map((row) => {
+          row[observationVariableField] = row[observationVariableField] || '';
+          row[observationUnitField] = row[observationUnitField] || '';
+          return row;
+        })
         .filter((row) =>
           observationIdField ? row[observationIdField] === id : true,
         )

--- a/frontend-v2/src/features/data/PreviewData.tsx
+++ b/frontend-v2/src/features/data/PreviewData.tsx
@@ -9,6 +9,8 @@ interface IPreviewData {
   firstTime: boolean;
 }
 
+const IGNORED_COLUMNS = [ 'Ignore', 'Ignored Observation' ];
+
 function useNormalisedColumn(state: StepperState, type: string) {
   const fieldIndex = state.normalisedFields.indexOf(type);
   const field = state.fields[fieldIndex];
@@ -54,36 +56,13 @@ const PreviewData: FC<IPreviewData> = ({ state, firstTime }: IPreviewData) => {
   useNormalisedColumn(state, "Infusion Duration");
   useNormalisedColumn(state, "Infusion Rate");
   useNormalisedColumn(state, "Interdose Interval");
+  useNormalisedColumn(state, "Censoring");
+  useNormalisedColumn(state, "Event ID");
+  useNormalisedColumn(state, "Ignored Observation");
   const { data } = state;
-  const fields = [...state.fields];
-  if (!state.fields.find((field) => field === "Group ID")) {
-    fields.push("Group ID");
-  }
-  if (!state.normalisedFields.find((field) => field === "Amount Variable")) {
-    fields.push("Amount Variable");
-  }
-  if (
-    !state.normalisedFields.find((field) => field === "Observation Variable")
-  ) {
-    fields.push("Observation Variable");
-  }
-  if (!state.normalisedFields.find((field) => field === "Amount")) {
-    fields.push("Amount");
-  }
-  if (!state.normalisedFields.find((field) => field === "Time Unit")) {
-    fields.push("Time Unit");
-  }
-  if (!state.normalisedFields.find((field) => field === "Amount Unit")) {
-    fields.push("Amount Unit");
-  }
-  if (
-    !state.normalisedFields.find((field) => field === "Observation Unit") &&
-    !state.fields.find((field) => field === "Observation Unit")
-  ) {
-    fields.push("Observation Unit");
-  }
+  const fields = Object.keys(data[0]);
   const visibleFields = fields.filter(
-    (field, index) => state.normalisedFields[index] !== "Ignore",
+    (field, index) => !IGNORED_COLUMNS.includes(state.normalisedFields[index])
   );
   const visibleRows = data.filter((row) =>
     validateDataRow(row, state.normalisedFields, state.fields),

--- a/frontend-v2/src/features/data/generateCSV.ts
+++ b/frontend-v2/src/features/data/generateCSV.ts
@@ -25,18 +25,18 @@ const HEADERS: string[] = [
   "ID",
   "Group",
   "Time",
-  "Time_unit",
+  "Time Unit",
   "Observation",
-  "Observation_unit",
-  "Observation_id",
-  "Observation_var",
-  "Adm",
-  "Amt",
-  "Amt_unit",
-  "Amt_var",
-  "Infusion_time",
-  "II",
-  "ADDL",
+  "Observation Unit",
+  "Observation ID",
+  "Observation Variable",
+  "Administration ID",
+  "Amount",
+  "Amount Unit",
+  "Amount Variable",
+  "Infusion Duration",
+  "Interdose Interval",
+  "Additional Doses",
 ];
 
 function parseDosingRow(
@@ -51,16 +51,16 @@ function parseDosingRow(
     units?.find((unit) => unit.id === protocol.time_unit)?.symbol || "";
   const qname = protocol.mapped_qname;
   return protocol.doses.map((dose) => ({
-    Adm: adminId,
+    "Administration ID": adminId,
     Group: groupId,
-    Amt: dose.amount.toString(),
-    Amt_unit: amountUnit,
+    Amount: dose.amount.toString(),
+    "Amount Unit": amountUnit,
     Time: dose.start_time.toString(),
-    Time_unit: timeUnit,
-    Infusion_time: dose.duration,
-    ADDL: (dose?.repeats || 1) - 1,
-    II: dose.repeat_interval,
-    Amt_var: qname,
+    "Time Unit": timeUnit,
+    "Infusion Duration": dose.duration,
+    "Additional Doses": (dose?.repeats || 1) - 1,
+    "Interdose Interval": dose.repeat_interval,
+    "Amount Variable": qname,
     Observation: ".",
   }));
 }
@@ -72,13 +72,13 @@ function parseBiomarkerRow(
   return {
     ID: row.subjectDatasetId,
     Time: row.time.toString(),
-    Time_unit: row.timeUnit?.symbol,
+    "Time Unit": row.timeUnit?.symbol,
     Observation: row.value.toString(),
-    Observation_unit: row.unit?.symbol,
-    Observation_id: row.label,
-    Observation_var: row.qname,
+    "Observation Unit": row.unit?.symbol,
+    "Observation ID": row.label,
+    "Observation Variable": row.qname,
     Group: groupId,
-    Amt: ".",
+    Amount: ".",
   };
 }
 


### PR DESCRIPTION
- standardise row headers for generated CSVs.
- for datasets where the first row is a dosing row, make sure that row has empty observation columns.
- use the first dataset row to determine the row headers for the preview step of an upload.