### PR TITLE
fix(frontend): normalised time units

### DIFF
--- a/frontend-v2/src/features/data/SetUnits.tsx
+++ b/frontend-v2/src/features/data/SetUnits.tsx
@@ -59,13 +59,15 @@ const SetUnits: FC<IMapObservations> = ({
       ...row,
       "Time Unit": event.target?.value,
     }));
+    const newNormalisedFields = new Map([
+      ...state.normalisedFields.entries(),
+      ["Time Unit", "Time Unit"],
+    ]);
     state.setData(newData);
+    state.setNormalisedFields(newNormalisedFields);
     const { errors, warnings } = validateState({
       ...state,
-      normalisedFields: new Map([
-        ...state.normalisedFields.entries(),
-        ["Time Unit", "Time Unit"],
-      ]),
+      normalisedFields: newNormalisedFields,
     });
     state.setErrors(errors);
     state.setWarnings(warnings);


### PR DESCRIPTION
Add 'Time Unit' to the stored column headers, after creating a new Time Unit column.