### PR TITLE
build(deps): upgrade react-toastify to v11

### DIFF
--- a/frontend-v2/package.json
+++ b/frontend-v2/package.json
@@ -20,7 +20,7 @@
     "react-player": "^2.16.0",
     "react-plotly.js": "^2.6.0",
     "react-redux": "^9.2.0",
-    "react-toastify": "^9.1.3"
+    "react-toastify": "^11.0.3"
   },
   "scripts": {
     "start": "npx tsc && vite",

--- a/frontend-v2/src/hooks/useCustomToast.tsx
+++ b/frontend-v2/src/hooks/useCustomToast.tsx
@@ -11,9 +11,9 @@ type ToastProps = {
 
 const defaultOptions: ToastOptions = {
   autoClose: Infinity,
-  position: toast.POSITION.TOP_RIGHT,
+  position: "top-right",
   pauseOnFocusLoss: false,
-  type: toast.TYPE.DEFAULT,
+  type: "default",
   pauseOnHover: false,
   closeButton: false,
   hideProgressBar: true,

--- a/frontend-v2/yarn.lock
+++ b/frontend-v2/yarn.lock
@@ -4353,13 +4353,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clsx@npm:^1.1.1":
-  version: 1.2.1
-  resolution: "clsx@npm:1.2.1"
-  checksum: 10c0/34dead8bee24f5e96f6e7937d711978380647e936a22e76380290e35486afd8634966ce300fc4b74a32f3762c7d4c0303f442c3e259f4ce02374eb0c82834f27
-  languageName: node
-  linkType: hard
-
 "clsx@npm:^2.1.1":
   version: 2.1.1
   resolution: "clsx@npm:2.1.1"
@@ -5969,7 +5962,7 @@ __metadata:
     react-player: "npm:^2.16.0"
     react-plotly.js: "npm:^2.6.0"
     react-redux: "npm:^9.2.0"
-    react-toastify: "npm:^9.1.3"
+    react-toastify: "npm:^11.0.3"
     start-server-and-test: "npm:^2.0.10"
     typescript: "npm:^5.7.3"
     typescript-eslint: "npm:^7.18.0"
@@ -8597,15 +8590,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-toastify@npm:^9.1.3":
-  version: 9.1.3
-  resolution: "react-toastify@npm:9.1.3"
+"react-toastify@npm:^11.0.3":
+  version: 11.0.3
+  resolution: "react-toastify@npm:11.0.3"
   dependencies:
-    clsx: "npm:^1.1.1"
+    clsx: "npm:^2.1.1"
   peerDependencies:
-    react: ">=16"
-    react-dom: ">=16"
-  checksum: 10c0/51de1e51e9357a24773fbcd45a4db18bf74b8ec40d86a2bfb4a4fee23ca4f9fffdac5dfb7a3c21baea39971f72f72dfcdc79403a6de006f74d69e7bc12f8b3e0
+    react: ^18 || ^19
+    react-dom: ^18 || ^19
+  checksum: 10c0/23b989c6080bc5bf0eb0c1f7ed17bd53d067d9beb33baf93c520119cd69cf75c9f2d1ee524dfe6c8a2a5d326029772b576de00e018b379d03a0e37630b83adea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes a bug where the Model tab crashes because `react-toastify` 9 is incompatible with React 19.