### PR TITLE
fix(frontend): ignore censored rows

### DIFF
--- a/frontend-v2/src/features/data/LoadDataStepper.tsx
+++ b/frontend-v2/src/features/data/LoadDataStepper.tsx
@@ -149,7 +149,7 @@ const LoadDataStepper: FC<IStepper> = ({ csv = "", onCancel, onFinish }) => {
         ).map((row) => {
           const newRow: Record<string, string> = {};
           Object.keys(row).forEach((field, index) => {
-            if (!["Ignore","Ignored Observation"].includes(normalisedFields[index])) {
+            if (normalisedFields[index] === "Ignore") {
               newRow[field] = row[field];
             }
           });

--- a/frontend-v2/src/features/data/PreviewData.tsx
+++ b/frontend-v2/src/features/data/PreviewData.tsx
@@ -9,7 +9,7 @@ interface IPreviewData {
   firstTime: boolean;
 }
 
-const IGNORED_COLUMNS = [ 'Ignore', 'Ignored Observation' ];
+const IGNORED_COLUMNS = [ 'Ignore' ];
 
 function useNormalisedColumn(state: StepperState, type: string) {
   const fieldIndex = state.normalisedFields.indexOf(type);

--- a/frontend-v2/src/features/data/normaliseDataHeaders.ts
+++ b/frontend-v2/src/features/data/normaliseDataHeaders.ts
@@ -116,11 +116,22 @@ export const validateDataRow = (
   fields: string[],
 ) => {
   const timeField = fields.find((field, i) => normalisedFields[i] === "Time");
+  const censorField = fields.find((field, i) => normalisedFields[i] === "Censoring");
+  const mdvField = fields.find((field, i) => normalisedFields[i] === "Ignored Observation");
   if (!timeField) {
     return false;
   }
+  if (censorField && parseInt(row[censorField]) === 1) {
+    return false;
+  }
+  if (mdvField && parseInt(row[mdvField]) === 1) {
+    return false;
+  }
   const time = parseFloat(row[timeField]);
-  return !isNaN(time);
+  if (isNaN(time)) {
+    return false;
+  }
+  return true;
 };
 
 export const validateState = (state: StepperState) => {


### PR DESCRIPTION
Ignore any data rows where either 'Censoring' or 'Ignored Observation' is set to 1.