### PR TITLE
feat(frontend): add start and end as secondary parameters

### DIFF
--- a/frontend-v2/src/features/results/columns.tsx
+++ b/frontend-v2/src/features/results/columns.tsx
@@ -65,8 +65,7 @@ export function columns({
     return parameters.map((parameter) => {
       return {
         header: parameter.name,
-        value: (interval: TimeIntervalRead) =>
-          parameter.value(interval, simulation, variable, aucVariable),
+        value: parameter.value,
       };
     });
   }

--- a/frontend-v2/src/features/results/useParameters.tsx
+++ b/frontend-v2/src/features/results/useParameters.tsx
@@ -147,6 +147,42 @@ export function useParameters() {
 
   return [
     {
+      name: "Start",
+      value(
+        interval: TimeIntervalRead,
+        simulation: SimulateResponse,
+        variable: VariableRead,
+      ) {
+        const [intervalValues] = variablePerInterval(
+          intervals,
+          variable,
+          simulation,
+          interval,
+        );
+        const start = intervalValues ? intervalValues[0] : 0;
+        return formattedNumber(start / variableConversionFactor(variable));
+      },
+    },
+    {
+      name: "End",
+      value(
+        interval: TimeIntervalRead,
+        simulation: SimulateResponse,
+        variable: VariableRead,
+      ) {
+        const [intervalValues] = variablePerInterval(
+          intervals,
+          variable,
+          simulation,
+          interval,
+        );
+        const end = intervalValues
+          ? intervalValues[intervalValues.length - 1]
+          : 0;
+        return formattedNumber(end / variableConversionFactor(variable));
+      },
+    },
+    {
       name: "Min",
       value(
         interval: TimeIntervalRead,


### PR DESCRIPTION
Two new parameters: the values of each variable at the start and end of each interval.