### PR TITLE
fix(frontend): y-axis REF variables

### DIFF
--- a/frontend-v2/src/features/simulation/SimulationPlotView.tsx
+++ b/frontend-v2/src/features/simulation/SimulationPlotView.tsx
@@ -442,10 +442,10 @@ const SimulationPlotView: FC<SimulationPlotProps> = ({
 
   const yAxisVariables = plotData
     .filter((d) => !d.yaxis)
-    .map((d) => d.name?.split(" ")[0]);
+    .map((d) => d.name?.replace("REF ", "").split(" ")[0]);
   const y2AxisVariables = plotData
     .filter((d) => d.yaxis)
-    .map((d) => d.name?.split(" ")[0]);
+    .map((d) => d.name?.replace("REF ", "").split(" ")[0]);
   let yAxisTitle = [...new Set(yAxisVariables)].join(", ");
   let y2AxisTitle = [...new Set(y2AxisVariables)].join(", ");
   let xAxisTitle = "Time";


### PR DESCRIPTION
When a plot is a reference plot, the variable name is displayed as `REF` on the y-axis. This fixes that by trimming the `REF ` prefix from y-axis plot names before finding the variable name.