### PR TITLE
refactor(frontend): generate administration IDs during stratification

### DIFF
--- a/frontend-v2/src/features/data/CreateDosingProtocols.tsx
+++ b/frontend-v2/src/features/data/CreateDosingProtocols.tsx
@@ -38,11 +38,10 @@ const CreateDosingProtocols: FC<IDosingProtocols> = ({
     (field) =>
       field === "Amount" || state.normalisedFields.get(field) === "Amount",
   );
-  const dosingRows: Row[] =
-    administrationIdField === "Group ID"
-      ? state.data
-      : // ignore rows with no amount and administration ID set to 0.
-        state.data.filter((row) => parseInt(row[administrationIdField]));
+  // ignore rows with no amount and administration ID set to 0.
+  const dosingRows: Row[] = state.data.filter((row) =>
+    parseInt(row[administrationIdField]),
+  );
   if (!amountField) {
     const newNormalisedFields = new Map([
       ...state.normalisedFields.entries(),

--- a/frontend-v2/src/features/data/LoadData.tsx
+++ b/frontend-v2/src/features/data/LoadData.tsx
@@ -146,14 +146,14 @@ const LoadData: FC<ILoadDataProps> = ({ state, firstTime }) => {
             normalisedFields,
             normalisedHeaders: [...normalisedFields.values()],
           });
-          const primaryCohort =
+          const groupColumn =
             fields.find(
               (field) => normalisedFields.get(field) === "Cat Covariate",
             ) || "Group";
           const errors = csvData.errors
             .map((e) => e.message)
             .concat(fieldValidation.errors);
-          state.setPrimaryCohort(primaryCohort);
+          state.setGroupColumn(groupColumn);
           state.setErrors(errors);
           state.setWarnings(fieldValidation.warnings);
           if (csvData.data.length > 0 && csvData.meta.fields) {

--- a/frontend-v2/src/features/data/LoadDataStepper.tsx
+++ b/frontend-v2/src/features/data/LoadDataStepper.tsx
@@ -66,8 +66,8 @@ export type StepperState = {
   setWarnings: (warnings: string[]) => void;
   amountUnit?: string;
   setAmountUnit: (amountUnit: string) => void;
-  primaryCohort: string;
-  setPrimaryCohort: (primaryCohort: string) => void;
+  groupColumn: string;
+  setGroupColumn: (primaryCohort: string) => void;
 };
 
 function validateSubjectProtocols(protocols: IProtocol[]) {
@@ -96,7 +96,7 @@ const LoadDataStepper: FC<IStepper> = ({ csv = "", onCancel, onFinish }) => {
   );
   const [timeUnit, setTimeUnit] = useState<string | undefined>(undefined);
   const [amountUnit, setAmountUnit] = useState<string | undefined>(undefined);
-  const [primaryCohort, setPrimaryCohort] = useState("Group");
+  const [groupColumn, setGroupColumn] = useState("Group");
   const selectedProject = useSelector(
     (state: RootState) => state.main.selectedProject,
   );
@@ -121,8 +121,8 @@ const LoadDataStepper: FC<IStepper> = ({ csv = "", onCancel, onFinish }) => {
     setTimeUnit,
     amountUnit,
     setAmountUnit,
-    primaryCohort,
-    setPrimaryCohort,
+    groupColumn,
+    setGroupColumn,
     get fields() {
       return [...normalisedFields.keys()];
     },

--- a/frontend-v2/src/features/data/MapDosing.tsx
+++ b/frontend-v2/src/features/data/MapDosing.tsx
@@ -82,7 +82,7 @@ const MapDosing: FC<IMapDosing> = ({ state, firstTime }: IMapDosing) => {
     />
   ) : (
     <CreateDosingProtocols
-      administrationIdField={administrationIdField || "Group ID"}
+      administrationIdField={administrationIdField || "Administration ID"}
       amountUnitField={amountUnitField || ""}
       amountUnit={amountUnit}
       state={state}


### PR DESCRIPTION
When a dataset doesn't contain an administration ID column, generate one during the stratification step. Assign a unique administration ID to each group by default.