### PR TITLE
fix(frontend): map dosing by group ID

### DIFF
--- a/frontend-v2/src/features/data/CreateDosingProtocols.tsx
+++ b/frontend-v2/src/features/data/CreateDosingProtocols.tsx
@@ -57,7 +57,6 @@ const CreateDosingProtocols: FC<IDosingProtocols> = ({
     ? dosingRows.map((row) => row[administrationIdField])
     : [];
   const uniqueAdministrationIds = [...new Set(administrationIds)];
-  console.log({ administrationIdField, amountField, uniqueAdministrationIds });
 
   const isAmount = (variable: VariableRead) => {
     const amountUnits = units?.find(

--- a/frontend-v2/src/features/data/CreateDosingProtocols.tsx
+++ b/frontend-v2/src/features/data/CreateDosingProtocols.tsx
@@ -38,13 +38,11 @@ const CreateDosingProtocols: FC<IDosingProtocols> = ({
     (field) =>
       field === "Amount" || state.normalisedFields.get(field) === "Amount",
   );
-  const dosingRows: Row[] = amountField
-    ? state.data.filter(
-        (row) =>
-          (row[amountField] && row[amountField] !== ".") ||
-          parseInt(row[administrationIdField]),
-      )
-    : state.data.filter((row) => parseInt(row[administrationIdField]));
+  const dosingRows: Row[] =
+    administrationIdField === "Group ID"
+      ? state.data
+      : // ignore rows with no amount and administration ID set to 0.
+        state.data.filter((row) => parseInt(row[administrationIdField]));
   if (!amountField) {
     const newNormalisedFields = new Map([
       ...state.normalisedFields.entries(),
@@ -59,6 +57,7 @@ const CreateDosingProtocols: FC<IDosingProtocols> = ({
     ? dosingRows.map((row) => row[administrationIdField])
     : [];
   const uniqueAdministrationIds = [...new Set(administrationIds)];
+  console.log({ administrationIdField, amountField, uniqueAdministrationIds });
 
   const isAmount = (variable: VariableRead) => {
     const amountUnits = units?.find(


### PR DESCRIPTION
When a CSV data file has no amount or administration ID columns, we want to map dosing compartments to the groups that were created during the Stratification step. Group IDs may not be integers, so can't be parsed with `parseInt`.