### PR TITLE
refactor(frontend): Results table

### DIFF
--- a/frontend-v2/src/features/model/secondary/ThresholdsTable.tsx
+++ b/frontend-v2/src/features/model/secondary/ThresholdsTable.tsx
@@ -124,6 +124,7 @@ function VariableRow({
           type="number"
           defaultValue={variable.lower_threshold || 0}
           onChange={onChangeLowerThreshold}
+          size="small"
         />
       </TableCell>
       <TableCell>
@@ -131,10 +132,11 @@ function VariableRow({
           type="number"
           defaultValue={variable.upper_threshold || Infinity}
           onChange={onChangeUpperThreshold}
+          size="small"
         />
       </TableCell>
       <TableCell>
-        <Select value={unitSymbol} onChange={onChangeUnit}>
+        <Select value={unitSymbol} onChange={onChangeUnit} size="small">
           {unit?.compatible_units?.map((unit) => (
             <MenuItem key={unit.id} value={unit.symbol}>
               {unit.symbol}

--- a/frontend-v2/src/features/results/ResultsTab.tsx
+++ b/frontend-v2/src/features/results/ResultsTab.tsx
@@ -1,6 +1,5 @@
 import { FC, useState } from "react";
 import {
-  Box,
   FormControl,
   InputLabel,
   MenuItem,
@@ -16,65 +15,6 @@ import { useConcentrationVariables } from "./useConcentrationVariables";
 import { useParameters, Parameter } from "./useParameters";
 import { ResultsTable } from "./ResultsTable";
 import { useModelTimeIntervals } from "../../hooks/useModelTimeIntervals";
-import { useUnits } from "./useUnits";
-
-function TimeUnitSelect({
-  timeUnit,
-  onChangeTimeUnit,
-}: {
-  timeUnit: string;
-  onChangeTimeUnit: (event: SelectChangeEvent) => void;
-}) {
-  const units = useUnits();
-  const timeUnits = units?.find(
-    (unit) => unit.symbol === "h",
-  )?.compatible_units;
-  return (
-    <FormControl size="small">
-      <InputLabel id="time-unit-label">Time Unit</InputLabel>
-      <Select
-        labelId="time-unit-label"
-        value={timeUnit}
-        onChange={onChangeTimeUnit}
-      >
-        {timeUnits?.map((unit) => (
-          <MenuItem key={unit.id} value={unit.symbol}>
-            {unit.symbol}
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
-  );
-}
-
-function ConcentrationUnitSelect({
-  concentrationUnit,
-  onChangeConcentrationUnit,
-}: {
-  concentrationUnit: string;
-  onChangeConcentrationUnit: (event: SelectChangeEvent) => void;
-}) {
-  const units = useUnits();
-  const concentrationUnits = units?.find(
-    (unit) => unit.symbol === "pmol/L",
-  )?.compatible_units;
-  return (
-    <FormControl size="small">
-      <InputLabel id="conc-unit-label">Concentration Unit</InputLabel>
-      <Select
-        labelId="conc-unit-label"
-        value={concentrationUnit}
-        onChange={onChangeConcentrationUnit}
-      >
-        {concentrationUnits?.map((unit) => (
-          <MenuItem key={unit.id} value={unit.symbol}>
-            {unit.symbol}
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
-  );
-}
 
 const options = [
   { name: "Parameters", value: "parameters" },
@@ -103,22 +43,10 @@ type RowFilter = {
 };
 
 const ResultsTab: FC = () => {
-  const [timeUnit, setTimeUnit] = useState("h");
-  const [concentrationUnit, setConcentrationUnit] = useState("pmol/L");
-  function onChangeTimeUnit(event: SelectChangeEvent) {
-    setTimeUnit(event.target.value);
-  }
-  function onChangeConcentrationUnit(event: SelectChangeEvent) {
-    setConcentrationUnit(event.target.value);
-  }
-
   const { groups = [] } = useSubjectGroups();
   const [intervals] = useModelTimeIntervals();
   const concentrationVariables = useConcentrationVariables();
-  const parameters = useParameters({
-    variableUnit: concentrationUnit,
-    timeUnit,
-  });
+  const parameters = useParameters();
 
   const [columns, setColumns] = useState("parameters");
   const [rows, setRows] = useState("variables");
@@ -360,27 +288,7 @@ const ResultsTab: FC = () => {
           intervalIndex={intervalIndex}
           rows={rowData}
           rowColumn={rowColumn}
-          concentrationUnit={concentrationUnit}
-          timeUnit={timeUnit}
-        >
-          <Box
-            sx={{
-              justifyContent: "flex-end",
-              display: "flex",
-              mt: "1rem",
-              gap: "0.5rem",
-            }}
-          >
-            <ConcentrationUnitSelect
-              concentrationUnit={concentrationUnit}
-              onChangeConcentrationUnit={onChangeConcentrationUnit}
-            />
-            <TimeUnitSelect
-              timeUnit={timeUnit}
-              onChangeTimeUnit={onChangeTimeUnit}
-            />
-          </Box>
-        </ResultsTable>
+        />
       </>
     );
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/frontend-v2/src/features/results/ResultsTable.tsx
+++ b/frontend-v2/src/features/results/ResultsTable.tsx
@@ -6,11 +6,11 @@ import {
   TableHead,
   TableRow,
 } from "@mui/material";
-import { FC, ReactElement } from "react";
+import { FC } from "react";
 
 import useSubjectGroups from "../../hooks/useSubjectGroups";
 
-import { useParameters } from "./useParameters";
+import { useParameterNames } from "./useParameters";
 import { useConcentrationVariables } from "./useConcentrationVariables";
 
 import { FilterIndex, RowData } from "./ResultsTab";
@@ -77,9 +77,6 @@ interface ResultsTableProps {
   parameterIndex: FilterIndex;
   rows: RowData;
   rowColumn: string;
-  concentrationUnit: string;
-  timeUnit: string;
-  children?: ReactElement;
 }
 
 /**
@@ -92,8 +89,6 @@ interface ResultsTableProps {
  * @param parameterIndex "rows" or "columns" or the index of the parameter to display in the table.
  * @param rows an array of row data.
  * @param rowColumn The name of the row column.
- * @param concentrationUnit The unit of the displayed concentration values.
- * @param timeUnit The unit of the displayed time values.
  */
 export const ResultsTable: FC<ResultsTableProps> = ({
   groupIndex,
@@ -102,15 +97,9 @@ export const ResultsTable: FC<ResultsTableProps> = ({
   parameterIndex,
   rows = [],
   rowColumn = "",
-  concentrationUnit = "pmol/L",
-  timeUnit = "h",
-  children,
 }) => {
   const { groups } = useSubjectGroups();
-  const parameters = useParameters({
-    variableUnit: concentrationUnit,
-    timeUnit,
-  });
+  const parameterNames = useParameterNames();
   const concentrationVariables = useConcentrationVariables();
   const [intervals] = useModelTimeIntervals();
   const tableRows = useTableRows({
@@ -119,8 +108,6 @@ export const ResultsTable: FC<ResultsTableProps> = ({
     intervalIndex,
     variableIndex,
     parameterIndex,
-    concentrationUnit,
-    timeUnit,
   });
 
   if (!rows[0]) {
@@ -130,7 +117,7 @@ export const ResultsTable: FC<ResultsTableProps> = ({
   try {
     const columnHeadings =
       parameterIndex === "columns"
-        ? parameters.map((parameter) => parameter.name)
+        ? parameterNames
         : variableIndex === "columns"
           ? concentrationVariables.map((variable) => variable.name)
           : intervalIndex === "columns"
@@ -168,7 +155,6 @@ export const ResultsTable: FC<ResultsTableProps> = ({
             ))}
           </TableBody>
         </Table>
-        {children}
       </TableContainer>
     );
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/frontend-v2/src/features/results/columns.tsx
+++ b/frontend-v2/src/features/results/columns.tsx
@@ -18,6 +18,10 @@ interface ParametersProps {
   intervals: TimeIntervalRead[];
 }
 
+/**
+ * Generate a list of table columns. Each column has a header, and a value function
+ * that returns the formatted value for each row in that column.
+ */
 export function columns({
   variable,
   aucVariable,
@@ -29,6 +33,7 @@ export function columns({
   interval,
   intervals = [],
 }: ParametersProps) {
+  // variables as colummns
   if (parameter && !variable) {
     return concentrationVariables.map((variable) => {
       return {
@@ -37,6 +42,7 @@ export function columns({
       };
     });
   }
+  // time intervals as columns
   if (parameter && !interval) {
     return intervals.map((interval) => {
       return {
@@ -45,6 +51,7 @@ export function columns({
       };
     });
   }
+  // simulations (groups) as columns
   if (parameter && !simulation) {
     return simulations.map(() => {
       return {
@@ -53,12 +60,13 @@ export function columns({
       };
     });
   }
+  // secondary parameters as columns
   if (simulation && variable && !parameter) {
     return parameters.map((parameter) => {
       return {
         header: parameter.name,
-        value: (intervalIndex: number) =>
-          parameter.value(intervalIndex, simulation, variable, aucVariable),
+        value: (interval: TimeIntervalRead) =>
+          parameter.value(interval, simulation, variable, aucVariable),
       };
     });
   }

--- a/frontend-v2/src/features/results/useTableRows.ts
+++ b/frontend-v2/src/features/results/useTableRows.ts
@@ -16,8 +16,6 @@ interface TableRowsProps {
   intervalIndex: FilterIndex;
   variableIndex: FilterIndex;
   parameterIndex: FilterIndex;
-  concentrationUnit?: string;
-  timeUnit?: string;
 }
 export function useTableRows({
   rows,
@@ -25,15 +23,10 @@ export function useTableRows({
   intervalIndex,
   variableIndex,
   parameterIndex,
-  concentrationUnit = "pmol/L",
-  timeUnit = "h",
 }: TableRowsProps) {
   const units = useUnits();
   const variables = useVariables();
-  const parameters = useParameters({
-    variableUnit: concentrationUnit,
-    timeUnit,
-  });
+  const parameters = useParameters();
   const concentrationVariables = useConcentrationVariables();
   const { simulations } = useContext(SimulationContext);
   const [intervals] = useModelTimeIntervals();

--- a/frontend-v2/src/features/results/utils.ts
+++ b/frontend-v2/src/features/results/utils.ts
@@ -210,7 +210,7 @@ export function tableRow({
   });
   const values = tableColumns.map((column, index) => {
     return column.value(
-      interval ? intervals.indexOf(interval) : index,
+      interval ? interval : intervals[index],
       simulation ? simulation : simulations[index],
       variable ? variable : concentrationVariables[index],
     );


### PR DESCRIPTION
- Change secondary parameters to take an interval, rather than an array index, in order to match how other table cell parameters are passed around.
- Remove the unit selects from the `ResultsTable` component, so that units are set under Model > Secondary Parameters.
- Only allow one selected time unit for all time intervals.