### PR TITLE
feat(frontend): Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ For search/bind, connecting to the LDAP server either anonymously or with a fixe
 There are also a number of optional variables that can be set:
 - `VITE_APP_ROCHE`: set to true to enable Roche branding
 - `VITE_APP_HELP_URL`: url of help page shown on login
+- `VITE_APP_GA_ID`: Google Analytics ID to enable analytics.
 
 
 ### SSL Certificate

--- a/frontend-v2/package.json
+++ b/frontend-v2/package.json
@@ -82,6 +82,7 @@
     "typescript-eslint": "^7.10.0",
     "vite": "^5.2.11",
     "vite-bundle-visualizer": "^1.2.1",
+    "vite-plugin-radar": "^0.9.6",
     "vite-tsconfig-paths": "^4.3.2",
     "web-vitals": "^2.1.4"
   },

--- a/frontend-v2/vite.config.ts
+++ b/frontend-v2/vite.config.ts
@@ -2,6 +2,7 @@ import react from '@vitejs/plugin-react';
 import svgr from '@svgr/rollup';
 import { defineConfig } from 'vite';
 import viteTsconfigPaths from 'vite-tsconfig-paths';
+import { VitePluginRadar } from 'vite-plugin-radar';
 
 const proxy = {
   "/backend": {
@@ -19,9 +20,17 @@ const proxy = {
     }
   },
 }
+
+const { VITE_APP_GA_ID } = process.env;
+const radarOptions = {
+  enableDev: true,
+  analytics: {
+    id: VITE_APP_GA_ID,
+  }
+};
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), viteTsconfigPaths(), svgr()],
+  plugins: [react(), viteTsconfigPaths(), svgr(), VitePluginRadar(radarOptions)],
   build: {
     outDir: 'build',
     rollupOptions: {

--- a/frontend-v2/yarn.lock
+++ b/frontend-v2/yarn.lock
@@ -5417,6 +5417,7 @@ __metadata:
     typescript-eslint: "npm:^7.10.0"
     vite: "npm:^5.2.11"
     vite-bundle-visualizer: "npm:^1.2.1"
+    vite-plugin-radar: "npm:^0.9.6"
     vite-tsconfig-paths: "npm:^4.3.2"
     web-vitals: "npm:^2.1.4"
   languageName: unknown
@@ -9130,6 +9131,15 @@ __metadata:
   bin:
     vite-bundle-visualizer: bin.js
   checksum: 10c0/038946556ba742726927047de97b0e38fbc2191ebbeb79d2e0767d1fb6fad1500ffeaea6c69bd9c906fdd26327165c9adcdb211286da166fb08ab02100149b41
+  languageName: node
+  linkType: hard
+
+"vite-plugin-radar@npm:^0.9.6":
+  version: 0.9.6
+  resolution: "vite-plugin-radar@npm:0.9.6"
+  peerDependencies:
+    vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
+  checksum: 10c0/6cfada1de71fbd7c4605ca3a45855bc8810368db3a63c0e979da0e0803ac3df5bea62ff11fc1095e94cd68b106d42499e30e1fc942955d0a0d993a53f2070f4b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add Google Analytics tracking, using `VITE_APP_GA_ID` to pass in a Google Analytics ID during the build.