### PR TITLE
feat(frontend): stratification by subject ID

### DIFF
--- a/frontend-v2/src/features/data/Stratification.tsx
+++ b/frontend-v2/src/features/data/Stratification.tsx
@@ -42,7 +42,7 @@ interface IStratification {
   firstTime: boolean;
 }
 
-const CAT_COVARIATE_COLUMNS = ["Cat Covariate", "Administration Name"];
+const CAT_COVARIATE_COLUMNS = ["Cat Covariate", "Administration Name", "ID"];
 
 const Stratification: FC<IStratification> = ({ state }: IStratification) => {
   const subjectDoses = getSubjectDoses(state);


### PR DESCRIPTION
Add `ID` to the list of CSV columns that can be used to stratify data into groups.