### PR TITLE
build(deps): upgrade to Plotly v3

### DIFF
--- a/frontend-v2/package.json
+++ b/frontend-v2/package.json
@@ -12,7 +12,7 @@
     "@mui/x-data-grid": "^7.27.1",
     "@reduxjs/toolkit": "^2.6.0",
     "papaparse": "^5.5.2",
-    "plotly.js-basic-dist-min": "^2.35.3",
+    "plotly.js-basic-dist-min": "^3.0.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-dropzone": "^14.3.8",

--- a/frontend-v2/src/features/simulation/utils.ts
+++ b/frontend-v2/src/features/simulation/utils.ts
@@ -518,20 +518,26 @@ export const getPlotAxes = ({
   const { rangey, rangey2 } = ranges(minY, maxY, minY2, maxY2, plot);
   return {
     xaxis: {
-      title: xAxisTitle,
+      title: {
+        text: xAxisTitle,
+      },
       automargin: true,
       exponentformat: "power",
       ...axisScaleOptions[plot.x_scale || "lin"],
     },
     yaxis: {
-      title: yAxisTitle,
+      title: {
+        text: yAxisTitle,
+      },
       automargin: true,
       range: rangey,
       exponentformat: "power",
       ...axisScaleOptions[plot.y_scale || "lin"],
     },
     yaxis2: {
-      title: y2AxisTitle,
+      title: {
+        text: y2AxisTitle,
+      },
       anchor: "free",
       range: rangey2,
       overlaying: "y",

--- a/frontend-v2/yarn.lock
+++ b/frontend-v2/yarn.lock
@@ -6067,7 +6067,7 @@ __metadata:
     eslint-plugin-react-hooks: "npm:^4.6.2"
     openapi-types: "npm:^12.1.3"
     papaparse: "npm:^5.5.2"
-    plotly.js-basic-dist-min: "npm:^2.35.3"
+    plotly.js-basic-dist-min: "npm:^3.0.1"
     prettier: "npm:^3.5.2"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
@@ -8381,10 +8381,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"plotly.js-basic-dist-min@npm:^2.35.3":
-  version: 2.35.3
-  resolution: "plotly.js-basic-dist-min@npm:2.35.3"
-  checksum: 10c0/f62c5558ccd0c96b1ffcad68fc71d75919e6e1539563358af49d7494cf1085b0cc1dbb8f7d3902a8f37fbaf27e400ce6153c5c4af748bab7949830ae868b11ce
+"plotly.js-basic-dist-min@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "plotly.js-basic-dist-min@npm:3.0.1"
+  checksum: 10c0/cb8685870137846cb3a8c8503bcfaee3c9c6443da6daf2f136d006cba2067fdb52f1840b26ca1a50e2dc077eb37d8685b6782f972cc62a8e57b60769b09a568c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- upgrade Plotly to 3.0.1.
- update axes to use title objects, not strings.