### PR TITLE
fix(frontend): remove ignored observations

### DIFF
--- a/frontend-v2/src/features/data/LoadDataStepper.tsx
+++ b/frontend-v2/src/features/data/LoadDataStepper.tsx
@@ -16,7 +16,11 @@ import { RootState } from "../../app/store";
 import { DatasetRead, useDatasetCsvUpdateMutation } from "../../app/backendApi";
 import Stratification from "./Stratification";
 import useDataset from "../../hooks/useDataset";
-import { normaliseHeader, validateDataRow } from "./normaliseDataHeaders";
+import {
+  normaliseHeader,
+  removeIgnoredObservations,
+  validateDataRow,
+} from "./normaliseDataHeaders";
 import { Alert } from "@mui/material";
 
 interface IStepper {
@@ -163,7 +167,8 @@ const LoadDataStepper: FC<IStepper> = ({ csv = "", onCancel, onFinish }) => {
             });
             return newRow;
           })
-          .filter((row) => validateDataRow(row, normalisedFields));
+          .filter((row) => validateDataRow(row, normalisedFields))
+          .map((row) => removeIgnoredObservations(row, normalisedFields));
         const csv = Papa.unparse(dataToUpload);
         const response = await updateDatasetCsv({
           id: dataset.id,


### PR DESCRIPTION
When MDV is 1 for a row:
- remove the row completely if it is not a dosing row.
- remove the observation entry if it is a dosing row.