### PR TITLE
fix(frontend): validate time intervals

### DIFF
--- a/frontend-v2/src/features/model/secondary/TimeIntervalsTable.tsx
+++ b/frontend-v2/src/features/model/secondary/TimeIntervalsTable.tsx
@@ -114,6 +114,8 @@ function IntervalRow({
           value={start}
           onChange={onChangeStart}
           size="small"
+          error={start > end}
+          helperText={start > end ? "Start time must be before end time" : ""}
         />
       </TableCell>
       <TableCell>
@@ -122,6 +124,8 @@ function IntervalRow({
           value={end}
           onChange={onChangeEnd}
           size="small"
+          error={end < start}
+          helperText={end < start ? "End time must be after start time" : ""}
         />
       </TableCell>
       <TableCell>


### PR DESCRIPTION
Validate that `end_time` is after `start_time` for each time interval.