### PR TITLE
fix(frontend): ignored observation IDs for some CSV files

### DIFF
--- a/frontend-v2/src/features/data/useObservationRows.ts
+++ b/frontend-v2/src/features/data/useObservationRows.ts
@@ -60,6 +60,8 @@ export default function useObservationRows(state: StepperState, tab: string) {
           : normaliseHeader(field),
       ),
     ) as Map<string, string>;
+    normalisedFields.set("Observation", "Observation");
+    normalisedFields.set("Observation ID", "Observation ID");
     state.setNormalisedFields(normalisedFields);
     state.setData(rows);
   }


### PR DESCRIPTION
When a CSV file has multiple observation columns, and the Observation ID column has been mapped to Ignore, merging the observations columns would create new observsation IDs, but those new IDs are ignored. The fix here is to explicitly set the new columns to Observation and Observation ID, overriding any Ignore settings.