### PR TITLE
fix(frontend): app crashes when intervals is empty

### DIFF
--- a/frontend-v2/src/features/results/useParameters.tsx
+++ b/frontend-v2/src/features/results/useParameters.tsx
@@ -77,7 +77,7 @@ const variablePerInterval = (
     variable,
     simulation,
   );
-  const intervalIndex = intervals.findIndex((i) => i.id === interval.id);
+  const intervalIndex = intervals.findIndex((i) => i.id === interval?.id);
   const intervalValues = variableValuesPerInterval[intervalIndex];
   const timePerInterval = timesPerInterval(simulation.time, intervals);
   const intervalTimes = timePerInterval[intervalIndex];


### PR DESCRIPTION
FIx another crash that can happen when the current time interval is undefined.