### PR TITLE
refactor(frontend): MMT function highlighting

### DIFF
--- a/frontend-v2/src/features/model/mmt.js
+++ b/frontend-v2/src/features/model/mmt.js
@@ -35,18 +35,6 @@ export default function mmt(hljs) {
       keyword: "model PDCompartment PKCompartment environment",
     },
   };
-  // field: value
-  const METADATA_MODE = {
-    scope: "meta",
-    begin: [/\s*/, /\w+/, /:\s*/, /.+$/],
-    beginScope: { 2: "keyword", 4: "comment" },
-    keywords: {
-      $pattern: hljs.IDENT_RE,
-      keyword: "author name desc",
-    },
-    end: /\w\n/,
-    endsWithParent: true,
-  };
   // (PD|PK)Compartment.variable
   const SCOPED_VARIABLE_MODE = {
     begin: [/(PD|PK)Compartment/, /\./, hljs.UNDERSCORE_IDENT_RE],
@@ -75,6 +63,12 @@ export default function mmt(hljs) {
     beginScope: { 1: "punctuation", 2: "comment" },
     end: /\n/,
   };
+  // field: description
+  const METADATA_MODE = {
+    scope: "meta",
+    beginKeywords: "author name desc",
+    contains: [COMMENT_MODE],
+  };
   // in [value] expressions
   const IN_VALUE_MODE = {
     scope: "expression",
@@ -96,7 +90,7 @@ export default function mmt(hljs) {
       keyword: FUNCTIONS,
     },
     contains: [NUMBER_MODE, SCOPED_VARIABLE_MODE, IDENTIFIER_MODE],
-    end: /\)\n/,
+    end: /\)/,
   };
   // dot(variable) = expression : description
   const DOT_VARIABLE_MODE = {

--- a/frontend-v2/src/features/model/mmt.js
+++ b/frontend-v2/src/features/model/mmt.js
@@ -7,6 +7,7 @@ Category: config
 
 const FUNCTIONS = [
   "if",
+  "piecewise",
   "cos",
   "sin",
   "tan",

--- a/frontend-v2/src/features/model/mmt.js
+++ b/frontend-v2/src/features/model/mmt.js
@@ -5,6 +5,23 @@ Description: language definition for Myokit models.
 Category: config
 */
 
+const FUNCTIONS = [
+  "if",
+  "cos",
+  "sin",
+  "tan",
+  "acos",
+  "asin",
+  "atan",
+  "exp",
+  "log",
+  "log10",
+  "sqrt",
+  "abs",
+  "ceil",
+  "floor",
+];
+
 export default function mmt(hljs) {
   // units inside in statements
   const UNIT_RE = /[\w\d*/^]+/;
@@ -70,14 +87,16 @@ export default function mmt(hljs) {
     endScope: "punctuation",
     contains: [NUMBER_MODE, UNIT_MODE],
   };
-  // if(condition, expression, expression)
-  const IF_EXPRESSION_MODE = {
+  // function(...args)
+  const FUNCTION_MODE = {
     scope: "expression",
-    begin: /if\(/,
-    beginScope: "keyword",
+    begin: /\w+\(/,
+    keywords: {
+      $pattern: hljs.IDENT_RE,
+      keyword: FUNCTIONS,
+    },
     contains: [NUMBER_MODE, SCOPED_VARIABLE_MODE, IDENTIFIER_MODE],
     end: /\)\n/,
-    endScope: "keyword",
   };
   // dot(variable) = expression : description
   const DOT_VARIABLE_MODE = {
@@ -94,7 +113,7 @@ export default function mmt(hljs) {
       SCOPED_VARIABLE_MODE,
       IN_VALUE_MODE,
       COMMENT_MODE,
-      IF_EXPRESSION_MODE,
+      FUNCTION_MODE,
       METADATA_MODE,
       IDENTIFIER_MODE,
     ],
@@ -110,7 +129,7 @@ export default function mmt(hljs) {
       SCOPED_VARIABLE_MODE,
       IN_VALUE_MODE,
       COMMENT_MODE,
-      IF_EXPRESSION_MODE,
+      FUNCTION_MODE,
       METADATA_MODE,
       IDENTIFIER_MODE,
     ],


### PR DESCRIPTION
Replace `IF_EXPRESSION_MODE` with `FUNCTION_MODE` in the MMT syntax highlighter, which should recognise any valid pre-defined function.
https://myokit.readthedocs.io/en/stable/syntax/model.html#pre-defined-functions

Fix a small bug where metadata highlighting doesn't always style the description as a comment.