### PR TITLE
feat(frontend): split variable thresholds for secondary parameters

### DIFF
--- a/frontend-v2/src/App.tsx
+++ b/frontend-v2/src/App.tsx
@@ -23,7 +23,8 @@ export type TimeInterval = {
   end: number;
   unit: string;
 };
-export type Thresholds = { [key: string]: number };
+type Threshold = { lower: number; upper: number };
+export type Thresholds = { [key: string]: Threshold };
 
 const TIME_INTERVALS: TimeInterval[] = [
   { start: 0, end: 168, unit: "h" },
@@ -34,10 +35,22 @@ const TIME_INTERVALS: TimeInterval[] = [
 ];
 
 const THRESHOLDS: Thresholds = {
-  C1: 1e4,
-  C1_t: 5e4,
-  CT1_f: 200,
-  CT1_b: 900,
+  C1: {
+    lower: 1e4,
+    upper: Infinity,
+  },
+  C1_t: {
+    lower: 5e4,
+    upper: Infinity,
+  },
+  CT1_f: {
+    lower: 200,
+    upper: Infinity,
+  },
+  CT1_b: {
+    lower: 900,
+    upper: Infinity,
+  },
 };
 
 function App() {

--- a/frontend-v2/src/features/model/secondary/ThresholdsTable.tsx
+++ b/frontend-v2/src/features/model/secondary/ThresholdsTable.tsx
@@ -36,12 +36,29 @@ function VariableRow({
   const [unitSymbol, setUnitSymbol] = useState<string | undefined>(
     unit?.symbol,
   );
-  function onChangeThreshold(event: ChangeEvent<HTMLInputElement>) {
+  function onChangeLowerThreshold(event: ChangeEvent<HTMLInputElement>) {
     const newValue = parseFloat(event.target.value);
+    const oldThresholds = thresholds[variable.name];
     if (!isNaN(newValue)) {
       setThresholds({
         ...thresholds,
-        [variable.name]: newValue,
+        [variable.name]: {
+          ...oldThresholds,
+          lower: newValue,
+        },
+      });
+    }
+  }
+  function onChangeUpperThreshold(event: ChangeEvent<HTMLInputElement>) {
+    const newValue = parseFloat(event.target.value);
+    const oldThresholds = thresholds[variable.name];
+    if (!isNaN(newValue)) {
+      setThresholds({
+        ...thresholds,
+        [variable.name]: {
+          ...oldThresholds,
+          upper: newValue,
+        },
       });
     }
   }
@@ -59,8 +76,15 @@ function VariableRow({
       <TableCell>
         <TextField
           type="number"
-          defaultValue={thresholds[variable.name]}
-          onChange={onChangeThreshold}
+          defaultValue={thresholds[variable.name]?.lower}
+          onChange={onChangeLowerThreshold}
+        />
+      </TableCell>
+      <TableCell>
+        <TextField
+          type="number"
+          defaultValue={thresholds[variable.name]?.upper}
+          onChange={onChangeUpperThreshold}
         />
       </TableCell>
       <TableCell>
@@ -108,7 +132,8 @@ const ThresholdsTable: FC<TableProps> = (props) => {
     <Table {...props}>
       <TableHead>
         <TableCell>Variable</TableCell>
-        <TableCell>Threshold</TableCell>
+        <TableCell>Lower Threshold</TableCell>
+        <TableCell>Upper Threshold</TableCell>
         <TableCell>Unit</TableCell>
       </TableHead>
       <TableBody>

--- a/frontend-v2/src/features/results/VariableTabs.tsx
+++ b/frontend-v2/src/features/results/VariableTabs.tsx
@@ -96,7 +96,8 @@ const VariableTabs: FC<VariableTabsProps> = ({ index }) => {
         </Tabs>
         <Box id="cvar-tabpanel">
           <Typography>
-            Threshold: {thresholds[concentrationVariables[tab].name]}
+            Thresholds: {thresholds[concentrationVariables[tab].name]?.lower} –{" "}
+            {thresholds[concentrationVariables[tab].name]?.upper}
           </Typography>
           <VariableTable
             key={variable.id}


### PR DESCRIPTION
Split the variable thresholds into upper and lower thresholds.

Display the time above each threshold, plus the difference (time spent above the lower threshold but below the upper threshold.)