### PR TITLE
fix(frontend): don't rename continuous covariate columns

### DIFF
--- a/frontend-v2/src/features/data/PreviewData.tsx
+++ b/frontend-v2/src/features/data/PreviewData.tsx
@@ -44,10 +44,14 @@ function useNormalisedColumn(state: StepperState, type: string) {
 const PreviewData: FC<IPreviewData> = ({ state }: IPreviewData) => {
   const normalisedHeaders = state.normalisedHeaders
     /* 
-    Don't rename cat covariates to 'Cat Covariate'
+    Don't rename cat covariates to 'Cat Covariate',
+    continuous covariates to 'Cont Covariate',
     or ignored columns to 'Ignore'.
   */
-    .filter((header) => !["Cat Covariate", "Ignore"].includes(header));
+    .filter(
+      (header) =>
+        !["Cat Covariate", "Cont Covariate", "Ignore"].includes(header),
+    );
   normalisedHeaders.forEach((header) => {
     useNormalisedColumn(state, header);
   });


### PR DESCRIPTION
The preview step renames columns like Dose, Age, or Weight to Cont Covariate. This causes problems since column names must be unique. Here, continuous covariate columns are not renamed before uploading to the backend.