### PR TITLE
refactor(frontend) align data upload dosing with Trial Design 

### DIFF
--- a/frontend-v2/src/features/data/DosingProtocols.tsx
+++ b/frontend-v2/src/features/data/DosingProtocols.tsx
@@ -154,6 +154,9 @@ const DosingProtocols: FC<IDosingProtocols> = ({
                   <Typography>{administrationIdField}</Typography>
                 </TableCell>
                 <TableCell>
+                  <Typography>Group ID</Typography>
+                </TableCell>
+                <TableCell>
                   <Typography>Dosing Compartment</Typography>
                 </TableCell>
                 <TableCell>
@@ -198,6 +201,9 @@ const DosingProtocols: FC<IDosingProtocols> = ({
                 return (
                   <TableRow key={adminId}>
                     <TableCell sx={{ width: "5rem" }}>{adminId}</TableCell>
+                    <TableCell sx={{ width: "5rem" }}>
+                      <Typography>{currentRow?.["Group ID"] || "."}</Typography>
+                    </TableCell>
                     <TableCell sx={{ width: "10rem" }}>
                       <FormControl fullWidth>
                         <InputLabel

--- a/frontend-v2/src/features/data/DosingProtocols.tsx
+++ b/frontend-v2/src/features/data/DosingProtocols.tsx
@@ -38,7 +38,7 @@ interface IDosingProtocols {
   };
 }
 
-function findFieldByName(name: string, state: StepperState) {
+function findFieldByType(name: string, state: StepperState) {
   return (
     state.fields.find((field) => state.normalisedFields.get(field) === name) ||
     name
@@ -54,12 +54,12 @@ const DosingProtocols: FC<IDosingProtocols> = ({
   variables,
   notificationsInfo,
 }: IDosingProtocols) => {
-  const amountField = findFieldByName("Amount", state);
-  const amountVariableField = findFieldByName("Amount Variable", state);
-  const timeField = findFieldByName("Time", state);
-  const timeUnitField = findFieldByName("Time Unit", state);
-  const addlDosesField = findFieldByName("Additional Doses", state);
-  const interDoseField = findFieldByName("Interdose Interval", state);
+  const amountField = findFieldByType("Amount", state);
+  const amountVariableField = findFieldByType("Amount Variable", state);
+  const timeField = findFieldByType("Time", state);
+  const timeUnitField = findFieldByType("Time Unit", state);
+  const addlDosesField = findFieldByType("Additional Doses", state);
+  const interDoseField = findFieldByType("Interdose Interval", state);
   const dosingRows: Row[] = amountField
     ? state.data.filter(
         (row) =>

--- a/frontend-v2/src/features/data/MapDosing.tsx
+++ b/frontend-v2/src/features/data/MapDosing.tsx
@@ -7,6 +7,7 @@ import { RootState } from "../../app/store";
 import {
   useCombinedModelListQuery,
   useProjectRetrieveQuery,
+  useProtocolListQuery,
   useUnitListQuery,
   useVariableListQuery,
 } from "../../app/backendApi";
@@ -34,6 +35,8 @@ const MapDosing: FC<IMapDosing> = ({
     { skip: !projectId },
   );
   const isPreclinical = project?.species !== "H";
+  const { data: projectProtocols, isLoading: isProtocolsLoading } =
+    useProtocolListQuery({ projectId: projectIdOrZero }, { skip: !projectId });
   const { data: models = [] } = useCombinedModelListQuery(
     { projectId: projectIdOrZero },
     { skip: !projectId },
@@ -79,6 +82,15 @@ const MapDosing: FC<IMapDosing> = ({
     state.setNormalisedFields(newNormalisedFields);
   }
 
+  const dosingCompartments = projectProtocols?.map((protocol) => {
+    return (
+      protocol.mapped_qname ||
+      variables?.find((variable) => variable.id === protocol.variables[0])
+        ?.qname ||
+      ""
+    );
+  });
+
   return hasDosingRows ? (
     <DosingProtocols
       administrationIdField={administrationIdField || ""}
@@ -94,6 +106,7 @@ const MapDosing: FC<IMapDosing> = ({
       administrationIdField={administrationIdField || "Administration ID"}
       amountUnitField={amountUnitField || ""}
       amountUnit={amountUnit}
+      dosingCompartments={dosingCompartments}
       state={state}
       units={units || []}
       variables={variables || []}

--- a/frontend-v2/src/features/data/Stratification.tsx
+++ b/frontend-v2/src/features/data/Stratification.tsx
@@ -51,10 +51,8 @@ function validateGroupProtocols(groups: Group[], protocols: IProtocol[]) {
  */
 function generateAdministrationIds(data: { [key: string]: string }[]) {
   const newData = data.map((row) => ({ ...row }));
-  const uniqueGroupIds = [...new Set(data.map((row) => row["Group ID"]))];
   newData.forEach((row) => {
-    const administrationId = uniqueGroupIds.indexOf(row["Group ID"]) + 1;
-    row["Administration ID"] = `${administrationId}`;
+    row["Administration ID"] = "0";
   });
   return newData;
 }

--- a/frontend-v2/src/features/data/Stratification.tsx
+++ b/frontend-v2/src/features/data/Stratification.tsx
@@ -43,20 +43,6 @@ function validateGroupProtocols(groups: Group[], protocols: IProtocol[]) {
   });
   return groupedProtocols.every((protocols) => protocols.length <= 1);
 }
-
-/**
- * Generate a unique administration ID for each group.
- * @param data
- * @returns data with administration ID column.
- */
-function generateAdministrationIds(data: { [key: string]: string }[]) {
-  const newData = data.map((row) => ({ ...row }));
-  newData.forEach((row) => {
-    row["Administration ID"] = "0";
-  });
-  return newData;
-}
-
 /**
  * Assign a group ID to each row based on a categorical covariate column.
  * @param data
@@ -96,9 +82,6 @@ const Stratification: FC<IStratification> = ({
     const values = state.data.map((row) => row[field]);
     return [...new Set(values)];
   });
-  const administrationIdField = state.fields.find(
-    (field) => state.normalisedFields.get(field) === "Administration ID",
-  );
 
   const [firstRow] = state.data;
   const [tab, setTab] = useState(0);
@@ -136,10 +119,7 @@ const Stratification: FC<IStratification> = ({
   }
 
   if (!firstRow["Group ID"]) {
-    let newData = groupDataRows(state.data, groupColumn);
-    if (!administrationIdField) {
-      newData = generateAdministrationIds(newData);
-    }
+    const newData = groupDataRows(state.data, groupColumn);
     state.setData(newData);
     state.setNormalisedFields(
       new Map([...state.normalisedFields.entries(), ["Group ID", "Group ID"]]),
@@ -152,10 +132,7 @@ const Stratification: FC<IStratification> = ({
 
   const handleGroupChange = (event: ChangeEvent<HTMLInputElement>) => {
     const newGroup = event.target.value;
-    let newData = groupDataRows(state.data, newGroup);
-    if (!administrationIdField) {
-      newData = generateAdministrationIds(newData);
-    }
+    const newData = groupDataRows(state.data, newGroup);
     setGroupColumn(newGroup);
     state.setData(newData);
   };

--- a/frontend-v2/src/features/main/Sidebar.tsx
+++ b/frontend-v2/src/features/main/Sidebar.tsx
@@ -109,8 +109,12 @@ export default function Sidebar() {
     );
   };
 
-  const doses = groups?.flatMap((group) => group.protocols.map((p) => p.doses));
-  const groupsAreIncomplete = doses?.some((dosing) => !dosing[0]?.amount);
+  const protocolsAreComplete = groups?.flatMap((group) => {
+    return group.protocols
+      .map((p) => p.doses.every((d) => d.amount > 0))
+      .some((d) => d);
+  });
+  const groupsAreComplete = protocolsAreComplete?.every((dosing) => dosing);
   const noSecondaryParameters = model
     ? model.derived_variables.reduce((acc, dv) => {
         return acc && dv.type !== "AUC";
@@ -123,7 +127,7 @@ export default function Sidebar() {
     errors[PageName.MODEL] =
       "Model is incomplete, see the Model tab for details";
   }
-  if (groupsAreIncomplete) {
+  if (!groupsAreComplete) {
     warnings[PageName.TRIAL_DESIGN] =
       "Trial design is incomplete, one or more dose amounts are zero";
   }
@@ -471,7 +475,7 @@ export default function Sidebar() {
               fontWeight: "bold",
               paddingLeft: "1rem",
               fontFamily: "Comfortaa",
-              flexGrow: project ? 0 : 1
+              flexGrow: project ? 0 : 1,
             }}
           >
             pkpd explorer


### PR DESCRIPTION
When uploading data without any dosing rows, use the project dosing protocols to determine the default dosing compartments. Previously, an uploaded subject group could only be mapped to a single dosing compartment, even if the model allowed for both IV and SC dosing. With the changes here, subject groups can be dosed from each compartment linked to the model (when an uploaded CSV doesn't have any dosing rows.)

Alter the dosing check in the sidebar so that it only flags up a group if none of that group's protocols have a dose set, rather than checking if any doses are 0. 