### PR TITLE
fix(frontend): interpolation errors for secondary parameters

### DIFF
--- a/frontend-v2/src/features/results/utils.ts
+++ b/frontend-v2/src/features/results/utils.ts
@@ -8,6 +8,8 @@ import {
 import { Parameter } from "./useParameters";
 import { columns } from "./columns";
 
+const TOLERANCE = 1e-8;
+
 /**
  * Given x0 in the range [x[0], x[1]], return the linearly interpolated value y0 in the range [y[0], y[1]].
  * @param x
@@ -48,6 +50,9 @@ export function valuesPerInterval(
     const endTime = Math.min(tMax, interval.end_time);
     const startIndex = times.findIndex((t) => t >= startTime);
     const endIndex = times.findIndex((t) => t >= endTime);
+    if (startIndex === endIndex) {
+      return [values[startIndex], values[endIndex]];
+    }
     const start =
       startIndex > 0
         ? interpolate(
@@ -89,6 +94,9 @@ export function timesPerInterval(
     const endTime = Math.min(tMax, interval.end_time);
     const startIndex = times.findIndex((t) => t >= startTime);
     const endIndex = times.findIndex((t) => t >= endTime);
+    if (startIndex === endIndex) {
+      return [times[startIndex], times[endIndex]];
+    }
     const intervalTimes = [
       startTime,
       ...times.slice(startIndex + 1, endIndex - 1),
@@ -176,6 +184,9 @@ export function formattedNumber(
   lowerThreshold: number = 1e-3,
 ) {
   if (value === 0) {
+    return "0.000";
+  }
+  if (Math.abs(value) < TOLERANCE) {
     return "0.000";
   }
   return value > upperThreshold || value < lowerThreshold


### PR DESCRIPTION
- Set an error tolerance of 1e-8 and treat smaller values as zero.
- Add exceptions to handle the case where an interval has a duration of zero.