### PR TITLE
refactor(frontend): derive CSV fields from normalised header state

### DIFF
--- a/frontend-v2/src/features/data/CreateDosingProtocols.tsx
+++ b/frontend-v2/src/features/data/CreateDosingProtocols.tsx
@@ -38,13 +38,11 @@ const CreateDosingProtocols: FC<IDosingProtocols> = ({
       field === "Amount" || state.normalisedFields.get(field) === "Amount",
   );
   if (!amountField) {
-    const newFields = [...state.fields, "Amount"];
     const newNormalisedFields = new Map([
       ...state.normalisedFields.entries(),
       ["Amount", "Amount"],
     ]);
     const newData = state.data.map((row) => ({ ...row, Amount: "." }));
-    state.setFields(newFields);
     state.setNormalisedFields(newNormalisedFields);
     state.setData(newData);
   }
@@ -78,6 +76,12 @@ const CreateDosingProtocols: FC<IDosingProtocols> = ({
           row["Amount Variable"] = value;
         });
       state.setData(nextData);
+      state.setNormalisedFields(
+        new Map([
+          ...state.normalisedFields.entries(),
+          ["Amount Variable", "Amount Variable"],
+        ]),
+      );
     };
   return (
     <>

--- a/frontend-v2/src/features/data/DosingProtocols.tsx
+++ b/frontend-v2/src/features/data/DosingProtocols.tsx
@@ -38,9 +38,10 @@ const DosingProtocols: FC<IDosingProtocols> = ({
   const amountField = state.fields.find(
     (field) => state.normalisedFields.get(field) === "Amount",
   );
-  const amountVariableField = state.fields.find(
-    (field) => state.normalisedFields.get(field) === "Amount Variable",
-  );
+  const amountVariableField =
+    state.fields.find(
+      (field) => state.normalisedFields.get(field) === "Amount Variable",
+    ) || "Amount Variable";
   const dosingRows = amountField
     ? state.data.filter((row) => row[amountField] && row[amountField] !== ".")
     : [];
@@ -74,9 +75,15 @@ const DosingProtocols: FC<IDosingProtocols> = ({
           administrationIdField ? row[administrationIdField] === id : true,
         )
         .forEach((row) => {
-          row[amountVariableField || "Amount Variable"] = value;
+          row[amountVariableField] = value;
         });
       state.setData(nextData);
+      state.setNormalisedFields(
+        new Map([
+          ...state.normalisedFields.entries(),
+          [amountVariableField, "Amount Variable"],
+        ]),
+      );
     };
   const handleAmountUnitChange = (id: string) => (event: SelectChangeEvent) => {
     const nextData = [...state.data];

--- a/frontend-v2/src/features/data/LoadData.tsx
+++ b/frontend-v2/src/features/data/LoadData.tsx
@@ -42,7 +42,6 @@ interface ILoadDataProps {
 function updateDataAndResetFields(state: StepperState, data: Data) {
   if (data.length > 0) {
     const newFields = Object.keys(data[0]);
-    state.setFields(newFields);
     state.setData(data);
     const normalisedFields = new Map(newFields.map(normaliseHeader));
     state.setNormalisedFields(normalisedFields);
@@ -103,7 +102,7 @@ const LoadData: FC<ILoadDataProps> = ({ state, firstTime }) => {
   const [showData, setShowData] = useState<boolean>(
     state.data.length > 0 && state.fields.length > 0,
   );
-  const normalisedHeaders = [...state.normalisedFields.values()];
+  const normalisedHeaders = state.normalisedHeaders;
   if (!normalisedHeaders.includes("ID")) {
     createDefaultSubjects(state);
   }
@@ -138,11 +137,14 @@ const LoadData: FC<ILoadDataProps> = ({ state, firstTime }) => {
           const csvData = Papa.parse(rawCsv.trim(), { header: true });
           const fields = csvData.meta.fields || [];
           const normalisedFields = new Map(fields.map(normaliseHeader));
+          state.setData(csvData.data as Data);
+          state.setNormalisedFields(normalisedFields);
           const fieldValidation = validateState({
             ...state,
             data: csvData.data as Data,
             fields,
             normalisedFields,
+            normalisedHeaders: [...normalisedFields.values()],
           });
           const primaryCohort =
             fields.find(
@@ -151,9 +153,6 @@ const LoadData: FC<ILoadDataProps> = ({ state, firstTime }) => {
           const errors = csvData.errors
             .map((e) => e.message)
             .concat(fieldValidation.errors);
-          state.setData(csvData.data as Data);
-          state.setFields(fields);
-          state.setNormalisedFields(normalisedFields);
           state.setPrimaryCohort(primaryCohort);
           state.setErrors(errors);
           state.setWarnings(fieldValidation.warnings);
@@ -205,7 +204,6 @@ const LoadData: FC<ILoadDataProps> = ({ state, firstTime }) => {
         {showData && (
           <MapHeaders
             data={state.data}
-            fields={state.fields}
             setNormalisedFields={setNormalisedFields}
             normalisedFields={state.normalisedFields}
           />

--- a/frontend-v2/src/features/data/MapHeaders.tsx
+++ b/frontend-v2/src/features/data/MapHeaders.tsx
@@ -17,20 +17,26 @@ import { groupedHeaders } from "./normaliseDataHeaders";
 
 interface IMapHeaders {
   data: Data;
-  fields: Field[];
   normalisedFields: Map<Field, string>;
   setNormalisedFields: (fields: Map<Field, string>) => void;
 }
 
 const MapHeaders: FC<IMapHeaders> = ({
   data,
-  fields,
   normalisedFields,
   setNormalisedFields,
 }: IMapHeaders) => {
+  const fields = [...normalisedFields.keys()];
+  const newData = { ...data };
   const handleFieldChange = (field: string) => (event: any) => {
-    const newFields = new Map(normalisedFields) as Map<Field, string>;
-    newFields.set(field, event.target.value as string);
+    const newFields = new Map([
+      ...normalisedFields.entries(),
+      [field, event.target.value],
+    ]);
+    // there can only be one ID column
+    if (event.target.value === "ID" && field !== "ID") {
+      newFields.set("ID", "Ignore");
+    }
     setNormalisedFields(newFields);
   };
 

--- a/frontend-v2/src/features/data/MapObservations.tsx
+++ b/frontend-v2/src/features/data/MapObservations.tsx
@@ -112,6 +112,13 @@ const MapObservations: FC<IMapObservations> = ({ state }: IMapObservations) => {
           }
         });
       state.setData(nextData);
+      state.setNormalisedFields(
+        new Map([
+          ...state.normalisedFields.entries(),
+          [observationVariableField, "Observation Variable"],
+          [observationUnitField, "Observation Unit"],
+        ]),
+      );
     };
   const handleUnitChange = (id: string) => (event: SelectChangeEvent) => {
     const nextData = [...state.data];

--- a/frontend-v2/src/features/data/SetUnits.tsx
+++ b/frontend-v2/src/features/data/SetUnits.tsx
@@ -45,7 +45,7 @@ const SetUnits: FC<IMapObservations> = ({
     return <Typography variant="h5">No project or units found</Typography>;
   }
 
-  const normalisedHeaders = [...state.normalisedFields.values()];
+  const normalisedHeaders = state.normalisedHeaders;
   const secondUnit = units.find((unit) => unit.symbol === "s");
   const timeUnits = secondUnit?.compatible_units.map((unit) => unit.symbol);
   const timeUnitOptions =

--- a/frontend-v2/src/features/data/Stratification.tsx
+++ b/frontend-v2/src/features/data/Stratification.tsx
@@ -56,6 +56,12 @@ const Stratification: FC<IStratification> = ({ state }: IStratification) => {
       row["Group ID"] = row[primaryCohort] || "1";
     });
     state.setData(newData);
+    state.setNormalisedFields(
+      new Map([
+        ...state.normalisedFields.entries(),
+        ["Group ID", "Group ID"]
+      ]),
+    );
   }
 
   const handleTabChange = (event: ChangeEvent<{}>, newValue: number) => {

--- a/frontend-v2/src/features/data/normaliseDataHeaders.ts
+++ b/frontend-v2/src/features/data/normaliseDataHeaders.ts
@@ -29,6 +29,7 @@ const normalisation = {
   Censoring: ["cens", "blq", "lloq"],
   "Cont Covariate": ["cont covariate", "weight", "wt", "bw", "age", "dose"],
   "Event ID": ["event id", "evid"],
+  "Group ID": ["group id"],
   ID: ["id", "subject", "animal number", "subject_id", "subjid"],
   "Ignored Observation": ["ignored observation", "mdv"],
   "Infusion Duration": [
@@ -102,6 +103,7 @@ export const groupedHeaders = {
     "Cat Covariate",
     "Cont Covariate",
     "Event ID",
+    "Group ID",
     "Occasion",
     "Regressor",
   ],
@@ -114,8 +116,8 @@ export const normalisedHeaders = Object.keys(normalisation);
 export const validateDataRow = (
   row: Record<string, string>,
   normalisedFields: Map<string, string>,
-  fields: string[],
 ) => {
+  const fields = [...normalisedFields.keys()];
   const timeField = fields.find(
     (field) => normalisedFields.get(field) === "Time",
   );
@@ -147,8 +149,7 @@ export const validateDataRow = (
 };
 
 export const validateState = (state: StepperState) => {
-  const { fields, normalisedFields } = state;
-  const normalisedHeaders = [...normalisedFields.values()];
+  const { fields, normalisedFields, normalisedHeaders } = state;
   const errors: string[] = [];
   const hasNoDosing =
     !normalisedHeaders.includes("Amount") ||

--- a/frontend-v2/src/features/data/useObservationRows.ts
+++ b/frontend-v2/src/features/data/useObservationRows.ts
@@ -38,7 +38,7 @@ function mergeObservationColumns(
 }
 
 export default function useObservationRows(state: StepperState, tab: string) {
-  let fields = [...state.fields];
+  const fields = state.fields;
   let normalisedFields = state.normalisedFields;
   const observationFields =
     fields.filter((field) => normalisedFields.get(field) === "Observation") ||
@@ -52,9 +52,14 @@ export default function useObservationRows(state: StepperState, tab: string) {
     rows = mergeObservationColumns(state, observationFields);
     observationField = "Observation";
     observationIdField = "Observation ID";
-    fields = Object.keys(rows[0]);
-    normalisedFields = new Map(fields.map(normaliseHeader));
-    state.setFields(fields);
+    const mergedFields = Object.keys(rows[0]);
+    normalisedFields = new Map(
+      mergedFields.map((field) =>
+        state.normalisedFields.has(field)
+          ? [field, state.normalisedFields.get(field)]
+          : normaliseHeader(field),
+      ),
+    ) as Map<string, string>;
     state.setNormalisedFields(normalisedFields);
     state.setData(rows);
   }


### PR DESCRIPTION
Refactor data upload stepper state so that `state.fields` is a read-only view of `state.normalisedFields.keys()`, rather than maintaining the same state in two separate places. This should fix bugs where fields were missing from `state.fields`, but were present in the CSV data.

Make header normalisation more robust, so that headers are only normalised if there is exactly one header of that type, which can be safely renamed. Normalise columns by renaming the existing column, rather than adding a new column with the normalised name.