### PR TITLE
refactor(backend): allow for multiple subject protocols

### DIFF
--- a/pkpdapp/pkpdapp/tests/test_utils/test_data_parser.py
+++ b/pkpdapp/pkpdapp/tests/test_utils/test_data_parser.py
@@ -20,6 +20,7 @@ class TestDataParser(TestCase):
         for filename in [
             "datasets/TCB4dataset.csv",
             "datasets/demo_pk_data_upload.csv",
+            "datasets/Mean%20IL6R%20for%20PKD%20explor%20plasma%20only%20with%20dosing%20export.csv",  # noqa: E501
             "usecase_monolix/TE_Data.txt",
             "usecase0/usecase0.csv",
             "usecase1/usecase1.csv",
@@ -136,3 +137,8 @@ class TestDataParser(TestCase):
                     "stored_unit__symbol", flat=True
                 )
                 self.assertCountEqual(biomarker_units, expected_units)
+            if filename == "datasets/Mean%20IL6R%20for%20PKD%20explor%20plasma%20only%20with%20dosing%20export.csv":  # noqa: E501
+                # check the right number of subjects and protocols added
+                self.assertEqual(dataset.subjects.count(), 3)
+                protocols = list(dataset.protocols.all())
+                self.assertEqual(len(protocols), 6)

--- a/pkpdapp/pkpdapp/tests/test_utils/test_data_parser.py
+++ b/pkpdapp/pkpdapp/tests/test_utils/test_data_parser.py
@@ -125,10 +125,8 @@ class TestDataParser(TestCase):
 
                 # check the right number of subjects and protocols added
                 self.assertEqual(dataset.subjects.count(), 66)
-                protocols = set(
-                    [subject.protocol for subject in dataset.subjects.all()]
-                )
-                self.assertEqual(len(protocols), 39)
+                protocols = list(dataset.protocols.all())
+                self.assertEqual(len(protocols), 0)
             if filename == "usecase_monolix/TE_Data.txt":
                 expected_names = ["observation", "dose", "dose_units", "dose_cat"]
                 biomarker_names = dataset.biomarker_types.values_list("name", flat=True)

--- a/pkpdapp/pkpdapp/utils/data_parser.py
+++ b/pkpdapp/pkpdapp/utils/data_parser.py
@@ -204,13 +204,13 @@ class DataParser:
 
         # put in default subject group if not present
         if "GROUP_ID" not in found_cols:
-            data["GROUP_ID"] = 1
+            data["GROUP_ID"] = data["SUBJECT_ID"]
         # put in default event ID if not present
         if "EVENT_ID" not in found_cols:
             data["EVENT_ID"] = None
         # put in default administration ID if not present
         if "ADMINISTRATION_ID" not in found_cols:
-            data["ADMINISTRATION_ID"] = None
+            data["ADMINISTRATION_ID"] = 1
 
         # put in default additional dosing columns if not present
         if "ADDITIONAL_DOSES" not in found_cols:


### PR DESCRIPTION
Link subjects to protocols via `group.protocols`, not `subject.protocol`. Change the `Dataset` model to group dosing rows by `GROUP_ID`, rather than `SUBJECT_ID`. Generate protocols and doses for rows that have `AMOUNT_VARIABLE` defined, so that each protocol is linked to a dosing compartment in the model.
