### PR TITLE
refactor(frontend): use a Map for normalised headers

### DIFF
--- a/frontend-v2/src/features/data/CreateDosingProtocols.tsx
+++ b/frontend-v2/src/features/data/CreateDosingProtocols.tsx
@@ -34,11 +34,15 @@ const CreateDosingProtocols: FC<IDosingProtocols> = ({
   variables,
 }: IDosingProtocols) => {
   const amountField = state.fields.find(
-    (field, i) => field === "Amount" || state.normalisedFields[i] === "Amount",
+    (field) =>
+      field === "Amount" || state.normalisedFields.get(field) === "Amount",
   );
   if (!amountField) {
     const newFields = [...state.fields, "Amount"];
-    const newNormalisedFields = [...state.normalisedFields, "Amount"];
+    const newNormalisedFields = new Map([
+      ...state.normalisedFields.entries(),
+      ["Amount", "Amount"],
+    ]);
     const newData = state.data.map((row) => ({ ...row, Amount: "." }));
     state.setFields(newFields);
     state.setNormalisedFields(newNormalisedFields);
@@ -99,7 +103,7 @@ const CreateDosingProtocols: FC<IDosingProtocols> = ({
             </TableRow>
           </TableHead>
           <TableBody>
-            {uniqueAdministrationIds.map((adminId, index) => {
+            {uniqueAdministrationIds.map((adminId) => {
               const currentRow = state.data.find((row) =>
                 administrationIdField
                   ? row[administrationIdField] === adminId

--- a/frontend-v2/src/features/data/DosingProtocols.tsx
+++ b/frontend-v2/src/features/data/DosingProtocols.tsx
@@ -36,10 +36,10 @@ const DosingProtocols: FC<IDosingProtocols> = ({
   variables,
 }: IDosingProtocols) => {
   const amountField = state.fields.find(
-    (field, i) => state.normalisedFields[i] === "Amount",
+    (field) => state.normalisedFields.get(field) === "Amount",
   );
   const amountVariableField = state.fields.find(
-    (field, i) => state.normalisedFields[i] === "Amount Variable",
+    (field) => state.normalisedFields.get(field) === "Amount Variable",
   );
   const dosingRows = amountField
     ? state.data.filter((row) => row[amountField] && row[amountField] !== ".")
@@ -92,7 +92,10 @@ const DosingProtocols: FC<IDosingProtocols> = ({
     const { errors, warnings } = validateState({
       ...state,
       data: nextData,
-      normalisedFields: [...state.normalisedFields, "Amount Unit"],
+      normalisedFields: new Map([
+        ...state.normalisedFields.entries(),
+        [amountUnitField, "Amount Unit"],
+      ]),
     });
     state.setErrors(errors);
     state.setWarnings(warnings);
@@ -128,7 +131,7 @@ const DosingProtocols: FC<IDosingProtocols> = ({
             </TableRow>
           </TableHead>
           <TableBody>
-            {uniqueAdministrationIds.map((adminId, index) => {
+            {uniqueAdministrationIds.map((adminId) => {
               const currentRow = dosingRows.find((row) =>
                 administrationIdField
                   ? row[administrationIdField] === adminId

--- a/frontend-v2/src/features/data/MapDosing.tsx
+++ b/frontend-v2/src/features/data/MapDosing.tsx
@@ -44,13 +44,13 @@ const MapDosing: FC<IMapDosing> = ({ state, firstTime }: IMapDosing) => {
   );
 
   const amountField = state.fields.find(
-    (field, i) => state.normalisedFields[i] === "Amount",
+    (field) => state.normalisedFields.get(field) === "Amount",
   );
-  const amountUnitField = state.fields.find((field, i) =>
-    ["Amount Unit", "Unit"].includes(state.normalisedFields[i]),
+  const amountUnitField = state.fields.find((field) =>
+    ["Amount Unit", "Unit"].includes(state.normalisedFields.get(field) || ""),
   );
   const administrationIdField = state.fields.find(
-    (field, i) => state.normalisedFields[i] === "Administration ID",
+    (field) => state.normalisedFields.get(field) === "Administration ID",
   );
   const hasDosingRows = amountField && administrationIdField;
 

--- a/frontend-v2/src/features/data/MapHeaders.tsx
+++ b/frontend-v2/src/features/data/MapHeaders.tsx
@@ -11,7 +11,6 @@ import {
   MenuItem,
   InputLabel,
   Typography,
-  Menu,
 } from "@mui/material";
 import { Data, Field } from "./LoadData";
 import { groupedHeaders } from "./normaliseDataHeaders";
@@ -19,8 +18,8 @@ import { groupedHeaders } from "./normaliseDataHeaders";
 interface IMapHeaders {
   data: Data;
   fields: Field[];
-  normalisedFields: Field[];
-  setNormalisedFields: (fields: Field[]) => void;
+  normalisedFields: Map<Field, string>;
+  setNormalisedFields: (fields: Map<Field, string>) => void;
 }
 
 const MapHeaders: FC<IMapHeaders> = ({
@@ -29,9 +28,9 @@ const MapHeaders: FC<IMapHeaders> = ({
   normalisedFields,
   setNormalisedFields,
 }: IMapHeaders) => {
-  const handleFieldChange = (index: number) => (event: any) => {
-    const newFields = [...normalisedFields];
-    newFields[index] = event.target.value;
+  const handleFieldChange = (field: string) => (event: any) => {
+    const newFields = new Map(normalisedFields) as Map<Field, string>;
+    newFields.set(field, event.target.value as string);
     setNormalisedFields(newFields);
   };
 
@@ -56,9 +55,9 @@ const MapHeaders: FC<IMapHeaders> = ({
                 <Select
                   labelId={`select-${index}-label`}
                   id={`select-${index}`}
-                  value={normalisedFields[index]}
+                  value={normalisedFields.get(field)}
                   label="Column Type"
-                  onChange={handleFieldChange(index)}
+                  onChange={handleFieldChange(field)}
                 >
                   {Object.entries(groupedHeaders).map(([group, headers]) => [
                     <ListSubheader key={group}>{group}</ListSubheader>,

--- a/frontend-v2/src/features/data/MapObservations.tsx
+++ b/frontend-v2/src/features/data/MapObservations.tsx
@@ -97,8 +97,8 @@ const MapObservations: FC<IMapObservations> = ({ state }: IMapObservations) => {
       );
       nextData
         .map((row) => {
-          row[observationVariableField] = row[observationVariableField] || '';
-          row[observationUnitField] = row[observationUnitField] || '';
+          row[observationVariableField] = row[observationVariableField] || "";
+          row[observationUnitField] = row[observationUnitField] || "";
           return row;
         })
         .filter((row) =>
@@ -127,7 +127,10 @@ const MapObservations: FC<IMapObservations> = ({ state }: IMapObservations) => {
     const { errors, warnings } = validateState({
       ...state,
       data: nextData,
-      normalisedFields: [...state.normalisedFields, "Observation Unit"],
+      normalisedFields: new Map([
+        ...state.normalisedFields.entries(),
+        ["Observation Unit", "Observation Unit"],
+      ]),
     });
     state.setErrors(errors);
     state.setWarnings(warnings);
@@ -154,7 +157,7 @@ const MapObservations: FC<IMapObservations> = ({ state }: IMapObservations) => {
   ].map((normalisedField) => {
     const field =
       state.fields.find(
-        (field, index) => state.normalisedFields[index] === normalisedField,
+        (field) => state.normalisedFields.get(field) === normalisedField,
       ) || normalisedField;
     return {
       field,

--- a/frontend-v2/src/features/data/PreviewData.tsx
+++ b/frontend-v2/src/features/data/PreviewData.tsx
@@ -9,28 +9,25 @@ interface IPreviewData {
   firstTime: boolean;
 }
 
-const IGNORED_COLUMNS = [ 'Ignore' ];
+const IGNORED_COLUMNS = ["Ignore"];
 
 function useNormalisedColumn(state: StepperState, type: string) {
-  const fieldIndex = state.normalisedFields.indexOf(type);
-  const field = state.fields[fieldIndex];
+  const normalisedHeaders = [...state.normalisedFields.entries()];
+  const [field] =
+    normalisedHeaders.find(([key, value]) => value === type) || [];
   const newData = [...state.data];
-  if (
-    fieldIndex > -1 &&
-    field.toLowerCase() !== type.toLowerCase()
-  ) {
+  if (field && field.toLowerCase() !== type.toLowerCase()) {
     const newFields = [...state.fields];
-    const newNormalisedFields = [...state.normalisedFields];
-    newNormalisedFields[fieldIndex] = "Ignore";
+    const newNormalisedFields = new Map([
+      ...state.normalisedFields.entries(),
+      [field, "Ignore"],
+      [type, type],
+    ]);
     if (!newFields.includes(type)) {
       newFields.push(type);
-      newNormalisedFields.push(type);
-    } else {
-      const normalisedFieldIndex = newFields.indexOf(type);
-      newNormalisedFields[normalisedFieldIndex] = type;
     }
     newData.forEach((row) => {
-      row[type] = row[field] || '';
+      row[type] = row[field] || "";
     });
     state.setData(newData);
     state.setFields(newFields);
@@ -59,10 +56,10 @@ const PreviewData: FC<IPreviewData> = ({ state, firstTime }: IPreviewData) => {
   const { data } = state;
   const fields = Object.keys(data[0]);
   const visibleFields = fields.filter(
-    (field) => {
-      const index = state.fields.indexOf(field);
-      return !IGNORED_COLUMNS.includes(state.normalisedFields[index]);
-  });
+    (field) =>
+      !IGNORED_COLUMNS.includes(state.normalisedFields.get(field) || ""),
+  );
+  console.log(fields, visibleFields, state.normalisedFields);
   const visibleRows = data.filter((row) =>
     validateDataRow(row, state.normalisedFields, state.fields),
   );
@@ -70,7 +67,7 @@ const PreviewData: FC<IPreviewData> = ({ state, firstTime }: IPreviewData) => {
   return (
     <>
       <Alert severity="info">
-        Preview your data. Click 'Finish' to upload and save.
+        Preview your data. Click &lsquo;Finish&rsquo; to upload and save.
       </Alert>
       <Box
         component="div"

--- a/frontend-v2/src/features/data/ProtocolDataGrid.tsx
+++ b/frontend-v2/src/features/data/ProtocolDataGrid.tsx
@@ -19,11 +19,11 @@ const ROW_COLS = ["Amount", "Amount Unit"];
 const ProtocolDataGrid: FC<IProtocolDataGrid> = ({ group, state }) => {
   const [selected, setSelected] = useState<GridRowId[]>([]);
   const idField = state.fields.find(
-    (field, index) => state.normalisedFields[index] === "ID",
+    (field) => state.normalisedFields.get(field) === "ID",
   );
   const { subjects } = group;
-  const outputColumns = state.fields.filter((field, index) =>
-    ROW_COLS.includes(state.normalisedFields[index]),
+  const outputColumns = state.fields.filter((field) =>
+    ROW_COLS.includes(state.normalisedFields.get(field) || ""),
   );
   const subjectRows = subjects
     .map((subject) => {

--- a/frontend-v2/src/features/data/SetUnits.tsx
+++ b/frontend-v2/src/features/data/SetUnits.tsx
@@ -45,14 +45,13 @@ const SetUnits: FC<IMapObservations> = ({
     return <Typography variant="h5">No project or units found</Typography>;
   }
 
+  const normalisedHeaders = [...state.normalisedFields.values()];
   const secondUnit = units.find((unit) => unit.symbol === "s");
   const timeUnits = secondUnit?.compatible_units.map((unit) => unit.symbol);
   const timeUnitOptions =
     timeUnits?.map((unit) => ({ value: unit, label: unit })) || [];
 
-  const noTimeUnit = !state.normalisedFields.find(
-    (field) => field === "Time Unit",
-  );
+  const noTimeUnit = !normalisedHeaders.find((field) => field === "Time Unit");
 
   function setTimeUnit(event: SelectChangeEvent) {
     state.setTimeUnit(event.target?.value);
@@ -63,7 +62,10 @@ const SetUnits: FC<IMapObservations> = ({
     state.setData(newData);
     const { errors, warnings } = validateState({
       ...state,
-      normalisedFields: [...state.normalisedFields, "Time Unit"],
+      normalisedFields: new Map([
+        ...state.normalisedFields.entries(),
+        ["Time Unit", "Time Unit"],
+      ]),
     });
     state.setErrors(errors);
     state.setWarnings(warnings);

--- a/frontend-v2/src/features/data/Stratification.tsx
+++ b/frontend-v2/src/features/data/Stratification.tsx
@@ -23,10 +23,10 @@ interface IStratification {
 
 const Stratification: FC<IStratification> = ({ state }: IStratification) => {
   const idField = state.fields.find(
-    (field, index) => state.normalisedFields[index] === "ID",
+    (field) => state.normalisedFields.get(field) === "ID",
   );
   const catCovariates = state.fields.filter(
-    (field, index) => state.normalisedFields[index] === "Cat Covariate",
+    (field) => state.normalisedFields.get(field) === "Cat Covariate",
   );
   const uniqueCovariateValues = catCovariates.map((field) => {
     const values = state.data.map((row) => row[field]);

--- a/frontend-v2/src/features/data/SubjectGroupForm.tsx
+++ b/frontend-v2/src/features/data/SubjectGroupForm.tsx
@@ -22,7 +22,7 @@ const SubjectGroupForm: FC<ISubjectGroupForm> = ({
 }) => {
   const selectedGroupInput = useRef<HTMLInputElement>(null);
   const idField = state.fields.find(
-    (field, index) => state.normalisedFields[index] === "ID",
+    (field) => state.normalisedFields.get(field) === "ID",
   );
 
   function onSubmitGroupIDForm(event: FormEvent<HTMLFormElement>) {

--- a/frontend-v2/src/features/data/protocolUtils.ts
+++ b/frontend-v2/src/features/data/protocolUtils.ts
@@ -19,19 +19,19 @@ export interface IProtocol {
 
 export function getSubjectDoses(state: StepperState): SubjectDoses[] {
   const idField = state.fields.find(
-    (field, index) => state.normalisedFields[index] === "ID",
+    (field) => state.normalisedFields.get(field) === "ID",
   );
   const amountField = state.fields.find(
-    (field, index) => state.normalisedFields[index] === "Amount",
+    (field) => state.normalisedFields.get(field) === "Amount",
   );
-  const amountUnitField = state.fields.find((field, index) =>
-    ["Amount Unit", "Unit"].includes(state.normalisedFields[index]),
+  const amountUnitField = state.fields.find((field) =>
+    ["Amount Unit", "Unit"].includes(state.normalisedFields.get(field) || ""),
   );
   const timeField = state.fields.find(
-    (field, index) => state.normalisedFields[index] === "Time",
+    (field) => state.normalisedFields.get(field) === "Time",
   );
   const timeUnitField = state.fields.find(
-    (field, index) => state.normalisedFields[index] === "Time Unit",
+    (field) => state.normalisedFields.get(field) === "Time Unit",
   );
   const routeField = state.fields.find(
     (field) => field.toLowerCase() === "route",

--- a/frontend-v2/src/features/data/useObservationRows.ts
+++ b/frontend-v2/src/features/data/useObservationRows.ts
@@ -10,8 +10,10 @@ function mergeObservationColumns(
   observationFields: string[],
 ) {
   const rows: Row[] = [];
-  const amountIndex = state.normalisedFields.indexOf("Amount");
-  const amountField = state.fields[amountIndex];
+  const amountField =
+    state.fields.find(
+      (field) => state.normalisedFields.get(field) === "Amount",
+    ) || "Amount";
   observationFields.forEach((field, i) => {
     const observationId = field;
     state.data.forEach((row) => {
@@ -37,12 +39,13 @@ function mergeObservationColumns(
 
 export default function useObservationRows(state: StepperState, tab: string) {
   let fields = [...state.fields];
-  let normalisedFields = [...state.normalisedFields];
+  let normalisedFields = state.normalisedFields;
   const observationFields =
-    fields.filter((field, i) => normalisedFields[i] === "Observation") || [];
+    fields.filter((field) => normalisedFields.get(field) === "Observation") ||
+    [];
   let [observationField] = observationFields;
   let observationIdField = fields.find(
-    (field, i) => state.normalisedFields[i] === "Observation ID",
+    (field) => state.normalisedFields.get(field) === "Observation ID",
   );
   let rows = state.data;
   if (observationFields.length > 1) {
@@ -50,7 +53,7 @@ export default function useObservationRows(state: StepperState, tab: string) {
     observationField = "Observation";
     observationIdField = "Observation ID";
     fields = Object.keys(rows[0]);
-    normalisedFields = fields.map(normaliseHeader);
+    normalisedFields = new Map(fields.map(normaliseHeader));
     state.setFields(fields);
     state.setNormalisedFields(normalisedFields);
     state.setData(rows);
@@ -64,12 +67,13 @@ export default function useObservationRows(state: StepperState, tab: string) {
     ? observationRows.map((row) => row[observationIdField || "Observation ID"])
     : [observationField];
   const observationUnitField =
-    fields.find((field, i) =>
-      ["Observation Unit", "Unit"].includes(normalisedFields[i]),
+    fields.find((field) =>
+      ["Observation Unit", "Unit"].includes(normalisedFields.get(field) || ""),
     ) || DEFAULT_UNIT_FIELD;
   const observationVariableField =
-    fields.find((field, i) => normalisedFields[i] === "Observation Variable") ||
-    DEFAULT_VARIABLE_FIELD;
+    fields.find(
+      (field) => normalisedFields.get(field) === "Observation Variable",
+    ) || DEFAULT_VARIABLE_FIELD;
   const observationUnits = observationRows.map(
     (row) => row[observationUnitField],
   );


### PR DESCRIPTION
Refactor normalised headers so that we can get a field's type as `normalisedFields.get(field)`, rather than relying on keeping two arrays in sync with each other.