### PR TITLE
fix(frontend): fix array filter during data uploads

### DIFF
--- a/frontend-v2/src/features/data/LoadDataStepper.tsx
+++ b/frontend-v2/src/features/data/LoadDataStepper.tsx
@@ -196,7 +196,9 @@ const LoadDataStepper: FC<IStepper> = ({ csv = "", onCancel, onFinish }) => {
           })
           .filter((row) => validateDataRow(row, normalisedFields))
           .map((row) => removeIgnoredObservations(row, normalisedFields));
-        const columns = [...normalisedFields.keys().filter((field) => normalisedFields.get(field) !== "Ignore")];
+        const columns = [...normalisedFields.keys()].filter(
+          (field) => normalisedFields.get(field) !== "Ignore",
+        );
         const csv = Papa.unparse(dataToUpload, { columns });
         const response = await updateDatasetCsv({
           id: dataset.id,


### PR DESCRIPTION
`.filter` can't be applied to iterators, only to an array generated from an iterator.