### PR TITLE
fix(frontend): remove group names from y axis labels

### DIFF
--- a/frontend-v2/src/features/simulation/SimulationPlotView.tsx
+++ b/frontend-v2/src/features/simulation/SimulationPlotView.tsx
@@ -308,16 +308,16 @@ const SimulationPlotView: FC<SimulationPlotProps> = ({
     concentrationUnit,
   );
 
-  let yAxisTitle = plotData
+  const yAxisVariables = plotData
     //@ts-expect-error
     .filter((d) => !d.yaxis)
-    .map((d) => d.name)
-    .join(", ");
-  let y2AxisTitle = plotData
+    .map((d) => d.name?.split(' ')[0]);
+  const y2AxisVariables = plotData
     //@ts-expect-error
     .filter((d) => d.yaxis)
-    .map((d) => d.name)
-    .join(", ");
+    .map((d) => d.name?.split(' ')[0]);
+  let yAxisTitle = [...new Set(yAxisVariables)].join(", ");
+  let y2AxisTitle = [...new Set(y2AxisVariables)].join(", ");
   let xAxisTitle = "Time";
   const yUnit = units.find((u) => u.id === plot.y_unit);
   const y2Unit = units.find((u) => u.id === plot.y_unit2);


### PR DESCRIPTION
Just show the variable name as the y axis label for simulation plots.

<img width="800" alt="Screenshot of some simulation plots, where the y axis label for each plot is just the variable name." src="https://github.com/user-attachments/assets/c11a81fb-f3c7-49d1-9322-3839cee41f82">
