### PR TITLE
fix(frontend): undefined values crash the app

### DIFF
--- a/frontend-v2/src/features/results/useParameters.tsx
+++ b/frontend-v2/src/features/results/useParameters.tsx
@@ -137,7 +137,7 @@ export function useParameters() {
   }
 
   function timeConversionFactor(interval: TimeIntervalRead) {
-    const displayUnit = units?.find((unit) => unit.id === interval.unit);
+    const displayUnit = units?.find((unit) => unit.id === interval?.unit);
     const modelUnit = displayUnit?.compatible_units.find(
       (u) => u.symbol === "h",
     );

--- a/frontend-v2/src/features/results/utils.ts
+++ b/frontend-v2/src/features/results/utils.ts
@@ -33,7 +33,13 @@ export function valuesPerInterval(
 ) {
   const times = simulation?.time || [];
   const tMax = times[times.length - 1];
-  const values = variable && simulation ? simulation.outputs[variable.id] : [];
+  if (!variable || !simulation) {
+    return timeIntervals.map(() => []);
+  }
+  if (!simulation.outputs[variable.id]) {
+    return timeIntervals.map(() => []);
+  }
+  const values = simulation.outputs[variable.id];
   return timeIntervals.map((interval) => {
     if (values.length === 0) {
       return [];


### PR DESCRIPTION
Catch undefined values in a couple of places, where they could crash the whole app if either:
- there are no time intervals defined for a model.
- a selected variable doesn't exist in `simulation.outputs`.