### PR TITLE
refactor(frontend): remove dummy time intervals and thresholds

### DIFF
--- a/frontend-v2/src/App.tsx
+++ b/frontend-v2/src/App.tsx
@@ -25,32 +25,9 @@ export type TimeInterval = {
 type Threshold = { lower: number; upper: number };
 export type Thresholds = { [key: string]: Threshold };
 
-const TIME_INTERVALS: TimeInterval[] = [
-  { start: 0, end: 168, unit: "h" },
-  { start: 168, end: 336, unit: "h" },
-  { start: 336, end: 504, unit: "h" },
-  { start: 504, end: 672, unit: "h" },
-  { start: 672, end: 840, unit: "h" },
-];
+const TIME_INTERVALS: TimeInterval[] = [];
 
-const THRESHOLDS: Thresholds = {
-  C1: {
-    lower: 1e4,
-    upper: Infinity,
-  },
-  C1_t: {
-    lower: 5e4,
-    upper: Infinity,
-  },
-  CT1_f: {
-    lower: 200,
-    upper: Infinity,
-  },
-  CT1_b: {
-    lower: 900,
-    upper: Infinity,
-  },
-};
+const THRESHOLDS: Thresholds = {};
 
 function App() {
   const dispatch = useAppDispatch();

--- a/frontend-v2/src/features/results/useParameters.tsx
+++ b/frontend-v2/src/features/results/useParameters.tsx
@@ -83,7 +83,9 @@ export function useParameters() {
           simulation,
           intervalIndex,
         );
-        return formattedNumber(Math.min(...intervalValues));
+        return intervalValues
+          ? formattedNumber(Math.min(...intervalValues))
+          : 0;
       },
     },
     {
@@ -99,7 +101,9 @@ export function useParameters() {
           simulation,
           intervalIndex,
         );
-        return formattedNumber(Math.max(...intervalValues));
+        return intervalValues
+          ? formattedNumber(Math.max(...intervalValues))
+          : 0;
       },
     },
     {
@@ -140,14 +144,16 @@ export function useParameters() {
           simulation,
           intervalIndex,
         );
-        return formattedNumber(
-          timeOverLowerThresholdPerInterval(
-            intervalValues,
-            intervalTimes,
-            variable,
-            thresholds,
-          ),
-        );
+        return intervalValues
+          ? formattedNumber(
+              timeOverLowerThresholdPerInterval(
+                intervalValues,
+                intervalTimes,
+                variable,
+                thresholds,
+              ),
+            )
+          : 0;
       },
     },
     {
@@ -167,14 +173,16 @@ export function useParameters() {
           simulation,
           intervalIndex,
         );
-        return formattedNumber(
-          timeOverUpperThresholdPerInterval(
-            intervalValues,
-            intervalTimes,
-            variable,
-            thresholds,
-          ),
-        );
+        return intervalValues
+          ? formattedNumber(
+              timeOverUpperThresholdPerInterval(
+                intervalValues,
+                intervalTimes,
+                variable,
+                thresholds,
+              ),
+            )
+          : 0;
       },
     },
     {
@@ -194,20 +202,22 @@ export function useParameters() {
           simulation,
           intervalIndex,
         );
-        return formattedNumber(
-          timeOverLowerThresholdPerInterval(
-            intervalValues,
-            intervalTimes,
-            variable,
-            thresholds,
-          ) -
-            timeOverUpperThresholdPerInterval(
-              intervalValues,
-              intervalTimes,
-              variable,
-              thresholds,
-            ),
-        );
+        return intervalValues
+          ? formattedNumber(
+              timeOverLowerThresholdPerInterval(
+                intervalValues,
+                intervalTimes,
+                variable,
+                thresholds,
+              ) -
+                timeOverUpperThresholdPerInterval(
+                  intervalValues,
+                  intervalTimes,
+                  variable,
+                  thresholds,
+                ),
+            )
+          : 0;
       },
     },
   ] as Parameter[];


### PR DESCRIPTION
- Remove dummy data for secondary parameters.
- Update `useParameters` for the case where we haven't defined any intervals yet.