### PR TITLE
refactor(frontend): validate data dosing rows

### DIFF
--- a/frontend-v2/src/features/data/LoadData.tsx
+++ b/frontend-v2/src/features/data/LoadData.tsx
@@ -3,7 +3,11 @@ import Papa from "papaparse";
 import { FC, useCallback } from "react";
 import { useDropzone } from "react-dropzone";
 import MapHeaders from "./MapHeaders";
-import { normaliseHeader, validateState } from "./dataValidation";
+import {
+  normaliseHeader,
+  validateDosingRows,
+  validateState,
+} from "./dataValidation";
 import { StepperState } from "./LoadDataStepper";
 import FileDownloadOutlinedIcon from "@mui/icons-material/FileDownloadOutlined";
 import { TableHeader } from "../../components/TableHeader";
@@ -170,6 +174,15 @@ const LoadData: FC<ILoadDataProps> = ({ state, notificationsInfo }) => {
           state.setGroupColumn(groupColumn);
           state.setErrors(errors);
           state.setWarnings(fieldValidation.warnings);
+          state.setHasDosingRows(
+            validateDosingRows({
+              ...state,
+              data: csvData.data as Data,
+              fields,
+              normalisedFields,
+              normalisedHeaders: [...normalisedFields.values()],
+            }),
+          );
         };
         reader.readAsText(file);
       });

--- a/frontend-v2/src/features/data/LoadData.tsx
+++ b/frontend-v2/src/features/data/LoadData.tsx
@@ -157,13 +157,16 @@ const LoadData: FC<ILoadDataProps> = ({ state, notificationsInfo }) => {
           const normalisedFields = new Map(fields.map(normaliseHeader));
           state.setData(csvData.data as Data);
           state.setNormalisedFields(normalisedFields);
-          const fieldValidation = validateState({
+          // Make a copy of the new state that we can pass to validators.
+          const csvState = {
             ...state,
             data: csvData.data as Data,
             fields,
             normalisedFields,
             normalisedHeaders: [...normalisedFields.values()],
-          });
+          };
+          const fieldValidation = validateState(csvState);
+          state.setHasDosingRows(validateDosingRows(csvState));
           const groupColumn =
             fields.find(
               (field) => normalisedFields.get(field) === "Cat Covariate",
@@ -174,15 +177,6 @@ const LoadData: FC<ILoadDataProps> = ({ state, notificationsInfo }) => {
           state.setGroupColumn(groupColumn);
           state.setErrors(errors);
           state.setWarnings(fieldValidation.warnings);
-          state.setHasDosingRows(
-            validateDosingRows({
-              ...state,
-              data: csvData.data as Data,
-              fields,
-              normalisedFields,
-              normalisedHeaders: [...normalisedFields.values()],
-            }),
-          );
         };
         reader.readAsText(file);
       });

