### PR TITLE
fix(frontend): order subject groups by group.id

### DIFF
--- a/frontend-v2/src/hooks/useSubjectGroups.ts
+++ b/frontend-v2/src/hooks/useSubjectGroups.ts
@@ -26,7 +26,8 @@ export default function useSubjectGroups() {
       { skip: !selectedProject },
     );
   const groups = useMemo(
-    () => datasetGroups?.concat(projectGroups || []),
+    () =>
+      datasetGroups?.concat(projectGroups || []).sort((a, b) => a.id - b.id),
     [datasetGroups, projectGroups],
   );
 


### PR DESCRIPTION
Simulations implicitly order subject groups by `group.id`. Order subject groups by `group.id` in the frontend so that group labels match their simulations in the Simulations tab.