### PR TITLE
fix(frontend): set defaults for data-fetching hooks

### DIFF
--- a/frontend-v2/src/features/results/useParameters.tsx
+++ b/frontend-v2/src/features/results/useParameters.tsx
@@ -105,7 +105,7 @@ export function useParameters() {
   const [baseIntervals] = useModelTimeIntervals();
   const baseVariables = useVariables();
   const intervals = useNormalisedIntervals(baseIntervals);
-  const variables = useNormalisedVariables(baseVariables || []);
+  const variables = useNormalisedVariables(baseVariables);
   return [
     {
       name: "Min",

--- a/frontend-v2/src/features/results/useUnits.ts
+++ b/frontend-v2/src/features/results/useUnits.ts
@@ -19,5 +19,5 @@ export function useUnits() {
     { compoundId: project?.compound },
     { skip: !project || !project.compound },
   );
-  return units;
+  return units || [];
 }

--- a/frontend-v2/src/features/results/useVariables.ts
+++ b/frontend-v2/src/features/results/useVariables.ts
@@ -20,5 +20,5 @@ export function useVariables() {
     { dosedPkModelId: model?.id || 0 },
     { skip: !model?.id },
   );
-  return variables;
+  return variables || [];
 }


### PR DESCRIPTION
Return empty arrays by default from `useUnits` and `useVariables`.