--- a/frontend-v2/src/features/data/LoadDataStepper.tsx
+++ b/frontend-v2/src/features/data/LoadDataStepper.tsx
@@ -56,19 +56,19 @@ type Field = string;
 
 export type StepperState = {
   fileName: string;
+  setFileName: (fileName: string) => void;
   fields: Field[];
   normalisedHeaders: Field[];
   normalisedFields: Map<Field, string>;
+  setNormalisedFields: (normalisedFields: Map<Field, string>) => void;
   data: Data;
+  setData: (data: Data) => void;
   errors: string[];
+  setErrors: (errors: string[]) => void;
   warnings: string[];
+  setWarnings: (warnings: string[]) => void;
   timeUnit?: string;
   setTimeUnit: (timeUnit: string) => void;
-  setFileName: (fileName: string) => void;
-  setNormalisedFields: (fields: Map<Field, string>) => void;
-  setData: (data: Data) => void;
-  setErrors: (errors: string[]) => void;
-  setWarnings: (warnings: string[]) => void;
   amountUnit?: string;
   setAmountUnit: (amountUnit: string) => void;
   groupColumn: string;
@@ -120,15 +120,15 @@ const LoadDataStepper: FC<IStepper> = ({ csv = "", onCancel, onFinish }) => {
 
   const state = {
     fileName,
-    normalisedFields,
-    data,
-    errors,
-    warnings,
-    setErrors,
-    setWarnings,
     setFileName,
+    normalisedFields,
     setNormalisedFields,
+    data,
     setData,
+    errors,
+    setErrors,
+    warnings,
+    setWarnings,
     timeUnit,
     setTimeUnit,
     amountUnit,

--- a/frontend-v2/src/features/data/LoadDataStepper.tsx
+++ b/frontend-v2/src/features/data/LoadDataStepper.tsx
@@ -73,6 +73,8 @@ export type StepperState = {
   setAmountUnit: (amountUnit: string) => void;
   groupColumn: string;
   setGroupColumn: (primaryCohort: string) => void;
+  hasDosingRows: boolean;
+  setHasDosingRows: (hasDosingRows: boolean) => void;
 };
 
 function validateSubjectProtocols(protocols: IProtocol[]) {
@@ -103,6 +105,7 @@ const LoadDataStepper: FC<IStepper> = ({ csv = "", onCancel, onFinish }) => {
   const [timeUnit, setTimeUnit] = useState<string | undefined>(undefined);
   const [amountUnit, setAmountUnit] = useState<string | undefined>(undefined);
   const [groupColumn, setGroupColumn] = useState("Group");
+  const [hasDosingRows, setHasDosingRows] = useState(false);
   const selectedProject = useSelector(
     (state: RootState) => state.main.selectedProject,
   );
@@ -132,6 +135,8 @@ const LoadDataStepper: FC<IStepper> = ({ csv = "", onCancel, onFinish }) => {
     setAmountUnit,
     groupColumn,
     setGroupColumn,
+    hasDosingRows,
+    setHasDosingRows,
     get fields() {
       return [...normalisedFields.keys()];
     },

--- a/frontend-v2/src/features/data/MapDosing.tsx
+++ b/frontend-v2/src/features/data/MapDosing.tsx
@@ -2,6 +2,7 @@ import { FC, useRef } from "react";
 import DosingProtocols from "./DosingProtocols";
 import CreateDosingProtocols from "./CreateDosingProtocols";
 import { StepperState } from "./LoadDataStepper";
+import { validateDosingRows } from "./dataValidation";
 import { useSelector } from "react-redux";
 import { RootState } from "../../app/store";
 import {
@@ -26,9 +27,6 @@ const MapDosing: FC<IMapDosing> = ({
   notificationsInfo,
 }: IMapDosing) => {
   // Derived state from the uploaded CSV data.
-  const amountField = state.fields.find(
-    (field) => state.normalisedFields.get(field) === "Amount",
-  );
   const amountUnitField =
     state.fields.find((field) =>
       ["Amount Unit", "Unit"].includes(state.normalisedFields.get(field) || ""),
@@ -39,10 +37,7 @@ const MapDosing: FC<IMapDosing> = ({
 
   // Check if the uploaded CSV had rows containing non-zero amounts.
   // Use a ref to persist the initial value across renders.
-  const hasDosingRowsRef = useRef(
-    amountField !== undefined &&
-      state.data.every((row) => row[amountField] !== "."),
-  );
+  const hasDosingRowsRef = useRef(validateDosingRows(state));
   const hasDosingRows = hasDosingRowsRef.current;
 
   // Fetch API data.

--- a/frontend-v2/src/features/data/MapDosing.tsx
+++ b/frontend-v2/src/features/data/MapDosing.tsx
@@ -1,8 +1,7 @@
-import { FC, useRef } from "react";
+import { FC } from "react";
 import DosingProtocols from "./DosingProtocols";
 import CreateDosingProtocols from "./CreateDosingProtocols";
 import { StepperState } from "./LoadDataStepper";
-import { validateDosingRows } from "./dataValidation";
 import { useSelector } from "react-redux";
 import { RootState } from "../../app/store";
 import {
@@ -34,11 +33,6 @@ const MapDosing: FC<IMapDosing> = ({
   const administrationIdField = state.fields.find(
     (field) => state.normalisedFields.get(field) === "Administration ID",
   );
-
-  // Check if the uploaded CSV had rows containing non-zero amounts.
-  // Use a ref to persist the initial value across renders.
-  const hasDosingRowsRef = useRef(validateDosingRows(state));
-  const hasDosingRows = hasDosingRowsRef.current;
 
   // Fetch API data.
   const projectId = useSelector(
@@ -72,7 +66,7 @@ const MapDosing: FC<IMapDosing> = ({
   );
 
   const hasInvalidUnits =
-    hasDosingRows &&
+    !!amountUnitField &&
     state.data
       .map((row) => row[amountUnitField])
       .some((symbol) => !units?.find((unit) => unit.symbol === symbol));
@@ -96,7 +90,7 @@ const MapDosing: FC<IMapDosing> = ({
     );
   });
 
-  return hasDosingRows ? (
+  return state.hasDosingRows ? (
     <DosingProtocols
       administrationIdField={administrationIdField || "Administration ID"}
       amountUnitField={amountUnitField}

--- a/frontend-v2/src/features/data/dataValidation.ts
+++ b/frontend-v2/src/features/data/dataValidation.ts
@@ -257,12 +257,20 @@ function validateCatCovariates(state: StepperState) {
   return validationErrors;
 }
 
+export function validateDosingRows(state: StepperState) {
+  const amountField = state.fields.find(
+    (field) => state.normalisedFields.get(field) === "Amount",
+  );
+  return (
+    amountField !== undefined &&
+    state.data.some((row) => row[amountField] !== ".")
+  );
+}
+
 export const validateState = (state: StepperState) => {
   const { fields, normalisedFields, normalisedHeaders } = state;
   const errors: string[] = [];
-  const hasNoDosing =
-    !normalisedHeaders.includes("Amount") ||
-    state.data.every((row) => row["Amount"] === ".");
+  const hasNoDosing = !validateDosingRows(state);
   // check for mandatory fields
   for (const field of manditoryHeaders) {
     if (!normalisedHeaders.includes(field)) {


### PR DESCRIPTION
Refactor data uploads, where the code was validating uploaded dosing rows in a couple of different places. Move that validation into a shared `validateDosingRows` function.

Hoist `hasDosingRows` up into `stepperState.hasDosingRows`, so that it persists when the dosing step unmounts.