### PR TITLE
feat: secondary parameters for models

### DIFF
--- a/frontend-v2/src/app/backendApi.ts
+++ b/frontend-v2/src/app/backendApi.ts
@@ -1921,7 +1921,7 @@ export type PkpdMappingRead = {
   /** variable in PD part of model */
   pd_variable: number;
 };
-export type TypeEnum = "RO" | "FUP" | "BPR" | "TLG";
+export type TypeEnum = "AUC" | "RO" | "FUP" | "BPR" | "TLG";
 export type DerivedVariable = {
   /** true if object has been stored */
   read_only?: boolean;
@@ -1929,6 +1929,7 @@ export type DerivedVariable = {
   datetime?: string | null;
   /** type of derived variable
     
+    * `AUC` - area under curve
     * `RO` - receptor occupancy
     * `FUP` - faction unbound plasma
     * `BPR` - blood plasma ratio
@@ -1947,6 +1948,7 @@ export type DerivedVariableRead = {
   datetime?: string | null;
   /** type of derived variable
     
+    * `AUC` - area under curve
     * `RO` - receptor occupancy
     * `FUP` - faction unbound plasma
     * `BPR` - blood plasma ratio

--- a/frontend-v2/src/features/model/MapVariablesTab.tsx
+++ b/frontend-v2/src/features/model/MapVariablesTab.tsx
@@ -194,6 +194,7 @@ const MapVariablesTab: FC<Props> = ({
     </>
   );
 
+  const aucHelp = <p>Lorem Ipsum (TODO: add help copy.)</p>;
   const sROHelp = (
     <p>
       The receptor occupancy for SM and LM (calc_RO) is calculated from the
@@ -308,6 +309,20 @@ const MapVariablesTab: FC<Props> = ({
                 </TableCell>
               </Tooltip>
             )}
+            <Tooltip
+              placement="top-start"
+              title="Calculate secondary parameters."
+            >
+              <TableCell>
+                <div style={{ ...defaultHeaderSx }}>
+                  {" "}
+                  Secondary parameters
+                  <HelpButton title={"Secondary Parameters"}>
+                    {aucHelp}
+                  </HelpButton>
+                </div>
+              </TableCell>
+            </Tooltip>
             <Tooltip
               placement="top-start"
               title="Select drug concentration that drives RO"

--- a/frontend-v2/src/features/model/VariableRow.tsx
+++ b/frontend-v2/src/features/model/VariableRow.tsx
@@ -43,7 +43,7 @@ interface Props {
   isAnyLagTimeSelected: boolean;
 }
 
-type DerivedVariableType = "RO" | "FUP" | "BPR" | "TLG";
+type DerivedVariableType = "AUC" | "RO" | "FUP" | "BPR" | "TLG";
 
 const derivedVariableRegex = /calc_.*_(f|bl|RO)/;
 
@@ -253,6 +253,7 @@ const VariableRow: FC<Props> = ({
   const noMapToPD = isPD || effectVariable === undefined || !isConcentration;
   const noDerivedVariables = !isConcentration || isPD;
   const isC1 = model.is_library_model && variable.qname.endsWith(".C1");
+  const disableAuc = false;
   const disableRo =
     !compound.dissociation_constant || !compound.target_concentration;
   const disableFUP =
@@ -344,6 +345,20 @@ const VariableRow: FC<Props> = ({
           )}
         </TableCell>
       )}
+      <TableCell>
+        {!noDerivedVariables && (
+          <FormControlLabel
+            disabled={disableAuc || isSharedWithMe}
+            control={
+              <MuiCheckbox
+                checked={isLinkedTo("AUC")}
+                onClick={onClickDerived("AUC")}
+              />
+            }
+            label=""
+          />
+        )}
+      </TableCell>
       <TableCell>
         {!noDerivedVariables && (
           <FormControlLabel

--- a/pkpdapp/schema.yml
+++ b/pkpdapp/schema.yml
@@ -3646,6 +3646,7 @@ components:
           description: |-
             type of derived variable
 
+            * `AUC` - area under curve
             * `RO` - receptor occupancy
             * `FUP` - faction unbound plasma
             * `BPR` - blood plasma ratio
@@ -5480,12 +5481,14 @@ components:
       - subjects
     TypeEnum:
       enum:
+      - AUC
       - RO
       - FUP
       - BPR
       - TLG
       type: string
       description: |-
+        * `AUC` - area under curve
         * `RO` - receptor occupancy
         * `FUP` - faction unbound plasma
         * `BPR` - blood plasma ratio


### PR DESCRIPTION
- add a new `AUC` type to derived variables.
- add a new state equation to the combined model, for the new derived type.
- add a checkbox column to the Map Variables view, which will let you select secondary parameters for a given model variable.
- towards #518.