### PR TITLE
fix(frontend): ignored Amount column

### DIFF
--- a/frontend-v2/src/features/data/CreateDosingProtocols.tsx
+++ b/frontend-v2/src/features/data/CreateDosingProtocols.tsx
@@ -16,6 +16,7 @@ import {
 } from "@mui/material";
 import { StepperState } from "./LoadDataStepper";
 import { UnitRead, VariableRead } from "../../app/backendApi";
+import { Row } from "./LoadData";
 
 interface IDosingProtocols {
   administrationIdField: string;
@@ -37,6 +38,13 @@ const CreateDosingProtocols: FC<IDosingProtocols> = ({
     (field) =>
       field === "Amount" || state.normalisedFields.get(field) === "Amount",
   );
+  const dosingRows: Row[] = amountField
+    ? state.data.filter(
+        (row) =>
+          (row[amountField] && row[amountField] !== ".") ||
+          parseInt(row[administrationIdField]),
+      )
+    : state.data.filter((row) => parseInt(row[administrationIdField]));
   if (!amountField) {
     const newNormalisedFields = new Map([
       ...state.normalisedFields.entries(),
@@ -46,8 +54,9 @@ const CreateDosingProtocols: FC<IDosingProtocols> = ({
     state.setNormalisedFields(newNormalisedFields);
     state.setData(newData);
   }
+
   const administrationIds = administrationIdField
-    ? state.data.map((row) => row[administrationIdField])
+    ? dosingRows.map((row) => row[administrationIdField])
     : [];
   const uniqueAdministrationIds = [...new Set(administrationIds)];
 

--- a/frontend-v2/src/features/data/DosingProtocols.tsx
+++ b/frontend-v2/src/features/data/DosingProtocols.tsx
@@ -17,6 +17,7 @@ import {
 import { StepperState } from "./LoadDataStepper";
 import { UnitRead, VariableRead } from "../../app/backendApi";
 import { validateState } from "./dataValidation";
+import { Row } from "./LoadData";
 
 interface IDosingProtocols {
   administrationIdField: string;
@@ -43,9 +44,13 @@ const DosingProtocols: FC<IDosingProtocols> = ({
     state.fields.find(
       (field) => state.normalisedFields.get(field) === "Amount Variable",
     ) || "Amount Variable";
-  const dosingRows = amountField
-    ? state.data.filter((row) => row[amountField] && row[amountField] !== ".")
-    : [];
+  const dosingRows: Row[] = amountField
+    ? state.data.filter(
+        (row) =>
+          (row[amountField] && row[amountField] !== ".") ||
+          parseInt(row[administrationIdField]),
+      )
+    : state.data.filter((row) => parseInt(row[administrationIdField]));
   const administrationIds = administrationIdField
     ? dosingRows.map((row) => row[administrationIdField])
     : [];

--- a/frontend-v2/src/features/data/MapDosing.tsx
+++ b/frontend-v2/src/features/data/MapDosing.tsx
@@ -53,6 +53,7 @@ const MapDosing: FC<IMapDosing> = ({ state, firstTime }: IMapDosing) => {
   const administrationIdField = state.fields.find(
     (field) => state.normalisedFields.get(field) === "Administration ID",
   );
+
   const hasDosingRows = amountField && administrationIdField;
   const hasInvalidUnits =
     hasDosingRows &&
@@ -81,7 +82,7 @@ const MapDosing: FC<IMapDosing> = ({ state, firstTime }: IMapDosing) => {
     />
   ) : (
     <CreateDosingProtocols
-      administrationIdField={"Group"}
+      administrationIdField={administrationIdField || "Group ID"}
       amountUnitField={amountUnitField || ""}
       amountUnit={amountUnit}
       state={state}


### PR DESCRIPTION
When the Amount column is marked as ignored, we want to create dosing protocols based on the Administration ID column (if present), but with dose amounts set to 0.

Also, parse Administration ID as a positive integer, see https://dataset.lixoft.com/description/description-of-column-types-used-to-define-the-dose-regimen/#admidcol