### PR TITLE
feat(frontend): Secondary parameters for model variables

### DIFF
--- a/frontend-v2/src/App.tsx
+++ b/frontend-v2/src/App.tsx
@@ -23,7 +23,8 @@ export type TimeInterval = {
   end: number;
   unit: string;
 };
-export type Thresholds = { [key: string]: number };
+type Threshold = { lower: number; upper: number };
+export type Thresholds = { [key: string]: Threshold };
 
 const TIME_INTERVALS: TimeInterval[] = [
   { start: 0, end: 168, unit: "h" },
@@ -34,10 +35,22 @@ const TIME_INTERVALS: TimeInterval[] = [
 ];
 
 const THRESHOLDS: Thresholds = {
-  C1: 1e4,
-  C1_t: 5e4,
-  CT1_f: 200,
-  CT1_b: 900,
+  C1: {
+    lower: 1e4,
+    upper: Infinity,
+  },
+  C1_t: {
+    lower: 5e4,
+    upper: Infinity,
+  },
+  CT1_f: {
+    lower: 200,
+    upper: Infinity,
+  },
+  CT1_b: {
+    lower: 900,
+    upper: Infinity,
+  },
 };
 
 function App() {

--- a/frontend-v2/src/App.tsx
+++ b/frontend-v2/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import "./App.css";
 
 import {
@@ -15,10 +15,18 @@ import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import { Typography } from "@mui/material";
 
+import { SimulationContext } from "./contexts/SimulationContext";
+import { SimulateResponse } from "./app/backendApi";
+
 function App() {
   const dispatch = useAppDispatch();
   const isAuth = useSelector(isAuthenticated);
   const error = useSelector((state: RootState) => state.login.error);
+  const [simulations, setSimulations] = useState<SimulateResponse[]>([]);
+  const simulationContext = {
+    simulations,
+    setSimulations,
+  };
 
   const onLogin = (username: string, password: string) => {
     dispatch(login({ username, password }));
@@ -29,7 +37,7 @@ function App() {
   }, [dispatch]);
 
   return (
-    <>
+    <SimulationContext.Provider value={simulationContext}>
       {isAuth ? (
         <>
           <Sidebar />
@@ -49,7 +57,7 @@ function App() {
       >
         pkpdx version {import.meta.env.VITE_APP_VERSION?.slice(0, 7) || "dev"}
       </Typography>
-    </>
+    </SimulationContext.Provider>
   );
 }
 

--- a/frontend-v2/src/App.tsx
+++ b/frontend-v2/src/App.tsx
@@ -18,14 +18,42 @@ import { Typography } from "@mui/material";
 import { SimulationContext } from "./contexts/SimulationContext";
 import { SimulateResponse } from "./app/backendApi";
 
+export type TimeInterval = {
+  start: number;
+  end: number;
+  unit: string;
+};
+export type Thresholds = { [key: string]: number };
+
+const TIME_INTERVALS: TimeInterval[] = [
+  { start: 0, end: 168, unit: "h" },
+  { start: 168, end: 336, unit: "h" },
+  { start: 336, end: 504, unit: "h" },
+  { start: 504, end: 672, unit: "h" },
+  { start: 672, end: 840, unit: "h" },
+];
+
+const THRESHOLDS: Thresholds = {
+  C1: 1e4,
+  C1_t: 5e4,
+  CT1_f: 200,
+  CT1_b: 900,
+};
+
 function App() {
   const dispatch = useAppDispatch();
   const isAuth = useSelector(isAuthenticated);
   const error = useSelector((state: RootState) => state.login.error);
   const [simulations, setSimulations] = useState<SimulateResponse[]>([]);
+  const [intervals, setIntervals] = useState<TimeInterval[]>(TIME_INTERVALS);
+  const [thresholds, setThresholds] = useState<Thresholds>(THRESHOLDS);
   const simulationContext = {
     simulations,
     setSimulations,
+    intervals,
+    setIntervals,
+    thresholds,
+    setThresholds,
   };
 
   const onLogin = (username: string, password: string) => {

--- a/frontend-v2/src/app/backendApi.ts
+++ b/frontend-v2/src/app/backendApi.ts
@@ -1921,7 +1921,7 @@ export type PkpdMappingRead = {
   /** variable in PD part of model */
   pd_variable: number;
 };
-export type TypeEnum = "RO" | "FUP" | "BPR" | "TLG";
+export type TypeEnum = "AUC" | "RO" | "FUP" | "BPR" | "TLG";
 export type DerivedVariable = {
   /** true if object has been stored */
   read_only?: boolean;
@@ -1929,6 +1929,7 @@ export type DerivedVariable = {
   datetime?: string | null;
   /** type of derived variable
     
+    * `AUC` - area under curve
     * `RO` - receptor occupancy
     * `FUP` - faction unbound plasma
     * `BPR` - blood plasma ratio
@@ -1947,6 +1948,7 @@ export type DerivedVariableRead = {
   datetime?: string | null;
   /** type of derived variable
     
+    * `AUC` - area under curve
     * `RO` - receptor occupancy
     * `FUP` - faction unbound plasma
     * `BPR` - blood plasma ratio

--- a/frontend-v2/src/contexts/SimulationContext.ts
+++ b/frontend-v2/src/contexts/SimulationContext.ts
@@ -1,0 +1,7 @@
+import { createContext } from "react";
+import { SimulateResponse } from "../app/backendApi";
+
+export const SimulationContext = createContext({
+  simulations: [] as SimulateResponse[],
+  setSimulations: (simulations: SimulateResponse[]) => {},
+});

--- a/frontend-v2/src/contexts/SimulationContext.ts
+++ b/frontend-v2/src/contexts/SimulationContext.ts
@@ -1,7 +1,12 @@
 import { createContext } from "react";
 import { SimulateResponse } from "../app/backendApi";
+import { TimeInterval, Thresholds } from "../App";
 
 export const SimulationContext = createContext({
   simulations: [] as SimulateResponse[],
   setSimulations: (simulations: SimulateResponse[]) => {},
+  intervals: [] as TimeInterval[],
+  setIntervals: (intervals: TimeInterval[]) => {},
+  thresholds: {} as Thresholds,
+  setThresholds: (thresholds: Thresholds) => {},
 });

--- a/frontend-v2/src/features/main/MainContent.tsx
+++ b/frontend-v2/src/features/main/MainContent.tsx
@@ -10,6 +10,7 @@ import Protocols from "../trial/Protocols";
 import { Box } from "@mui/material";
 import Help from "../help/Help";
 import Data from "../data/Data";
+import Results from "../results/Results";
 
 interface TabPanelProps {
   children?: ReactNode;
@@ -60,6 +61,9 @@ const MainContent: FC = () => {
       </TabPanel>
       <TabPanel value={page} index={PageName.SIMULATIONS}>
         <Simulations key={projectIdOrZero} />
+      </TabPanel>
+      <TabPanel value={page} index={PageName.RESULTS}>
+        <Results key={projectIdOrZero} />
       </TabPanel>
       <TabPanel value={page} index={PageName.HELP}>
         <Help />

--- a/frontend-v2/src/features/main/Sidebar.tsx
+++ b/frontend-v2/src/features/main/Sidebar.tsx
@@ -37,6 +37,7 @@ import BiotechIcon from "@mui/icons-material/Biotech";
 import FunctionsIcon from "@mui/icons-material/Functions";
 import VaccinesIcon from "@mui/icons-material/Vaccines";
 import SsidChartIcon from "@mui/icons-material/SsidChart";
+import QueryStatsIcon from "@mui/icons-material/QueryStats";
 import ContactSupportIcon from "@mui/icons-material/ContactSupport";
 import TableViewIcon from "@mui/icons-material/TableView";
 import "@fontsource/comfortaa"; // Defaults to weight 400
@@ -137,6 +138,7 @@ export default function Sidebar() {
     [PageName.TRIAL_DESIGN]: <VaccinesIcon />,
     [PageName.DATA]: <TableViewIcon />,
     [PageName.SIMULATIONS]: <SsidChartIcon />,
+    [PageName.RESULTS]: <QueryStatsIcon />,
     [PageName.HELP]: <ContactSupportIcon />,
   };
 

--- a/frontend-v2/src/features/main/mainSlice.ts
+++ b/frontend-v2/src/features/main/mainSlice.ts
@@ -7,6 +7,7 @@ export enum PageName {
   DATA = "Data",
   TRIAL_DESIGN = "Trial Design",
   SIMULATIONS = "Simulations",
+  RESULTS = "Results",
   HELP = "Help & Feedback",
 }
 

--- a/frontend-v2/src/features/main/mainSlice.ts
+++ b/frontend-v2/src/features/main/mainSlice.ts
@@ -14,6 +14,7 @@ export enum SubPageName {
   PKPDMODEL = "PK/PD Model",
   MAPVARIABLES = "Map Variables",
   PARAMETERS = "Parameters",
+  SECONDARYPARAMETERS = "Secondary Parameters",
   TUTORIALS = "Tutorials",
   PROJECTS = "Projects",
   DRUG = "Drug",

--- a/frontend-v2/src/features/model/MapVariablesTab.tsx
+++ b/frontend-v2/src/features/model/MapVariablesTab.tsx
@@ -194,6 +194,7 @@ const MapVariablesTab: FC<Props> = ({
     </>
   );
 
+  const aucHelp = <p>Lorem Ipsum (TODO: add help copy.)</p>;
   const sROHelp = (
     <p>
       The receptor occupancy for SM and LM (calc_RO) is calculated from the
@@ -308,6 +309,20 @@ const MapVariablesTab: FC<Props> = ({
                 </TableCell>
               </Tooltip>
             )}
+            <Tooltip
+              placement="top-start"
+              title="Calculate secondary parameters."
+            >
+              <TableCell>
+                <div style={{ ...defaultHeaderSx }}>
+                  {" "}
+                  Secondary parameters
+                  <HelpButton title={"Secondary Parameters"}>
+                    {aucHelp}
+                  </HelpButton>
+                </div>
+              </TableCell>
+            </Tooltip>
             <Tooltip
               placement="top-start"
               title="Select drug concentration that drives RO"

--- a/frontend-v2/src/features/model/Model.tsx
+++ b/frontend-v2/src/features/model/Model.tsx
@@ -22,6 +22,7 @@ import { FC, useEffect, useMemo } from "react";
 import { DynamicTabs, TabPanel } from "../../components/DynamicTabs";
 import MapVariablesTab from "./MapVariablesTab";
 import PKPDModelTab from "./PKPDModelTab";
+import SecondaryParametersTab from "./secondary/SecondaryParameters";
 import ParametersTab from "./ParametersTab";
 import useDirty from "../../hooks/useDirty";
 import { SubPageName } from "../main/mainSlice";
@@ -205,6 +206,7 @@ const Model: FC = () => {
     SubPageName.PKPDMODEL,
     SubPageName.MAPVARIABLES,
     SubPageName.PARAMETERS,
+    SubPageName.SECONDARYPARAMETERS,
   ];
   if (model.pk_model === null) {
     tabErrors[tabKeys[0]] = "Please select a PK model to simulate";
@@ -268,6 +270,9 @@ const Model: FC = () => {
           units={units}
           compound={compound}
         />
+      </TabPanel>
+      <TabPanel>
+        <SecondaryParametersTab />
       </TabPanel>
     </DynamicTabs>
   );

--- a/frontend-v2/src/features/model/VariableRow.tsx
+++ b/frontend-v2/src/features/model/VariableRow.tsx
@@ -1,5 +1,5 @@
 // src/components/ProjectTable.tsx
-import { FC, useEffect } from "react";
+import { FC, useEffect, useContext } from "react";
 import { Control, useFieldArray, useForm } from "react-hook-form";
 import {
   TableCell,
@@ -25,6 +25,7 @@ import { useSelector } from "react-redux";
 import { RootState } from "../../app/store";
 import { selectIsProjectShared } from "../login/loginSlice";
 import useEditProtocol from "./useEditProtocol";
+import { SimulationContext } from "../../contexts/SimulationContext";
 
 interface Props {
   project: ProjectRead;
@@ -79,6 +80,7 @@ const VariableRow: FC<Props> = ({
     control,
     name: "model.derived_variables",
   });
+  const { thresholds, setThresholds } = useContext(SimulationContext);
 
   const {
     handleSubmit,
@@ -244,6 +246,13 @@ const VariableRow: FC<Props> = ({
       pkpd_model: model.id,
       type,
     });
+
+    if (type === "AUC") {
+      setThresholds({
+        ...thresholds,
+        [variable.name]: 0,
+      });
+    }
   };
 
   const removeDerived = (index: number | number[]) => {

--- a/frontend-v2/src/features/model/VariableRow.tsx
+++ b/frontend-v2/src/features/model/VariableRow.tsx
@@ -43,7 +43,7 @@ interface Props {
   isAnyLagTimeSelected: boolean;
 }
 
-type DerivedVariableType = "RO" | "FUP" | "BPR" | "TLG";
+type DerivedVariableType = "AUC" | "RO" | "FUP" | "BPR" | "TLG";
 
 const derivedVariableRegex = /calc_.*_(f|bl|RO)/;
 
@@ -253,6 +253,7 @@ const VariableRow: FC<Props> = ({
   const noMapToPD = isPD || effectVariable === undefined || !isConcentration;
   const noDerivedVariables = !isConcentration || isPD;
   const isC1 = model.is_library_model && variable.qname.endsWith(".C1");
+  const disableAuc = false;
   const disableRo =
     !compound.dissociation_constant || !compound.target_concentration;
   const disableFUP =
@@ -344,6 +345,20 @@ const VariableRow: FC<Props> = ({
           )}
         </TableCell>
       )}
+      <TableCell>
+        {!noDerivedVariables && (
+          <FormControlLabel
+            disabled={disableAuc || isSharedWithMe}
+            control={
+              <MuiCheckbox
+                checked={isLinkedTo("AUC")}
+                onClick={onClickDerived("AUC")}
+              />
+            }
+            label=""
+          />
+        )}
+      </TableCell>
       <TableCell>
         {!noDerivedVariables && (
           <FormControlLabel

--- a/frontend-v2/src/features/model/secondary/SecondaryParameters.tsx
+++ b/frontend-v2/src/features/model/secondary/SecondaryParameters.tsx
@@ -1,0 +1,22 @@
+import { FC } from "react";
+import { Stack, Typography } from "@mui/material";
+
+import TimeIntervalsTable from "./TimeIntervalsTable";
+import ThresholdsTable from "./ThresholdsTable";
+
+const SecondaryParameters: FC = () => {
+  return (
+    <Stack direction="column" spacing={2} useFlexGap>
+      <Typography variant="h5" component="h2">
+        Define time intervals
+      </Typography>
+      <TimeIntervalsTable size="small" />
+      <Typography variant="h5" component="h2">
+        Define thresholds
+      </Typography>
+      <ThresholdsTable size="small" stickyHeader />
+    </Stack>
+  );
+};
+
+export default SecondaryParameters;

--- a/frontend-v2/src/features/model/secondary/ThresholdsTable.tsx
+++ b/frontend-v2/src/features/model/secondary/ThresholdsTable.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FC, useState } from "react";
+import { ChangeEvent, FC, useContext, useState } from "react";
 import {
   MenuItem,
   Select,
@@ -23,6 +23,7 @@ import {
   useVariableListQuery,
   VariableRead,
 } from "../../../app/backendApi";
+import { SimulationContext } from "../../../contexts/SimulationContext";
 
 function VariableRow({
   variable,
@@ -31,12 +32,15 @@ function VariableRow({
   variable: VariableRead;
   unit: UnitRead | undefined;
 }) {
-  const [threshold, setThreshold] = useState<number>(0);
+  const { thresholds, setThresholds } = useContext(SimulationContext);
   const [unitSymbol, setUnitSymbol] = useState<string | undefined>(
     unit?.symbol,
   );
   function onChangeThreshold(event: ChangeEvent<HTMLInputElement>) {
-    setThreshold(event.target.value as unknown as number);
+    setThresholds({
+      ...thresholds,
+      [variable.name]: parseFloat(event.target.value),
+    });
   }
   function onChangeUnit(event: SelectChangeEvent) {
     setUnitSymbol(event.target.value as string);
@@ -52,7 +56,7 @@ function VariableRow({
       <TableCell>
         <TextField
           type="number"
-          value={threshold}
+          value={thresholds[variable.name]}
           onChange={onChangeThreshold}
         />
       </TableCell>

--- a/frontend-v2/src/features/model/secondary/ThresholdsTable.tsx
+++ b/frontend-v2/src/features/model/secondary/ThresholdsTable.tsx
@@ -1,0 +1,120 @@
+import { ChangeEvent, FC, useState } from "react";
+import {
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableProps,
+  TableRow,
+  TextField,
+  Tooltip,
+} from "@mui/material";
+import { useSelector } from "react-redux";
+
+import { RootState } from "../../../app/store";
+import {
+  UnitRead,
+  useCombinedModelListQuery,
+  useProjectRetrieveQuery,
+  useUnitListQuery,
+  useVariableListQuery,
+  VariableRead,
+} from "../../../app/backendApi";
+
+function VariableRow({
+  variable,
+  unit,
+}: {
+  variable: VariableRead;
+  unit: UnitRead | undefined;
+}) {
+  const [threshold, setThreshold] = useState<number>(0);
+  const [unitSymbol, setUnitSymbol] = useState<string | undefined>(
+    unit?.symbol,
+  );
+  function onChangeThreshold(event: ChangeEvent<HTMLInputElement>) {
+    setThreshold(event.target.value as unknown as number);
+  }
+  function onChangeUnit(event: SelectChangeEvent) {
+    setUnitSymbol(event.target.value as string);
+  }
+
+  return (
+    <TableRow>
+      <TableCell>
+        <Tooltip title={`${variable.name}: ${variable.description}`}>
+          <span>{variable.name}</span>
+        </Tooltip>
+      </TableCell>
+      <TableCell>
+        <TextField
+          type="number"
+          value={threshold}
+          onChange={onChangeThreshold}
+        />
+      </TableCell>
+      <TableCell>
+        <Select value={unitSymbol} onChange={onChangeUnit}>
+          {unit?.compatible_units?.map((unit) => (
+            <MenuItem key={unit.id} value={unit.symbol}>
+              {unit.symbol}
+            </MenuItem>
+          ))}
+        </Select>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+const ThresholdsTable: FC<TableProps> = (props) => {
+  const projectId = useSelector(
+    (state: RootState) => state.main.selectedProject,
+  );
+  const projectIdOrZero = projectId || 0;
+  const { data: project } = useProjectRetrieveQuery(
+    { id: projectIdOrZero },
+    { skip: !projectId },
+  );
+  const { data: models } = useCombinedModelListQuery(
+    { projectId: projectIdOrZero },
+    { skip: !projectId },
+  );
+  const model = models?.[0] || null;
+  const { data: variables } = useVariableListQuery(
+    { dosedPkModelId: model?.id || 0 },
+    { skip: !model?.id },
+  );
+  const { data: units } = useUnitListQuery(
+    { compoundId: project?.compound },
+    { skip: !project || !project.compound },
+  );
+
+  const concentrationVariables = variables?.filter((variable) =>
+    model?.derived_variables?.find(
+      (dv) => dv.pk_variable === variable.id && dv.type === "AUC",
+    ),
+  );
+  return (
+    <Table {...props}>
+      <TableHead>
+        <TableCell>Variable</TableCell>
+        <TableCell>Threshold</TableCell>
+        <TableCell>Unit</TableCell>
+      </TableHead>
+      <TableBody>
+        {concentrationVariables?.map((variable) => (
+          <VariableRow
+            key={variable.id}
+            variable={variable}
+            unit={units?.find((unit) => unit.id === variable.unit)}
+          />
+        ))}
+      </TableBody>
+    </Table>
+  );
+};
+
+export default ThresholdsTable;

--- a/frontend-v2/src/features/model/secondary/ThresholdsTable.tsx
+++ b/frontend-v2/src/features/model/secondary/ThresholdsTable.tsx
@@ -36,12 +36,29 @@ function VariableRow({
   const [unitSymbol, setUnitSymbol] = useState<string | undefined>(
     unit?.symbol,
   );
-  function onChangeThreshold(event: ChangeEvent<HTMLInputElement>) {
+  function onChangeLowerThreshold(event: ChangeEvent<HTMLInputElement>) {
     const newValue = parseFloat(event.target.value);
+    const oldThresholds = thresholds[variable.name];
     if (!isNaN(newValue)) {
       setThresholds({
         ...thresholds,
-        [variable.name]: newValue,
+        [variable.name]: {
+          ...oldThresholds,
+          lower: newValue,
+        },
+      });
+    }
+  }
+  function onChangeUpperThreshold(event: ChangeEvent<HTMLInputElement>) {
+    const newValue = parseFloat(event.target.value);
+    const oldThresholds = thresholds[variable.name];
+    if (!isNaN(newValue)) {
+      setThresholds({
+        ...thresholds,
+        [variable.name]: {
+          ...oldThresholds,
+          upper: newValue,
+        },
       });
     }
   }
@@ -59,8 +76,15 @@ function VariableRow({
       <TableCell>
         <TextField
           type="number"
-          defaultValue={thresholds[variable.name]}
-          onChange={onChangeThreshold}
+          defaultValue={thresholds[variable.name]?.lower}
+          onChange={onChangeLowerThreshold}
+        />
+      </TableCell>
+      <TableCell>
+        <TextField
+          type="number"
+          defaultValue={thresholds[variable.name]?.upper}
+          onChange={onChangeUpperThreshold}
         />
       </TableCell>
       <TableCell>
@@ -108,7 +132,8 @@ const ThresholdsTable: FC<TableProps> = (props) => {
     <Table {...props}>
       <TableHead>
         <TableCell>Variable</TableCell>
-        <TableCell>Threshold</TableCell>
+        <TableCell>Lower Threshold</TableCell>
+        <TableCell>Upper Threshold</TableCell>
         <TableCell>Unit</TableCell>
       </TableHead>
       <TableBody>

--- a/frontend-v2/src/features/model/secondary/ThresholdsTable.tsx
+++ b/frontend-v2/src/features/model/secondary/ThresholdsTable.tsx
@@ -37,10 +37,13 @@ function VariableRow({
     unit?.symbol,
   );
   function onChangeThreshold(event: ChangeEvent<HTMLInputElement>) {
-    setThresholds({
-      ...thresholds,
-      [variable.name]: parseFloat(event.target.value),
-    });
+    const newValue = parseFloat(event.target.value);
+    if (!isNaN(newValue)) {
+      setThresholds({
+        ...thresholds,
+        [variable.name]: newValue,
+      });
+    }
   }
   function onChangeUnit(event: SelectChangeEvent) {
     setUnitSymbol(event.target.value as string);
@@ -56,7 +59,7 @@ function VariableRow({
       <TableCell>
         <TextField
           type="number"
-          value={thresholds[variable.name]}
+          defaultValue={thresholds[variable.name]}
           onChange={onChangeThreshold}
         />
       </TableCell>

--- a/frontend-v2/src/features/model/secondary/TimeIntervalsTable.tsx
+++ b/frontend-v2/src/features/model/secondary/TimeIntervalsTable.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from "react";
+import { FC, useContext } from "react";
 import {
   Button,
   FormControl,
@@ -22,12 +22,8 @@ import {
   useUnitListQuery,
 } from "../../../app/backendApi";
 import { RootState } from "../../../app/store";
-
-type TimeInterval = {
-  start: number;
-  end: number;
-  unit: string;
-};
+import { SimulationContext } from "../../../contexts/SimulationContext";
+import { TimeInterval } from "../../../App";
 
 type TimeUnitSelectProps = {
   interval: TimeInterval;
@@ -106,13 +102,21 @@ function IntervalRow({ interval, onDelete, onUpdate }: IntervalRowProps) {
   );
 }
 
-const defaultIntervals: TimeInterval[] = [{ start: 0, end: 0, unit: "h" }];
-
 const TimeIntervalsTable: FC<TableProps> = (props) => {
-  const [intervals, setIntervals] = useState<TimeInterval[]>(defaultIntervals);
+  const { intervals, setIntervals } = useContext(SimulationContext);
 
   function addInterval() {
-    setIntervals([...intervals, { start: 0, end: 0, unit: "h" }]);
+    const lastInterval = intervals[intervals.length - 1];
+    let newInterval: TimeInterval = { start: 0, end: 0, unit: "h" };
+    if (lastInterval) {
+      const duration = lastInterval.end - lastInterval.start;
+      newInterval = {
+        start: lastInterval.end,
+        end: lastInterval.end + duration,
+        unit: lastInterval.unit,
+      };
+    }
+    setIntervals([...intervals, newInterval]);
   }
   function removeInterval(index: number) {
     setIntervals(intervals.filter((_, i) => i !== index));

--- a/frontend-v2/src/features/model/secondary/TimeIntervalsTable.tsx
+++ b/frontend-v2/src/features/model/secondary/TimeIntervalsTable.tsx
@@ -1,0 +1,154 @@
+import { FC, useState } from "react";
+import {
+  Button,
+  FormControl,
+  IconButton,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableProps,
+  TableRow,
+  TextField,
+} from "@mui/material";
+import Delete from "@mui/icons-material/Delete";
+import { useSelector } from "react-redux";
+
+import {
+  useProjectRetrieveQuery,
+  useUnitListQuery,
+} from "../../../app/backendApi";
+import { RootState } from "../../../app/store";
+
+type TimeInterval = {
+  start: number;
+  end: number;
+  unit: string;
+};
+
+type TimeUnitSelectProps = {
+  interval: TimeInterval;
+  onChange: (interval: TimeInterval) => void;
+};
+
+function TimeUnitSelect({ interval, onChange }: TimeUnitSelectProps) {
+  const projectId = useSelector(
+    (state: RootState) => state.main.selectedProject,
+  );
+  const { data: project } = useProjectRetrieveQuery(
+    { id: projectId || 0 },
+    { skip: !projectId },
+  );
+  const { data: units } = useUnitListQuery(
+    { compoundId: project?.compound },
+    { skip: !project || !project.compound },
+  );
+  const hourUnit = units?.find((unit) => unit.symbol === "h");
+  const timeUnits = hourUnit?.compatible_units.map((unit) => unit.symbol);
+  const timeUnitOptions =
+    timeUnits?.map((unit) => ({ value: unit, label: unit })) || [];
+
+  function onChangeUnit(event: SelectChangeEvent) {
+    onChange({ ...interval, unit: event.target.value });
+  }
+
+  return (
+    <FormControl>
+      <Select value={interval.unit} onChange={onChangeUnit}>
+        {timeUnitOptions.map((option) => (
+          <MenuItem key={option.value} value={option.value}>
+            {option.label}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+}
+
+type IntervalRowProps = {
+  interval: TimeInterval;
+  onDelete: () => void;
+  onUpdate: (interval: TimeInterval) => void;
+};
+
+function IntervalRow({ interval, onDelete, onUpdate }: IntervalRowProps) {
+  function onChangeStart(event: React.ChangeEvent<HTMLInputElement>) {
+    onUpdate({ ...interval, start: parseFloat(event.target.value) });
+  }
+  function onChangeEnd(event: React.ChangeEvent<HTMLInputElement>) {
+    onUpdate({ ...interval, end: parseFloat(event.target.value) });
+  }
+
+  return (
+    <TableRow>
+      <TableCell>
+        <TextField
+          type="number"
+          value={interval.start}
+          onChange={onChangeStart}
+        />
+      </TableCell>
+      <TableCell>
+        <TextField type="number" value={interval.end} onChange={onChangeEnd} />
+      </TableCell>
+      <TableCell>
+        <TimeUnitSelect interval={interval} onChange={onUpdate} />
+      </TableCell>
+      <TableCell>
+        <IconButton onClick={onDelete}>
+          <Delete />
+        </IconButton>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+const defaultIntervals: TimeInterval[] = [{ start: 0, end: 0, unit: "h" }];
+
+const TimeIntervalsTable: FC<TableProps> = (props) => {
+  const [intervals, setIntervals] = useState<TimeInterval[]>(defaultIntervals);
+
+  function addInterval() {
+    setIntervals([...intervals, { start: 0, end: 0, unit: "h" }]);
+  }
+  function removeInterval(index: number) {
+    setIntervals(intervals.filter((_, i) => i !== index));
+  }
+  function updateInterval(index: number, interval: TimeInterval) {
+    setIntervals(
+      intervals.map((i, iIndex) => (iIndex === index ? interval : i)),
+    );
+  }
+  const onDelete = (index: number) => () => removeInterval(index);
+  const onUpdate = (index: number) => (interval: TimeInterval) =>
+    updateInterval(index, interval);
+
+  return (
+    <>
+      <Table {...props}>
+        <TableHead>
+          <TableCell>Start time</TableCell>
+          <TableCell>End time</TableCell>
+          <TableCell>Unit</TableCell>
+          <TableCell>Remove</TableCell>
+        </TableHead>
+        <TableBody>
+          {intervals.map((interval, index) => (
+            <IntervalRow
+              key={index}
+              interval={interval}
+              onDelete={onDelete(index)}
+              onUpdate={onUpdate(index)}
+            />
+          ))}
+        </TableBody>
+      </Table>
+      <Button onClick={addInterval}>Add time interval</Button>
+    </>
+  );
+};
+
+export default TimeIntervalsTable;

--- a/frontend-v2/src/features/results/Results.tsx
+++ b/frontend-v2/src/features/results/Results.tsx
@@ -1,0 +1,49 @@
+import { SyntheticEvent, FC, useState } from "react";
+
+import { Box, Tab, Tabs } from "@mui/material";
+import useSubjectGroups from "../../hooks/useSubjectGroups";
+import VariableTabs from "./VariableTabs";
+
+const Results: FC = () => {
+  const [tab, setTab] = useState(0);
+  const { groups = [] } = useSubjectGroups();
+
+  function handleTabChange(
+    event: SyntheticEvent<Element, Event>,
+    newValue: number,
+  ) {
+    setTab(newValue);
+  }
+
+  try {
+    return (
+      <>
+        <Tabs value={tab} onChange={handleTabChange}>
+          <Tab
+            label={"Project"}
+            id="group-tab-0"
+            aria-controls="group-tabpanel"
+          />
+          {groups?.map((group, index) => {
+            return (
+              <Tab
+                key={group.id}
+                label={group.name}
+                id={`group-tab-${index + 1}`}
+                aria-controls="group-tabpanel"
+              />
+            );
+          })}
+        </Tabs>
+        <Box id="group-tabpanel">
+          <VariableTabs index={tab} />
+        </Box>
+      </>
+    );
+  } catch (e: any) {
+    console.error(e);
+    return <div>Error {e.message}</div>;
+  }
+};
+
+export default Results;

--- a/frontend-v2/src/features/results/VariableTable.tsx
+++ b/frontend-v2/src/features/results/VariableTable.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, useContext } from "react";
 
 import { VariableRead } from "../../app/backendApi";
 import {
@@ -9,26 +9,8 @@ import {
   TableRow,
 } from "@mui/material";
 
-type TimeInterval = {
-  start: number;
-  end: number;
-  unit: string;
-};
-
-const timeIntervals = [
-  { start: 0, end: 168, unit: "h" },
-  { start: 168, end: 336, unit: "h" },
-  { start: 336, end: 504, unit: "h" },
-  { start: 504, end: 672, unit: "h" },
-  { start: 672, end: 840, unit: "h" },
-];
-
-const thresholds: { [key: string]: number } = {
-  C1: 1e4,
-  C1_t: 5e4,
-  CT1_f: 200,
-  CT1_b: 900,
-};
+import { SimulationContext } from "../../contexts/SimulationContext";
+import { TimeInterval } from "../../App";
 
 const IntervalRow: FC<{
   interval: { start: number; end: number; unit: string };
@@ -164,10 +146,11 @@ const VariableTable: FC<{
   aucValues: number[];
   times: number[];
 }> = ({ variable, values = [], aucValues = [], times = [] }) => {
-  const variablePerInterval = valuesPerInterval(timeIntervals, values, times);
-  const timePerInterval = timesPerInterval(times, timeIntervals);
-  const aucPerInterval = valuesPerInterval(timeIntervals, aucValues, times);
-  const timeOverThresholdPerInterval = timeIntervals.map((interval, k) => {
+  const { intervals, thresholds } = useContext(SimulationContext);
+  const variablePerInterval = valuesPerInterval(intervals, values, times);
+  const timePerInterval = timesPerInterval(times, intervals);
+  const aucPerInterval = valuesPerInterval(intervals, aucValues, times);
+  const timeOverThresholdPerInterval = intervals.map((interval, k) => {
     const intervalValues = variablePerInterval[k];
     const intervalTimes = timePerInterval[k];
     const threshold = thresholds[variable.name];
@@ -192,7 +175,7 @@ const VariableTable: FC<{
         </TableRow>
       </TableHead>
       <TableBody>
-        {timeIntervals.map((interval, k) => (
+        {intervals.map((interval, k) => (
           <IntervalRow
             key={interval.start}
             interval={interval}

--- a/frontend-v2/src/features/results/VariableTable.tsx
+++ b/frontend-v2/src/features/results/VariableTable.tsx
@@ -211,13 +211,21 @@ const VariableTable: FC<{
     const intervalValues = variablePerInterval[k];
     const intervalTimes = timePerInterval[k];
     const threshold = thresholds[variable.name];
-    return timeOverThreshold(intervalTimes, intervalValues, threshold?.lower);
+    return timeOverThreshold(
+      intervalTimes,
+      intervalValues,
+      threshold?.lower || 0,
+    );
   });
   const timeOverUpperThresholdPerInterval = intervals.map((interval, k) => {
     const intervalValues = variablePerInterval[k];
     const intervalTimes = timePerInterval[k];
     const threshold = thresholds[variable.name];
-    return timeOverThreshold(intervalTimes, intervalValues, threshold?.upper);
+    return timeOverThreshold(
+      intervalTimes,
+      intervalValues,
+      threshold?.upper || Infinity,
+    );
   });
   const unit = units.find((u) => u.id === variable.unit);
   const aucUnit = aucVariable && units.find((u) => u.id === aucVariable.unit);

--- a/frontend-v2/src/features/results/VariableTable.tsx
+++ b/frontend-v2/src/features/results/VariableTable.tsx
@@ -1,10 +1,6 @@
 import { FC, useContext } from "react";
 
-import {
-  UnitListApiResponse,
-  UnitRead,
-  VariableRead,
-} from "../../app/backendApi";
+import { UnitListApiResponse, VariableRead } from "../../app/backendApi";
 import {
   Table,
   TableBody,

--- a/frontend-v2/src/features/results/VariableTable.tsx
+++ b/frontend-v2/src/features/results/VariableTable.tsx
@@ -1,0 +1,209 @@
+import { FC } from "react";
+
+import { VariableRead } from "../../app/backendApi";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+} from "@mui/material";
+
+type TimeInterval = {
+  start: number;
+  end: number;
+  unit: string;
+};
+
+const timeIntervals = [
+  { start: 0, end: 168, unit: "h" },
+  { start: 168, end: 336, unit: "h" },
+  { start: 336, end: 504, unit: "h" },
+  { start: 504, end: 672, unit: "h" },
+  { start: 672, end: 840, unit: "h" },
+];
+
+const thresholds: { [key: string]: number } = {
+  C1: 1e4,
+  C1_t: 5e4,
+  CT1_f: 200,
+  CT1_b: 900,
+};
+
+const IntervalRow: FC<{
+  interval: { start: number; end: number; unit: string };
+  values: number[];
+  aucValues: number[];
+  timeOverThreshold: number;
+}> = ({ interval, values, aucValues, timeOverThreshold }) => {
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const auc = aucValues[aucValues.length - 1] - aucValues[0];
+  return (
+    <TableRow>
+      <TableCell scope="row">
+        {interval.start} – {interval.end} {interval.unit}
+      </TableCell>
+      <TableCell>{min.toFixed(2)}</TableCell>
+      <TableCell>{max.toFixed(2)}</TableCell>
+      <TableCell>{auc.toFixed(2)}</TableCell>
+      <TableCell>{timeOverThreshold.toFixed(2)}</TableCell>
+    </TableRow>
+  );
+};
+
+/**
+ * Given x0 in the range [x[0], x[1]], return the linearly interpolated value y0 in the range [y[0], y[1]].
+ * @param x
+ * @param y
+ * @param x0
+ * @returns y0 in the range [y[0], y[1]].
+ */
+function interpolate(x: [number, number], y: [number, number], x0: number) {
+  return y[0] + ((x0 - x[0]) * (y[1] - y[0])) / (x[1] - x[0]);
+}
+
+/**
+ * Given a list of time intervals, a list of values, and a list of times, return a list of values per interval.
+ * @param timeIntervals
+ * @param values
+ * @param times
+ * @returns values per interval
+ */
+function valuesPerInterval(
+  timeIntervals: TimeInterval[],
+  values: number[],
+  times: number[],
+) {
+  return timeIntervals.map((interval) => {
+    const startIndex = times.findIndex((t) => t >= interval.start);
+    const endIndex = times.findIndex((t) => t >= interval.end);
+    const start =
+      startIndex > 0
+        ? interpolate(
+            [times[startIndex - 1], times[startIndex]],
+            [values[startIndex - 1], values[startIndex]],
+            interval.start,
+          )
+        : values[0];
+    const end =
+      endIndex > -1
+        ? interpolate(
+            [times[endIndex - 1], times[endIndex]],
+            [values[endIndex - 1], values[endIndex]],
+            interval.end,
+          )
+        : values[values.length - 1];
+    const intervalValues = [
+      start,
+      ...values.slice(startIndex + 1, endIndex - 1),
+      end,
+    ];
+    return intervalValues;
+  });
+}
+
+/**
+ * Given a list of times and a list of time intervals, return a list of times per interval.
+ * @param times
+ * @param timeIntervals
+ * @returns times per interval
+ */
+function timesPerInterval(times: number[], timeIntervals: TimeInterval[]) {
+  return timeIntervals.map((interval) => {
+    const startIndex = times.findIndex((t) => t >= interval.start);
+    const endIndex = times.findIndex((t) => t >= interval.end);
+    return [
+      interval.start,
+      ...times.slice(startIndex + 1, endIndex - 1),
+      interval.end,
+    ];
+  });
+}
+
+/**
+ * Given a list of times and cooresponding values, calculate the time that the values are above a threshold.
+ * @param intervalTimes
+ * @param intervalValues
+ * @param threshold
+ * @returns
+ */
+function timeOverThreshold(
+  intervalTimes: number[],
+  intervalValues: number[],
+  threshold: number,
+) {
+  const thresholdStart = intervalValues.findIndex((v) => v >= threshold);
+  const thresholdEnd = intervalValues.findIndex(
+    (v, i) => i > thresholdStart && v < threshold,
+  );
+  const startTime =
+    thresholdStart > 0
+      ? interpolate(
+          [intervalValues[thresholdStart - 1], intervalValues[thresholdStart]],
+          [intervalTimes[thresholdStart - 1], intervalTimes[thresholdStart]],
+          threshold,
+        )
+      : intervalTimes[0];
+  const endTime =
+    thresholdStart === -1 // threshold never reached
+      ? startTime
+      : thresholdEnd > 0
+        ? interpolate(
+            [intervalValues[thresholdEnd - 1], intervalValues[thresholdEnd]],
+            [intervalTimes[thresholdEnd - 1], intervalTimes[thresholdEnd]],
+            threshold,
+          )
+        : intervalTimes[intervalTimes.length - 1]; // threshold reached beyond the end of the interval
+  return endTime - startTime;
+}
+
+const VariableTable: FC<{
+  variable: VariableRead;
+  values: number[];
+  aucValues: number[];
+  times: number[];
+}> = ({ variable, values = [], aucValues = [], times = [] }) => {
+  const variablePerInterval = valuesPerInterval(timeIntervals, values, times);
+  const timePerInterval = timesPerInterval(times, timeIntervals);
+  const aucPerInterval = valuesPerInterval(timeIntervals, aucValues, times);
+  const timeOverThresholdPerInterval = timeIntervals.map((interval, k) => {
+    const intervalValues = variablePerInterval[k];
+    const intervalTimes = timePerInterval[k];
+    const threshold = thresholds[variable.name];
+    return timeOverThreshold(intervalTimes, intervalValues, threshold);
+  });
+
+  return (
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell>Interval</TableCell>
+          <TableCell>
+            {variable.name}
+            <sub>min</sub>
+          </TableCell>
+          <TableCell>
+            {variable.name}
+            <sub>max</sub>
+          </TableCell>
+          <TableCell>AUC</TableCell>
+          <TableCell>Time over threshold</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {timeIntervals.map((interval, k) => (
+          <IntervalRow
+            key={interval.start}
+            interval={interval}
+            values={variablePerInterval[k]}
+            aucValues={aucPerInterval[k]}
+            timeOverThreshold={timeOverThresholdPerInterval[k]}
+          />
+        ))}
+      </TableBody>
+    </Table>
+  );
+};
+
+export default VariableTable;

--- a/frontend-v2/src/features/results/VariableTable.tsx
+++ b/frontend-v2/src/features/results/VariableTable.tsx
@@ -1,6 +1,10 @@
 import { FC, useContext } from "react";
 
-import { VariableRead } from "../../app/backendApi";
+import {
+  UnitListApiResponse,
+  UnitRead,
+  VariableRead,
+} from "../../app/backendApi";
 import {
   Table,
   TableBody,
@@ -26,9 +30,9 @@ const IntervalRow: FC<{
       <TableCell scope="row">
         {interval.start} – {interval.end} {interval.unit}
       </TableCell>
-      <TableCell>{min.toFixed(2)}</TableCell>
-      <TableCell>{max.toFixed(2)}</TableCell>
-      <TableCell>{auc.toFixed(2)}</TableCell>
+      <TableCell>{min > 1e4 ? min.toExponential(4) : min.toFixed(2)}</TableCell>
+      <TableCell>{max > 1e4 ? max.toExponential(4) : max.toFixed(2)}</TableCell>
+      <TableCell>{auc.toExponential(4)}</TableCell>
       <TableCell>{timeOverThreshold.toFixed(2)}</TableCell>
     </TableRow>
   );
@@ -177,10 +181,21 @@ function timeOverThreshold(
 
 const VariableTable: FC<{
   variable: VariableRead;
+  aucVariable?: VariableRead;
+  timeVariable?: VariableRead;
   values: number[];
   aucValues: number[];
   times: number[];
-}> = ({ variable, values = [], aucValues = [], times = [] }) => {
+  units: UnitListApiResponse | undefined;
+}> = ({
+  variable,
+  aucVariable,
+  timeVariable,
+  values = [],
+  aucValues = [],
+  times = [],
+  units = [],
+}) => {
   const { intervals, thresholds } = useContext(SimulationContext);
   const variablePerInterval = valuesPerInterval(intervals, values, times);
   const timePerInterval = timesPerInterval(times, intervals);
@@ -191,6 +206,10 @@ const VariableTable: FC<{
     const threshold = thresholds[variable.name];
     return timeOverThreshold(intervalTimes, intervalValues, threshold);
   });
+  const unit = units.find((u) => u.id === variable.unit);
+  const aucUnit = aucVariable && units.find((u) => u.id === aucVariable.unit);
+  const timeUnit =
+    timeVariable && units.find((u) => u.id === timeVariable.unit);
 
   return (
     <Table>
@@ -199,14 +218,14 @@ const VariableTable: FC<{
           <TableCell>Interval</TableCell>
           <TableCell>
             {variable.name}
-            <sub>min</sub>
+            <sub>min</sub> [{unit?.symbol}]
           </TableCell>
           <TableCell>
             {variable.name}
-            <sub>max</sub>
+            <sub>max</sub> [{unit?.symbol}]
           </TableCell>
-          <TableCell>AUC</TableCell>
-          <TableCell>Time over threshold</TableCell>
+          <TableCell>AUC [{aucUnit?.symbol}]</TableCell>
+          <TableCell>Time over threshold [{timeUnit?.symbol}]</TableCell>
         </TableRow>
       </TableHead>
       <TableBody>

--- a/frontend-v2/src/features/results/VariableTabs.tsx
+++ b/frontend-v2/src/features/results/VariableTabs.tsx
@@ -75,6 +75,10 @@ const VariableTabs: FC<VariableTabsProps> = ({ index }) => {
   const values = variableValues(variable?.name)[index];
   const aucValues = variableValues(aucVariable?.name)[index];
 
+  if (!concentrationVariables[tab]) {
+    return <p>Loading…</p>;
+  }
+
   try {
     return (
       <>

--- a/frontend-v2/src/features/results/VariableTabs.tsx
+++ b/frontend-v2/src/features/results/VariableTabs.tsx
@@ -1,0 +1,107 @@
+import { SyntheticEvent, FC, useContext, useState } from "react";
+import { useSelector } from "react-redux";
+
+import { SimulationContext } from "../../contexts/SimulationContext";
+import { RootState } from "../../app/store";
+import {
+  useCombinedModelListQuery,
+  useVariableListQuery,
+} from "../../app/backendApi";
+import { Box, Tab, Tabs, Typography } from "@mui/material";
+import VariableTable from "./VariableTable";
+
+const thresholds: { [key: string]: number } = {
+  C1: 1e4,
+  C1_t: 5e4,
+  CT1_f: 200,
+  CT1_b: 900,
+};
+
+interface VariableTabsProps {
+  index: number;
+}
+
+const VariableTabs: FC<VariableTabsProps> = ({ index }) => {
+  const [tab, setTab] = useState(0);
+  const projectId = useSelector(
+    (state: RootState) => state.main.selectedProject,
+  );
+  const projectIdOrZero = projectId || 0;
+  const { data: models } = useCombinedModelListQuery(
+    { projectId: projectIdOrZero },
+    { skip: !projectId },
+  );
+  const model = models?.[0] || null;
+  const { data: variables } = useVariableListQuery(
+    { dosedPkModelId: model?.id || 0 },
+    { skip: !model?.id },
+  );
+
+  const { simulations } = useContext(SimulationContext);
+  const simulationVariableIDs = simulations?.[0]?.outputs
+    ? Object.keys(simulations[0].outputs).map((key) => parseInt(key))
+    : [];
+  const concentrationVariables =
+    variables?.filter(
+      (variable) =>
+        simulationVariableIDs.includes(variable.id) &&
+        model?.derived_variables?.find(
+          (dv) => dv.pk_variable === variable.id && dv.type === "AUC",
+        ),
+    ) || [];
+
+  function variableValues(name: string) {
+    const variable = variables?.find((v) => v.name === name);
+    return variable
+      ? simulations.map((simulation) => simulation.outputs[variable.id])
+      : [];
+  }
+
+  function handleTabChange(
+    event: SyntheticEvent<Element, Event>,
+    newValue: number,
+  ) {
+    setTab(newValue);
+  }
+  const simulation = simulations[index];
+  const variable = concentrationVariables[tab];
+  const aucVariable = variable && `calc_${variable.name}_AUC`;
+  const values = variableValues(variable?.name)[index];
+  const aucValues = variableValues(aucVariable)[index];
+
+  try {
+    return (
+      <>
+        <Tabs value={tab} onChange={handleTabChange}>
+          {concentrationVariables?.map((cVar, index) => {
+            return (
+              <Tab
+                key={cVar.id}
+                label={cVar.name}
+                id={`cvar-tab-${index}`}
+                aria-controls="cvar-tabpanel"
+              />
+            );
+          })}
+        </Tabs>
+        <Box id="cvar-tabpanel">
+          <Typography>
+            Threshold: {thresholds[concentrationVariables[tab].name]}
+          </Typography>
+          <VariableTable
+            key={variable.id}
+            variable={variable}
+            values={values}
+            aucValues={aucValues}
+            times={simulation.time}
+          />
+        </Box>
+      </>
+    );
+  } catch (e: any) {
+    console.error(e);
+    return <div>Error {e.message}</div>;
+  }
+};
+
+export default VariableTabs;

--- a/frontend-v2/src/features/results/VariableTabs.tsx
+++ b/frontend-v2/src/features/results/VariableTabs.tsx
@@ -96,7 +96,8 @@ const VariableTabs: FC<VariableTabsProps> = ({ index }) => {
         </Tabs>
         <Box id="cvar-tabpanel">
           <Typography>
-            Threshold: {thresholds[concentrationVariables[tab].name]}
+            Thresholds: {thresholds[concentrationVariables[tab].name]?.lower} –{" "}
+            {thresholds[concentrationVariables[tab].name]?.upper}
           </Typography>
           <VariableTable
             key={variable.id}

--- a/frontend-v2/src/features/results/VariableTabs.tsx
+++ b/frontend-v2/src/features/results/VariableTabs.tsx
@@ -10,13 +10,6 @@ import {
 import { Box, Tab, Tabs, Typography } from "@mui/material";
 import VariableTable from "./VariableTable";
 
-const thresholds: { [key: string]: number } = {
-  C1: 1e4,
-  C1_t: 5e4,
-  CT1_f: 200,
-  CT1_b: 900,
-};
-
 interface VariableTabsProps {
   index: number;
 }
@@ -37,7 +30,7 @@ const VariableTabs: FC<VariableTabsProps> = ({ index }) => {
     { skip: !model?.id },
   );
 
-  const { simulations } = useContext(SimulationContext);
+  const { simulations, thresholds } = useContext(SimulationContext);
   const simulationVariableIDs = simulations?.[0]?.outputs
     ? Object.keys(simulations[0].outputs).map((key) => parseInt(key))
     : [];

--- a/frontend-v2/src/features/simulation/SimulationPlotView.tsx
+++ b/frontend-v2/src/features/simulation/SimulationPlotView.tsx
@@ -6,7 +6,6 @@ import {
   SimulateResponse,
   Simulation,
   SimulationYAxis,
-  SubjectGroup,
   SubjectGroupRead,
   UnitRead,
   VariableRead,
@@ -155,18 +154,18 @@ function genIcLines(
 }
 
 function generatePlotData(
-  d: SimulateResponse, 
-  visibleGroups: string[], 
-  colour: string, 
-  dash: string, 
-  index: number, 
-  group: SubjectGroupRead | undefined, 
-  y_axis: SimulationYAxis, 
-  plot: FieldArrayWithId<Simulation, "plots", "id">, 
-  units: UnitRead[], 
-  model: CombinedModelRead, 
-  variables: VariableRead[], 
-  xconversionFactor: number
+  d: SimulateResponse,
+  visibleGroups: string[],
+  colour: string,
+  dash: string,
+  index: number,
+  group: SubjectGroupRead | undefined,
+  y_axis: SimulationYAxis,
+  plot: FieldArrayWithId<Simulation, "plots", "id">,
+  units: UnitRead[],
+  model: CombinedModelRead,
+  variables: VariableRead[],
+  xconversionFactor: number,
 ) {
   const visible =
     index === 0
@@ -219,7 +218,14 @@ function generatePlotData(
   }
 }
 
-function minMaxAxisLimits(data: number[], minY: number | undefined, maxY: number | undefined, minY2: number | undefined, maxY2: number | undefined, has_right_axis: Boolean | undefined) {
+function minMaxAxisLimits(
+  data: number[],
+  minY: number | undefined,
+  maxY: number | undefined,
+  minY2: number | undefined,
+  maxY2: number | undefined,
+  has_right_axis: boolean | undefined,
+) {
   if (has_right_axis) {
     if (minY2 === undefined) {
       minY2 = Math.min(...data);
@@ -301,21 +307,23 @@ const SimulationPlotView: FC<SimulationPlotProps> = ({
     remove(index);
     setOpen(false);
   };
-  
-  const handleCopyToClipboard = (gd: PlotlyHTMLElement, ev: MouseEvent) => {
-    Plotly.toImage(gd, { format: 'png', width: 1000, height: 600})
-          .then(async (url: string) => {
-            try {
-              const data = await fetch(url);
-              const blob = await data.blob();
-              await navigator.clipboard.write([new ClipboardItem({[blob.type]: blob})]);
-              console.log('Image copied.');
-            } 
-            catch (err: any) {
-              console.error(err.name, err.message);
-            }
-          });
-  }
+
+  const handleCopyToClipboard = (gd: PlotlyHTMLElement) => {
+    Plotly.toImage(gd, { format: "png", width: 1000, height: 600 }).then(
+      async (url: string) => {
+        try {
+          const data = await fetch(url);
+          const blob = await data.blob();
+          await navigator.clipboard.write([
+            new ClipboardItem({ [blob.type]: blob }),
+          ]);
+          console.log("Image copied.");
+        } catch (err: any) {
+          console.error(err.name, err.message);
+        }
+      },
+    );
+  };
 
   const timeVariable = variables.find((v) => v.binding === "time");
   const timeUnit = units.find((u) => u.id === timeVariable?.unit);
@@ -339,21 +347,65 @@ const SimulationPlotView: FC<SimulationPlotProps> = ({
   const plotData = plot.y_axes
     .map((y_axis, i) => {
       const colourOffset = data.length * i;
-      return data.map((d, index) => {
-        const colourIndex = index + colourOffset;
-        const colour = plotColours[colourIndex % plotColours.length]
-        const group = groups?.[index - 1];
-        const plotData = generatePlotData(d, visibleGroups, colour, 'solid', index, group, y_axis, plot, units, model, variables, xconversionFactor);
-        ({ minY, maxY, minY2, maxY2 } = minMaxAxisLimits(plotData.y, minY, maxY, minY2, maxY2, y_axis.right));
-        return plotData;
-      }).concat(dataReference.map((d, index) => {
-        const colourIndex = index + colourOffset;
-        const colour = plotColours[colourIndex % plotColours.length]
-        const group = groups?.[index - 1];
-        const plotDataReference = generatePlotData(dataReference[index], visibleGroups, colour, 'dot', index, group, y_axis, plot, units, model, variables, xconversionFactor);
-        ({ minY, maxY, minY2, maxY2 } = minMaxAxisLimits(plotDataReference.y, minY, maxY, minY2, maxY2, y_axis.right));
-          return plotDataReference;
-        }));
+      return data
+        .map((d, index) => {
+          const colourIndex = index + colourOffset;
+          const colour = plotColours[colourIndex % plotColours.length];
+          const group = groups?.[index - 1];
+          const plotData = generatePlotData(
+            d,
+            visibleGroups,
+            colour,
+            "solid",
+            index,
+            group,
+            y_axis,
+            plot,
+            units,
+            model,
+            variables,
+            xconversionFactor,
+          );
+          ({ minY, maxY, minY2, maxY2 } = minMaxAxisLimits(
+            plotData.y,
+            minY,
+            maxY,
+            minY2,
+            maxY2,
+            y_axis.right,
+          ));
+          return plotData;
+        })
+        .concat(
+          dataReference.map((d, index) => {
+            const colourIndex = index + colourOffset;
+            const colour = plotColours[colourIndex % plotColours.length];
+            const group = groups?.[index - 1];
+            const plotDataReference = generatePlotData(
+              dataReference[index],
+              visibleGroups,
+              colour,
+              "dot",
+              index,
+              group,
+              y_axis,
+              plot,
+              units,
+              model,
+              variables,
+              xconversionFactor,
+            );
+            ({ minY, maxY, minY2, maxY2 } = minMaxAxisLimits(
+              plotDataReference.y,
+              minY,
+              maxY,
+              minY2,
+              maxY2,
+              y_axis.right,
+            ));
+            return plotDataReference;
+          }),
+        );
     })
     .flat() as Partial<ScatterData>[];
 
@@ -487,9 +539,9 @@ const SimulationPlotView: FC<SimulationPlotProps> = ({
     width: 300,
     height: 600,
     path: "M102.17,29.66A3,3,0,0,0,100,26.79L73.62,1.1A3,3,0,0,0,71.31,0h-46a5.36,5.36,0,0,0-5.36,5.36V20.41H5.36A5.36,5.36,0,0,0,0,25.77v91.75a5.36,5.36,0,0,0,5.36,5.36H76.9a5.36,5.36,0,0,0,5.33-5.36v-15H96.82a5.36,5.36,0,0,0,5.33-5.36q0-33.73,0-67.45ZM25.91,20.41V6h42.4V30.24a3,3,0,0,0,3,3H96.18q0,31.62,0,63.24h-14l0-46.42a3,3,0,0,0-2.17-2.87L53.69,21.51a2.93,2.93,0,0,0-2.3-1.1ZM54.37,30.89,72.28,47.67H54.37V30.89ZM6,116.89V26.37h42.4V50.65a3,3,0,0,0,3,3H76.26q0,31.64,0,63.24ZM17.33,69.68a2.12,2.12,0,0,1,1.59-.74H54.07a2.14,2.14,0,0,1,1.6.73,2.54,2.54,0,0,1,.63,1.7,2.57,2.57,0,0,1-.64,1.7,2.16,2.16,0,0,1-1.59.74H18.92a2.15,2.15,0,0,1-1.6-.73,2.59,2.59,0,0,1,0-3.4Zm0,28.94a2.1,2.1,0,0,1,1.58-.74H63.87a2.12,2.12,0,0,1,1.59.74,2.57,2.57,0,0,1,.64,1.7,2.54,2.54,0,0,1-.63,1.7,2.14,2.14,0,0,1-1.6.73H18.94a2.13,2.13,0,0,1-1.59-.73,2.56,2.56,0,0,1,0-3.4ZM63.87,83.41a2.12,2.12,0,0,1,1.59.74,2.59,2.59,0,0,1,0,3.4,2.13,2.13,0,0,1-1.6.72H18.94a2.12,2.12,0,0,1-1.59-.72,2.55,2.55,0,0,1-.64-1.71,2.5,2.5,0,0,1,.65-1.69,2.1,2.1,0,0,1,1.58-.74ZM17.33,55.2a2.15,2.15,0,0,1,1.59-.73H39.71a2.13,2.13,0,0,1,1.6.72,2.61,2.61,0,0,1,0,3.41,2.15,2.15,0,0,1-1.59.73H18.92a2.14,2.14,0,0,1-1.6-.72,2.61,2.61,0,0,1,0-3.41Zm0-14.47A2.13,2.13,0,0,1,18.94,40H30.37a2.12,2.12,0,0,1,1.59.72,2.61,2.61,0,0,1,0,3.41,2.13,2.13,0,0,1-1.58.73H18.94a2.16,2.16,0,0,1-1.59-.72,2.57,2.57,0,0,1-.64-1.71,2.54,2.54,0,0,1,.65-1.7ZM74.3,10.48,92.21,27.26H74.3V10.48Z",
-    transform: "scale(4.5)"
-  }
-  
+    transform: "scale(4.5)",
+  };
+
   const config: Partial<Config> = {
     modeBarButtonsToAdd: [
       {

--- a/frontend-v2/src/features/simulation/Simulations.tsx
+++ b/frontend-v2/src/features/simulation/Simulations.tsx
@@ -140,7 +140,7 @@ const Simulations: FC = () => {
   const isSharedWithMe = useSelector((state: RootState) =>
     selectIsProjectShared(state, project),
   );
-  
+
   const EMPTY_OBJECT: SliderValues = {};
 
   const defaultSimulation: SimulationRead = {
@@ -169,6 +169,7 @@ const Simulations: FC = () => {
   const timeMax = simulation?.id && getTimeMax(simulation);
 
   const simInputs = useSimulationInputs(
+    model,
     simulation,
     sliderValues,
     variables,
@@ -180,20 +181,20 @@ const Simulations: FC = () => {
     data,
     error: simulateError,
   } = useSimulation(simInputs, simulatedVariables, model);
-  
+
   const refSimInputs = useSimulationInputs(
+    model,
     simulation,
     EMPTY_OBJECT,
     variables,
     timeMax,
   );
   const referenceVariables = useSimulatedVariables(variables, EMPTY_OBJECT);
-  const {
-    loadingSimulate: loadingReference,
-    data: dataReference,
-    error: referenceError,
-  } = useSimulation(refSimInputs, referenceVariables, showReference ? model: undefined);
-  
+  const { data: dataReference } = useSimulation(
+    refSimInputs,
+    referenceVariables,
+    showReference ? model : undefined,
+  );
 
   const {
     reset,
@@ -270,21 +271,20 @@ const Simulations: FC = () => {
   // save simulation every second if dirty
   useEffect(() => {
     const onSubmit = (dta: Simulation) => {
-      // empty string keeps getting in, so convert to null
       for (let i = 0; i < dta.plots.length; i++) {
-        // @ts-ignore
+        // @ts-expect-error empty string keeps getting in, so convert to null
         if (dta.plots[i].min === "") {
           dta.plots[i].min = null;
         }
-        // @ts-ignore
+        // @ts-expect-error empty string keeps getting in, so convert to null
         if (dta.plots[i].max === "") {
           dta.plots[i].max = null;
         }
-        // @ts-ignore
+        // @ts-expect-error empty string keeps getting in, so convert to null
         if (dta.plots[i].min2 === "") {
           dta.plots[i].min2 = null;
         }
-        // @ts-ignore
+        // @ts-expect-error empty string keeps getting in, so convert to null
         if (dta.plots[i].max2 === "") {
           dta.plots[i].max2 = null;
         }
@@ -451,7 +451,12 @@ const Simulations: FC = () => {
             Add new plot
           </DropdownButton>
           <FormControlLabel
-            control={<Checkbox checked={showReference} onChange={(e) => setShowReference(e.target.checked)}></Checkbox>}
+            control={
+              <Checkbox
+                checked={showReference}
+                onChange={(e) => setShowReference(e.target.checked)}
+              ></Checkbox>
+            }
             label="Show reference"
           />
         </Stack>

--- a/frontend-v2/src/features/simulation/useSimulation.ts
+++ b/frontend-v2/src/features/simulation/useSimulation.ts
@@ -15,6 +15,8 @@ interface ErrorObject {
   error: string;
 }
 
+const SIMULATION_PAGES = [PageName.SIMULATIONS, PageName.RESULTS];
+
 export default function useSimulation(
   simInputs: Simulate,
   simulatedVariables: { qname: string; value: number | undefined }[],
@@ -41,7 +43,7 @@ export default function useSimulation(
       model &&
       protocols &&
       compound &&
-      page === PageName.SIMULATIONS
+      SIMULATION_PAGES.includes(page)
     ) {
       setLoadingSimulate(true);
       console.log("Simulating with params", simulatedVariables);
@@ -62,7 +64,15 @@ export default function useSimulation(
     return () => {
       ignore = true;
     };
-  }, [compound, model, protocols, simulate, JSON.stringify(simInputs), JSON.stringify(simulatedVariables), page]);
+  }, [
+    compound,
+    model,
+    protocols,
+    simulate,
+    JSON.stringify(simInputs),
+    JSON.stringify(simulatedVariables),
+    page,
+  ]);
 
   return {
     loadingSimulate,

--- a/frontend-v2/src/features/simulation/useSimulation.ts
+++ b/frontend-v2/src/features/simulation/useSimulation.ts
@@ -1,5 +1,7 @@
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import useProtocols from "./useProtocols";
+import { SimulationContext } from "../../contexts/SimulationContext";
+
 import {
   CombinedModelRead,
   Simulate,
@@ -16,6 +18,7 @@ export default function useSimulation(
   model: CombinedModelRead | undefined,
 ) {
   const { compound, protocols } = useProtocols();
+  const { setSimulations } = useContext(SimulationContext);
   const [loadingSimulate, setLoadingSimulate] = useState<boolean>(false);
   const [data, setData] = useState<SimulateResponse[]>([]);
   const [simulate, { error: simulateErrorBase }] =
@@ -46,6 +49,7 @@ export default function useSimulation(
           if ("data" in response) {
             const responseData = response.data as SimulateResponse[];
             setData(responseData);
+            setSimulations(responseData);
           }
         }
       });

--- a/pkpdapp/pkpdapp/models/combined_model.py
+++ b/pkpdapp/pkpdapp/models/combined_model.py
@@ -328,10 +328,12 @@ class CombinedModel(MyokitModelMixin, StoredModel):
                 )
                 if has_name:
                     continue
+                time_var = pkpd_model.binding("time")
                 var = myokit_compartment.add_variable(
                     new_names[0],
                     rhs=myokit.Name(myokit_var),
-                    initial_value=0
+                    initial_value=0,
+                    unit=myokit_var.unit() * time_var.unit(),
                 )
                 var.meta[
                     "desc"

--- a/pkpdapp/schema.yml
+++ b/pkpdapp/schema.yml
@@ -3646,6 +3646,7 @@ components:
           description: |-
             type of derived variable
 
+            * `AUC` - area under curve
             * `RO` - receptor occupancy
             * `FUP` - faction unbound plasma
             * `BPR` - blood plasma ratio
@@ -5480,12 +5481,14 @@ components:
       - subjects
     TypeEnum:
       enum:
+      - AUC
       - RO
       - FUP
       - BPR
       - TLG
       type: string
       description: |-
+        * `AUC` - area under curve
         * `RO` - receptor occupancy
         * `FUP` - faction unbound plasma
         * `BPR` - blood plasma ratio


### PR DESCRIPTION
A demo version of the new secondary parameters feature in the frontend.
- new `AUC` derived variable type in the combined model.
- 'secondary parameters' checkboxes in the Model view. Enable secondary parameters for any concentration variable in the model.
- edit time intervals in the Model view, and set thresholds for variables.
- a Results view showing a table of secondary parameter values for each group and variable.
- a new `SimulationContext` to share simulation outputs across the Simulation and Results views.