### PR TITLE
refactor(frontend): optimise model variables form

### DIFF
--- a/frontend-v2/src/features/model/VariableRow.tsx
+++ b/frontend-v2/src/features/model/VariableRow.tsx
@@ -64,15 +64,11 @@ const VariableRow: FC<Props> = ({
     name: "model.derived_variables",
   });
 
-  const {
-    handleSubmit,
-    reset,
-    setValue,
-    formState: { isDirty: isDirtyForm },
-    watch,
-  } = useForm<Variable>({ defaultValues: variable || { id: 0, name: "" } });
+  const { handleSubmit, reset, setValue, formState, watch } = useForm<Variable>(
+    { defaultValues: variable || { id: 0, name: "" } },
+  );
   const watchProtocolId = watch("protocol");
-  const isDirty = watchProtocolId !== variable?.protocol || isDirtyForm;
+  const isDirty = watchProtocolId !== variable?.protocol || formState.isDirty;
   useDirty(isDirty);
   const [updateVariable] = useVariableUpdateMutation();
   const { addProtocol, removeProtocol, hasProtocol } = useEditProtocol({
@@ -94,10 +90,12 @@ const VariableRow: FC<Props> = ({
     }
   }
   async function onRemoveProtocol() {
-    const value = await removeProtocol();
-    if (value && "data" in value) {
-      setValue("protocol", null);
-    }
+    setValue("protocol", null);
+    updateVariable({
+      id: variable.id,
+      variable: { ...variable, protocol: null },
+    });
+    removeProtocol();
   }
 
   const isSharedWithMe = useSelector((state: RootState) =>

--- a/frontend-v2/src/features/model/useEditProtocol.ts
+++ b/frontend-v2/src/features/model/useEditProtocol.ts
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {
   CompoundRead,
   DoseRead,
@@ -25,7 +26,9 @@ export default function useEditProtocol({
   variable,
   watchProtocolId,
 }: EditProtocolProps) {
-  const hasProtocol: boolean = watchProtocolId != null;
+  const [hasProtocol, setHasProtocol] = useState<boolean>(
+    watchProtocolId !== null,
+  );
   const variableUnit = units.find((unit) => unit.id === variable.unit);
   const defaultTimeUnit = timeVariable
     ? units?.find((u) => u.id === timeVariable.unit)
@@ -48,6 +51,7 @@ export default function useEditProtocol({
       repeats: 1,
       duration: 0.0833,
     };
+    setHasProtocol(true);
     return createProtocol({
       protocol: {
         doses: [defaultDose],
@@ -62,6 +66,7 @@ export default function useEditProtocol({
 
   const removeProtocol = () => {
     if (hasProtocol && watchProtocolId) {
+      setHasProtocol(false);
       return destroyProtocol({ id: watchProtocolId });
     }
   };


### PR DESCRIPTION
Make the dosing variable checkboxes appear to be more responsive when clicked.
- update checkbox state immediately (in component state), without waiting for API requests to complete.
- small refactor of `removeProtocol` to update the variable form state without waiting for an async action.