### PR TITLE
fix (frontend): ESLint config

### DIFF
--- a/frontend-v2/eslint.config.js
+++ b/frontend-v2/eslint.config.js
@@ -10,14 +10,11 @@ export default [
   js.configs.recommended,
   reactRecommended,
   reactJSXRuntime,
+  reactHooks.configs["recommended-latest"],
+  pluginJsxA11y.flatConfigs.recommended,
   ...typescript.configs.recommended,
   prettier,
   {
-    plugins: {
-      "jsx-a11y": pluginJsxA11y,
-      "react-hooks": reactHooks,
-    },
-    rules: pluginJsxA11y.configs.recommended.rules,
     settings: {
       react: {
         version: "detect",


### PR DESCRIPTION
Fix a couple of ESLint plugins that broke during the update to v9. ESLint should warn about missing dependencies for React hooks now.