### PR TITLE
fix(frontend): use search inputs for plot axis labels

### DIFF
--- a/frontend-v2/src/components/TextField.tsx
+++ b/frontend-v2/src/components/TextField.tsx
@@ -52,6 +52,8 @@ function TextField<T extends FieldValues>({
           // Save an empty string in place of the default value.
           const newValue =
             e.target.value === defaultValue ? "" : e.target.value;
+          // Display the default value in place of an empty field.
+          setFieldValue(newValue === "" ? defaultValue : newValue);
           if (mode === "onBlur" && newValue !== value) {
             onChange({ target: { value: newValue } });
           }

--- a/frontend-v2/src/features/simulation/SimulationPlotForm.tsx
+++ b/frontend-v2/src/features/simulation/SimulationPlotForm.tsx
@@ -228,6 +228,10 @@ const SimulationPlotForm: FC<SimulationPlotFormProps> = ({
   const defaultProps = {
     disabled: isSharedWithMe,
   };
+  const axisLabelProps = {
+    ...defaultProps,
+    type: "search",
+  };
 
   return (
     <Stack>
@@ -246,7 +250,7 @@ const SimulationPlotForm: FC<SimulationPlotFormProps> = ({
           label="X Axis Label"
           name={`plots.${index}.x_label`}
           control={control}
-          textFieldProps={defaultProps}
+          textFieldProps={axisLabelProps}
           defaultValue={xAxisTitle}
         />
         <SelectField
@@ -287,7 +291,7 @@ const SimulationPlotForm: FC<SimulationPlotFormProps> = ({
           label="Y Axis Label"
           name={`plots.${index}.y_label`}
           control={control}
-          textFieldProps={defaultProps}
+          textFieldProps={axisLabelProps}
           defaultValue={yAxisTitle}
         />
         <SelectField
@@ -411,7 +415,7 @@ const SimulationPlotForm: FC<SimulationPlotFormProps> = ({
           label="Y2 Axis Label"
           name={`plots.${index}.y2_label`}
           control={control}
-          textFieldProps={defaultProps}
+          textFieldProps={axisLabelProps}
           defaultValue={y2AxisTitle}
         />
         <SelectField


### PR DESCRIPTION
- use a search field for plot axis labels, so that we can quickly delete the label, if necessary.
- on blur, display the default label if the search field is empty.