### PR TITLE
feat(frontend): MMT keyword syntax highlighting

### DIFF
--- a/frontend-v2/src/features/model/mmt.js
+++ b/frontend-v2/src/features/model/mmt.js
@@ -47,6 +47,9 @@ export default function mmt(hljs) {
     end: /[\n+\-*/^]?/,
     excludesEnd: true,
   };
+  const KEYWORD_MODE = {
+    beginKeywords: "bind label",
+  };
   const NUMBER_MODE = {
     scope: "number",
     begin: hljs.C_NUMBER_RE,
@@ -126,6 +129,7 @@ export default function mmt(hljs) {
       COMMENT_MODE,
       FUNCTION_MODE,
       METADATA_MODE,
+      KEYWORD_MODE,
       IDENTIFIER_MODE,
     ],
     end: /\n/,


### PR DESCRIPTION
Add `KEYWORD_MODE` for syntax highlighting of MMT `bind` and `label` keywords.