### PR TITLE
fix(frontend): respect Ignore columns for data upload

### DIFF
--- a/frontend-v2/src/features/data/LoadDataStepper.tsx
+++ b/frontend-v2/src/features/data/LoadDataStepper.tsx
@@ -139,7 +139,15 @@ const LoadDataStepper: FC<IStepper> = ({ csv = "", onCancel, onFinish }) => {
       try {
         const dataToUpload = data.filter((row) =>
           validateDataRow(row, normalisedFields, fields),
-        );
+        ).map((row) => {
+          const newRow: Record<string, string> = {};
+          Object.keys(row).forEach((field, index) => {
+            if (!["Ignore","Ignored Observation"].includes(normalisedFields[index])) {
+              newRow[field] = row[field];
+            }
+          });
+          return newRow;
+        });
         const csv = Papa.unparse(dataToUpload);
         const response = await updateDatasetCsv({
           id: dataset.id,


### PR DESCRIPTION
Remove ignored columns from a new dataset before converting it to CSV and uploading it.