### PR TITLE
refactor(frontend): include secondary parameters in simulations by default

### DIFF
--- a/frontend-v2/src/features/simulation/SimulationPlotView.tsx
+++ b/frontend-v2/src/features/simulation/SimulationPlotView.tsx
@@ -6,7 +6,6 @@ import {
   SimulateResponse,
   Simulation,
   SimulationYAxis,
-  SubjectGroup,
   SubjectGroupRead,
   UnitRead,
   VariableRead,
@@ -155,18 +154,18 @@ function genIcLines(
 }
 
 function generatePlotData(
-  d: SimulateResponse, 
-  visibleGroups: string[], 
-  colour: string, 
-  dash: string, 
-  index: number, 
-  group: SubjectGroupRead | undefined, 
-  y_axis: SimulationYAxis, 
-  plot: FieldArrayWithId<Simulation, "plots", "id">, 
-  units: UnitRead[], 
-  model: CombinedModelRead, 
-  variables: VariableRead[], 
-  xconversionFactor: number
+  d: SimulateResponse,
+  visibleGroups: string[],
+  colour: string,
+  dash: string,
+  index: number,
+  group: SubjectGroupRead | undefined,
+  y_axis: SimulationYAxis,
+  plot: FieldArrayWithId<Simulation, "plots", "id">,
+  units: UnitRead[],
+  model: CombinedModelRead,
+  variables: VariableRead[],
+  xconversionFactor: number,
 ) {
   const visible =
     index === 0
@@ -219,7 +218,14 @@ function generatePlotData(
   }
 }
 
-function minMaxAxisLimits(data: number[], minY: number | undefined, maxY: number | undefined, minY2: number | undefined, maxY2: number | undefined, has_right_axis: Boolean | undefined) {
+function minMaxAxisLimits(
+  data: number[],
+  minY: number | undefined,
+  maxY: number | undefined,
+  minY2: number | undefined,
+  maxY2: number | undefined,
+  has_right_axis: boolean | undefined,
+) {
   if (has_right_axis) {
     if (minY2 === undefined) {
       minY2 = Math.min(...data);
@@ -301,21 +307,23 @@ const SimulationPlotView: FC<SimulationPlotProps> = ({
     remove(index);
     setOpen(false);
   };
-  
-  const handleCopyToClipboard = (gd: PlotlyHTMLElement, ev: MouseEvent) => {
-    Plotly.toImage(gd, { format: 'png', width: 1000, height: 600})
-          .then(async (url: string) => {
-            try {
-              const data = await fetch(url);
-              const blob = await data.blob();
-              await navigator.clipboard.write([new ClipboardItem({[blob.type]: blob})]);
-              console.log('Image copied.');
-            } 
-            catch (err: any) {
-              console.error(err.name, err.message);
-            }
-          });
-  }
+
+  const handleCopyToClipboard = (gd: PlotlyHTMLElement) => {
+    Plotly.toImage(gd, { format: "png", width: 1000, height: 600 }).then(
+      async (url: string) => {
+        try {
+          const data = await fetch(url);
+          const blob = await data.blob();
+          await navigator.clipboard.write([
+            new ClipboardItem({ [blob.type]: blob }),
+          ]);
+          console.log("Image copied.");
+        } catch (err: any) {
+          console.error(err.name, err.message);
+        }
+      },
+    );
+  };
 
   const timeVariable = variables.find((v) => v.binding === "time");
   const timeUnit = units.find((u) => u.id === timeVariable?.unit);
@@ -339,21 +347,65 @@ const SimulationPlotView: FC<SimulationPlotProps> = ({
   const plotData = plot.y_axes
     .map((y_axis, i) => {
       const colourOffset = data.length * i;
-      return data.map((d, index) => {
-        const colourIndex = index + colourOffset;
-        const colour = plotColours[colourIndex % plotColours.length]
-        const group = groups?.[index - 1];
-        const plotData = generatePlotData(d, visibleGroups, colour, 'solid', index, group, y_axis, plot, units, model, variables, xconversionFactor);
-        ({ minY, maxY, minY2, maxY2 } = minMaxAxisLimits(plotData.y, minY, maxY, minY2, maxY2, y_axis.right));
-        return plotData;
-      }).concat(dataReference.map((d, index) => {
-        const colourIndex = index + colourOffset;
-        const colour = plotColours[colourIndex % plotColours.length]
-        const group = groups?.[index - 1];
-        const plotDataReference = generatePlotData(dataReference[index], visibleGroups, colour, 'dot', index, group, y_axis, plot, units, model, variables, xconversionFactor);
-        ({ minY, maxY, minY2, maxY2 } = minMaxAxisLimits(plotDataReference.y, minY, maxY, minY2, maxY2, y_axis.right));
-          return plotDataReference;
-        }));
+      return data
+        .map((d, index) => {
+          const colourIndex = index + colourOffset;
+          const colour = plotColours[colourIndex % plotColours.length];
+          const group = groups?.[index - 1];
+          const plotData = generatePlotData(
+            d,
+            visibleGroups,
+            colour,
+            "solid",
+            index,
+            group,
+            y_axis,
+            plot,
+            units,
+            model,
+            variables,
+            xconversionFactor,
+          );
+          ({ minY, maxY, minY2, maxY2 } = minMaxAxisLimits(
+            plotData.y,
+            minY,
+            maxY,
+            minY2,
+            maxY2,
+            y_axis.right,
+          ));
+          return plotData;
+        })
+        .concat(
+          dataReference.map((d, index) => {
+            const colourIndex = index + colourOffset;
+            const colour = plotColours[colourIndex % plotColours.length];
+            const group = groups?.[index - 1];
+            const plotDataReference = generatePlotData(
+              dataReference[index],
+              visibleGroups,
+              colour,
+              "dot",
+              index,
+              group,
+              y_axis,
+              plot,
+              units,
+              model,
+              variables,
+              xconversionFactor,
+            );
+            ({ minY, maxY, minY2, maxY2 } = minMaxAxisLimits(
+              plotDataReference.y,
+              minY,
+              maxY,
+              minY2,
+              maxY2,
+              y_axis.right,
+            ));
+            return plotDataReference;
+          }),
+        );
     })
     .flat() as Partial<ScatterData>[];
 
@@ -487,9 +539,9 @@ const SimulationPlotView: FC<SimulationPlotProps> = ({
     width: 300,
     height: 600,
     path: "M102.17,29.66A3,3,0,0,0,100,26.79L73.62,1.1A3,3,0,0,0,71.31,0h-46a5.36,5.36,0,0,0-5.36,5.36V20.41H5.36A5.36,5.36,0,0,0,0,25.77v91.75a5.36,5.36,0,0,0,5.36,5.36H76.9a5.36,5.36,0,0,0,5.33-5.36v-15H96.82a5.36,5.36,0,0,0,5.33-5.36q0-33.73,0-67.45ZM25.91,20.41V6h42.4V30.24a3,3,0,0,0,3,3H96.18q0,31.62,0,63.24h-14l0-46.42a3,3,0,0,0-2.17-2.87L53.69,21.51a2.93,2.93,0,0,0-2.3-1.1ZM54.37,30.89,72.28,47.67H54.37V30.89ZM6,116.89V26.37h42.4V50.65a3,3,0,0,0,3,3H76.26q0,31.64,0,63.24ZM17.33,69.68a2.12,2.12,0,0,1,1.59-.74H54.07a2.14,2.14,0,0,1,1.6.73,2.54,2.54,0,0,1,.63,1.7,2.57,2.57,0,0,1-.64,1.7,2.16,2.16,0,0,1-1.59.74H18.92a2.15,2.15,0,0,1-1.6-.73,2.59,2.59,0,0,1,0-3.4Zm0,28.94a2.1,2.1,0,0,1,1.58-.74H63.87a2.12,2.12,0,0,1,1.59.74,2.57,2.57,0,0,1,.64,1.7,2.54,2.54,0,0,1-.63,1.7,2.14,2.14,0,0,1-1.6.73H18.94a2.13,2.13,0,0,1-1.59-.73,2.56,2.56,0,0,1,0-3.4ZM63.87,83.41a2.12,2.12,0,0,1,1.59.74,2.59,2.59,0,0,1,0,3.4,2.13,2.13,0,0,1-1.6.72H18.94a2.12,2.12,0,0,1-1.59-.72,2.55,2.55,0,0,1-.64-1.71,2.5,2.5,0,0,1,.65-1.69,2.1,2.1,0,0,1,1.58-.74ZM17.33,55.2a2.15,2.15,0,0,1,1.59-.73H39.71a2.13,2.13,0,0,1,1.6.72,2.61,2.61,0,0,1,0,3.41,2.15,2.15,0,0,1-1.59.73H18.92a2.14,2.14,0,0,1-1.6-.72,2.61,2.61,0,0,1,0-3.41Zm0-14.47A2.13,2.13,0,0,1,18.94,40H30.37a2.12,2.12,0,0,1,1.59.72,2.61,2.61,0,0,1,0,3.41,2.13,2.13,0,0,1-1.58.73H18.94a2.16,2.16,0,0,1-1.59-.72,2.57,2.57,0,0,1-.64-1.71,2.54,2.54,0,0,1,.65-1.7ZM74.3,10.48,92.21,27.26H74.3V10.48Z",
-    transform: "scale(4.5)"
-  }
-  
+    transform: "scale(4.5)",
+  };
+
   const config: Partial<Config> = {
     modeBarButtonsToAdd: [
       {

--- a/frontend-v2/src/features/simulation/Simulations.tsx
+++ b/frontend-v2/src/features/simulation/Simulations.tsx
@@ -190,11 +190,7 @@ const Simulations: FC = () => {
     timeMax,
   );
   const referenceVariables = useSimulatedVariables(variables, EMPTY_OBJECT);
-  const {
-    loadingSimulate: loadingReference,
-    data: dataReference,
-    error: referenceError,
-  } = useSimulation(
+  const { data: dataReference } = useSimulation(
     refSimInputs,
     referenceVariables,
     showReference ? model : undefined,
@@ -275,21 +271,20 @@ const Simulations: FC = () => {
   // save simulation every second if dirty
   useEffect(() => {
     const onSubmit = (dta: Simulation) => {
-      // empty string keeps getting in, so convert to null
       for (let i = 0; i < dta.plots.length; i++) {
-        // @ts-ignore
+        // @ts-expect-error empty string keeps getting in, so convert to null
         if (dta.plots[i].min === "") {
           dta.plots[i].min = null;
         }
-        // @ts-ignore
+        // @ts-expect-error empty string keeps getting in, so convert to null
         if (dta.plots[i].max === "") {
           dta.plots[i].max = null;
         }
-        // @ts-ignore
+        // @ts-expect-error empty string keeps getting in, so convert to null
         if (dta.plots[i].min2 === "") {
           dta.plots[i].min2 = null;
         }
-        // @ts-ignore
+        // @ts-expect-error empty string keeps getting in, so convert to null
         if (dta.plots[i].max2 === "") {
           dta.plots[i].max2 = null;
         }

--- a/frontend-v2/src/features/simulation/Simulations.tsx
+++ b/frontend-v2/src/features/simulation/Simulations.tsx
@@ -140,7 +140,7 @@ const Simulations: FC = () => {
   const isSharedWithMe = useSelector((state: RootState) =>
     selectIsProjectShared(state, project),
   );
-  
+
   const EMPTY_OBJECT: SliderValues = {};
 
   const defaultSimulation: SimulationRead = {
@@ -169,6 +169,7 @@ const Simulations: FC = () => {
   const timeMax = simulation?.id && getTimeMax(simulation);
 
   const simInputs = useSimulationInputs(
+    model,
     simulation,
     sliderValues,
     variables,
@@ -180,8 +181,9 @@ const Simulations: FC = () => {
     data,
     error: simulateError,
   } = useSimulation(simInputs, simulatedVariables, model);
-  
+
   const refSimInputs = useSimulationInputs(
+    model,
     simulation,
     EMPTY_OBJECT,
     variables,
@@ -192,8 +194,11 @@ const Simulations: FC = () => {
     loadingSimulate: loadingReference,
     data: dataReference,
     error: referenceError,
-  } = useSimulation(refSimInputs, referenceVariables, showReference ? model: undefined);
-  
+  } = useSimulation(
+    refSimInputs,
+    referenceVariables,
+    showReference ? model : undefined,
+  );
 
   const {
     reset,
@@ -451,7 +456,12 @@ const Simulations: FC = () => {
             Add new plot
           </DropdownButton>
           <FormControlLabel
-            control={<Checkbox checked={showReference} onChange={(e) => setShowReference(e.target.checked)}></Checkbox>}
+            control={
+              <Checkbox
+                checked={showReference}
+                onChange={(e) => setShowReference(e.target.checked)}
+              ></Checkbox>
+            }
             label="Show reference"
           />
         </Stack>

--- a/frontend-v2/src/features/simulation/useSimulation.ts
+++ b/frontend-v2/src/features/simulation/useSimulation.ts
@@ -15,6 +15,8 @@ interface ErrorObject {
   error: string;
 }
 
+const SIMULATION_PAGES = [PageName.SIMULATIONS, PageName.RESULTS];
+
 export default function useSimulation(
   simInputs: Simulate,
   simulatedVariables: { qname: string; value: number | undefined }[],
@@ -41,7 +43,7 @@ export default function useSimulation(
       model &&
       protocols &&
       compound &&
-      page === PageName.SIMULATIONS
+      SIMULATION_PAGES.includes(page)
     ) {
       setLoadingSimulate(true);
       console.log("Simulating with params", simulatedVariables);
@@ -62,7 +64,15 @@ export default function useSimulation(
     return () => {
       ignore = true;
     };
-  }, [compound, model, protocols, simulate, JSON.stringify(simInputs), JSON.stringify(simulatedVariables), page]);
+  }, [
+    compound,
+    model,
+    protocols,
+    simulate,
+    JSON.stringify(simInputs),
+    JSON.stringify(simulatedVariables),
+    page,
+  ]);
 
   return {
     loadingSimulate,


### PR DESCRIPTION
- Automatically run simulations for the Results page.
- Automatically add variables with secondary parameters, and their derived variables, to the simulation outputs.