### PR TITLE
fix(frontend): default amount unit for empty protocols

### DIFF
--- a/frontend-v2/src/features/data/CreateDosingProtocols.tsx
+++ b/frontend-v2/src/features/data/CreateDosingProtocols.tsx
@@ -74,12 +74,14 @@ const CreateDosingProtocols: FC<IDosingProtocols> = ({
         )
         .forEach((row) => {
           row["Amount Variable"] = value;
+          row["Amount Unit"] = amountUnit?.symbol === "pmol" ? "mg" : "mg/kg";
         });
       state.setData(nextData);
       state.setNormalisedFields(
         new Map([
           ...state.normalisedFields.entries(),
           ["Amount Variable", "Amount Variable"],
+          ["Amount Unit", "Amount Unit"],
         ]),
       );
     };


### PR DESCRIPTION
Make sure the dosing compartments have a default unit set, even when there is no dosing information in an uploaded CSV. Otherwise, Trial Design doesn't let you choose a unit.