### PR TITLE
feat(backend): sort units by type and multiplier

### DIFF
--- a/pkpdapp/pkpdapp/api/serializers/unit.py
+++ b/pkpdapp/pkpdapp/api/serializers/unit.py
@@ -29,6 +29,10 @@ class UnitSerializer(serializers.ModelSerializer):
 
     def get_compatible_units(self, unit) -> List[Dict[str, str]]:
         compound = self.context.get("compound")
+        compatible_units = unit.get_compatible_units(compound=compound)
+        sorted_units = compatible_units.order_by(
+            "-g", "-m", "K", "A", "cd", "mol", "s", "-multiplier"
+        )
         return [
             {
                 "id": u.id,
@@ -40,5 +44,5 @@ class UnitSerializer(serializers.ModelSerializer):
                     u, compound=compound, is_target=True
                 ),
             }
-            for u in unit.get_compatible_units(compound=compound)
+            for u in sorted_units
         ]

--- a/pkpdapp/pkpdapp/api/views/unit.py
+++ b/pkpdapp/pkpdapp/api/views/unit.py
@@ -3,7 +3,7 @@
 # is released under the BSD 3-clause license. See accompanying LICENSE.md for
 # copyright notice and full license details.
 #
-from rest_framework import viewsets
+from rest_framework import filters, viewsets
 from pkpdapp.api.views import (
     DosedPkModelFilter,
     PdModelFilter,
@@ -17,7 +17,8 @@ from drf_spectacular.types import OpenApiTypes
 class UnitView(viewsets.ModelViewSet):
     queryset = Unit.objects.all()
     serializer_class = UnitSerializer
-    filter_backends = [DosedPkModelFilter, PdModelFilter]
+    filter_backends = [DosedPkModelFilter, PdModelFilter, filters.OrderingFilter]
+    ordering = ["-g", "-m", "K", "A", "cd", "mol", "s", "-multiplier"]
 
     def get_serializer_context(self):
         context = super().get_serializer_context()


### PR DESCRIPTION
Set a default ordering by type and multiplier for the units serializer and for `unit.compatible_units`.