### PR TITLE
fix(frontend): create dosing protocols duplicates dosing

### DIFF
--- a/frontend-v2/src/features/data/CreateDosingProtocols.tsx
+++ b/frontend-v2/src/features/data/CreateDosingProtocols.tsx
@@ -47,8 +47,9 @@ export function generateAdministrationIds(
   const dosingCompartments = [
     ...new Set(dosingRows.map((row) => row["Amount Variable"])),
   ];
-  const groupIds = dosingRows.map((row) => row[groupIdField]);
-  const uniqueGroupIds = [...new Set(groupIds)];
+  const uniqueGroupIds = [
+    ...new Set(dosingRows.map((row) => row[groupIdField])),
+  ];
   const administrationIds: string[] = [];
   dosingRows.forEach((row) => {
     const groupIndex = uniqueGroupIds.indexOf(row[groupIdField]) + 1;
@@ -217,11 +218,16 @@ const CreateDosingProtocols: FC<IDosingProtocols> = ({
     state.setNormalisedFields(newNormalisedFields);
     state.setData(newData);
   }
-  dosingRows = generateAdministrationIds(
-    dosingRows,
-    administrationIdField,
-    groupIdField,
+  const missingAdministrationIds = dosingRows.some(
+    (row) => !(administrationIdField in row),
   );
+  if (missingAdministrationIds) {
+    dosingRows = generateAdministrationIds(
+      dosingRows,
+      administrationIdField,
+      groupIdField,
+    );
+  }
 
   type InputChangeEvent =
     | ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -262,6 +268,9 @@ const CreateDosingProtocols: FC<IDosingProtocols> = ({
           <Table stickyHeader size="small">
             <TableHead>
               <TableRow>
+                <TableCell>
+                  <Typography>Administration ID</Typography>
+                </TableCell>
                 <TableCell>
                   <Typography>Group</Typography>
                 </TableCell>
@@ -318,6 +327,9 @@ const CreateDosingProtocols: FC<IDosingProtocols> = ({
                     currentRow?.[amountUnitField] || defaultAmountUnit;
                   return (
                     <TableRow key={adminId}>
+                      <TableCell sx={{ width: "5rem" }}>
+                        {currentRow?.[administrationIdField]}
+                      </TableCell>
                       <TableCell sx={{ width: "5rem" }}>
                         {currentRow?.[groupIdField]}
                       </TableCell>

--- a/frontend-v2/src/features/data/MapDosing.tsx
+++ b/frontend-v2/src/features/data/MapDosing.tsx
@@ -92,14 +92,16 @@ const MapDosing: FC<IMapDosing> = ({
     state.setNormalisedFields(newNormalisedFields);
   }
 
-  const dosingCompartments = projectProtocols?.map((protocol) => {
-    return (
-      protocol.mapped_qname ||
-      variables?.find((variable) => variable.id === protocol.variables[0])
-        ?.qname ||
-      ""
-    );
-  });
+  const dosingCompartments = projectProtocols
+    ?.filter((protocol) => protocol.variables.length > 0)
+    .map((protocol) => {
+      return (
+        protocol.mapped_qname ||
+        variables?.find((variable) => variable.id === protocol.variables[0])
+          ?.qname ||
+        ""
+      );
+    });
 
   return state.hasDosingRows ? (
     <DosingProtocols


### PR DESCRIPTION
- add an Admin ID column to the `CreateDosingProtocols` table.
- check for missing Admin IDs before generating new dosing rows.
- fix a bug where the Map Dosing step might duplicate editor rows for the same admin ID/dosing compartment, if there are multiple existing protocols for that compartment in the backend. This can happen if you've previously uploaded a dataset, but are now overwriting it with a new dataset.