### PR TITLE
refactor(frontend): simplify Model tab form state

### DIFF
--- a/frontend-v2/src/features/model/AdditionalParametersRow.tsx
+++ b/frontend-v2/src/features/model/AdditionalParametersRow.tsx
@@ -60,8 +60,8 @@ const AdditionalParametersRow: FC<Props> = ({
 }) => {
   const {
     mappings,
-    appendMapping,
-    removeMapping,
+    mappingsAppend,
+    mappingsRemove,
     derivedVariables,
     derivedVariablesAppend,
     derivedVariablesRemove,
@@ -143,9 +143,9 @@ const AdditionalParametersRow: FC<Props> = ({
   const addPDMapping = () => {
     if (effectVariable) {
       if (mappings.length > 0) {
-        removeMapping(0);
+        mappingsRemove(0);
       }
-      appendMapping({
+      mappingsAppend({
         pk_variable: variable.id,
         pd_variable: effectVariable.id,
         pkpd_model: model.id,
@@ -158,7 +158,7 @@ const AdditionalParametersRow: FC<Props> = ({
       (mapping) => mapping.pk_variable === variable.id,
     );
     if (mapping_index >= 0) {
-      removeMapping(mapping_index);
+      mappingsRemove(mapping_index);
     }
   };
 

--- a/frontend-v2/src/features/model/Model.tsx
+++ b/frontend-v2/src/features/model/Model.tsx
@@ -117,8 +117,9 @@ function useModelFormState({
     useCombinedModelSetParamsToDefaultsUpdateMutation();
 
   const species = project?.species;
+  const defaultModel = model || DEFAULT_MODEL;
   const defaultValues: FormData = {
-    ...DEFAULT_MODEL,
+    ...defaultModel,
     project: project?.id || 0,
     species,
   };
@@ -126,11 +127,10 @@ function useModelFormState({
     reset,
     handleSubmit,
     control,
-    formState: { isDirty, dirtyFields },
+    formState: { isDirty },
   } = useForm<FormData>({
     defaultValues,
   });
-  console.log(isDirty, dirtyFields);
 
   useDirty(isDirty);
 
@@ -245,7 +245,6 @@ const Model: FC = () => {
   } = useApiQueries();
 
   const { control } = useModelFormState({ model, project, simulation });
-  console.log(control);
 
   if (isLoading) {
     return <div>Loading...</div>;

--- a/frontend-v2/src/features/model/Model.tsx
+++ b/frontend-v2/src/features/model/Model.tsx
@@ -4,6 +4,7 @@ import {
   CombinedModel,
   CombinedModelRead,
   ProjectRead,
+  ProjectSpeciesEnum,
   SimulationRead,
   useCombinedModelListQuery,
   useCombinedModelSetParamsToDefaultsUpdateMutation,
@@ -29,9 +30,8 @@ import useDirty from "../../hooks/useDirty";
 import { SubPageName } from "../main/mainSlice";
 import { TableHeader } from "../../components/TableHeader";
 
-export type FormData = {
-  project: ProjectRead;
-  model: CombinedModel;
+export type FormData = Omit<CombinedModel, "species"> & {
+  species: ProjectSpeciesEnum | undefined;
 };
 
 function useApiQueries() {
@@ -115,62 +115,68 @@ function useModelFormState({
 
   const [setParamsToDefault] =
     useCombinedModelSetParamsToDefaultsUpdateMutation();
-  const defaultValues: FormData = {
-    project: DEFAULT_PROJECT,
-    model: {
-      ...DEFAULT_MODEL,
-      project: project?.id || 0,
-    },
-  };
 
+  const species = project?.species;
+  const defaultValues: FormData = {
+    ...DEFAULT_MODEL,
+    project: project?.id || 0,
+    species,
+  };
   const {
     reset,
     handleSubmit,
     control,
-    formState: { isDirty },
+    formState: { isDirty, dirtyFields },
   } = useForm<FormData>({
     defaultValues,
   });
+  console.log(isDirty, dirtyFields);
 
   useDirty(isDirty);
 
   useEffect(() => {
-    if (model && project) {
-      reset({ model, project });
+    if (model && species) {
+      const newModel: FormData = {
+        ...model,
+        species,
+      };
+      reset(newModel);
     }
-  }, [model, project, reset]);
+  }, [model, species, reset]);
 
   const handleFormData = useCallback(
     (data: FormData) => {
       if (!model || !project) {
         return;
       }
+      const { species, ...modelData } = data;
       // if tlag checkbox is unchecked, then remove tlag derived variables
-      if (data.model.has_lag !== model.has_lag && !data.model.has_lag) {
-        data.model.derived_variables = data.model.derived_variables.filter(
+      if (modelData.has_lag !== model.has_lag && !modelData.has_lag) {
+        modelData.derived_variables = modelData.derived_variables.filter(
           (dv) => dv.type !== "TLG",
         );
       }
       // if only pd_model has changed, need to clear pd_model2
-      if (data.model.pd_model !== model?.pd_model) {
-        data.model.pd_model2 = null;
+      if (modelData.pd_model !== model?.pd_model) {
+        modelData.pd_model2 = null;
       }
       // if species changed then update project
-      if (data.project.species !== project.species) {
+      if (species !== project.species) {
         updateProject({
           id: project.id,
-          project: { ...project, species: data.project.species },
+          project: { ...project, species },
         });
         // if species has changed, then clear the models
-        data.model.pk_model = null;
-        data.model.pd_model = null;
-        data.model.pd_model2 = null;
+        modelData.pk_model = null;
+        modelData.pd_model = null;
+        modelData.pd_model2 = null;
       }
-      return updateModel({ id: model.id, combinedModel: data.model }).then(
+
+      return updateModel({ id: model.id, combinedModel: modelData }).then(
         (response) => {
           if (response?.data) {
             // if the pk_model has changed, need to reset the simulation time_max_unit and set default parameters again
-            if (data.model.pk_model !== model?.pk_model && simulation) {
+            if (modelData.pk_model !== model?.pk_model && simulation) {
               const time_max_unit = response.data.time_unit;
               updateSimulation({
                 id: simulation.id,
@@ -178,8 +184,8 @@ function useModelFormState({
               });
             }
             // if the pk model has changed, need to reset the parameters
-            if (data.model.pk_model !== model?.pk_model) {
-              setParamsToDefault({ id: model.id, combinedModel: data.model });
+            if (modelData.pk_model !== model?.pk_model) {
+              setParamsToDefault({ id: model.id, combinedModel: modelData });
             }
           }
         },
@@ -225,17 +231,6 @@ const DEFAULT_MODEL: CombinedModelRead = {
   is_library_model: false,
 };
 
-const DEFAULT_PROJECT: ProjectRead = {
-  id: 0,
-  user_access: [],
-  name: "",
-  created: "",
-  compound: 0,
-  users: [],
-  protocols: [],
-  datasets: [],
-};
-
 const Model: FC = () => {
   const {
     isLoading,
@@ -250,6 +245,7 @@ const Model: FC = () => {
   } = useApiQueries();
 
   const { control } = useModelFormState({ model, project, simulation });
+  console.log(control);
 
   if (isLoading) {
     return <div>Loading...</div>;
@@ -321,10 +317,8 @@ const Model: FC = () => {
           <ParametersTab
             model={model}
             project={project}
-            control={control}
             variables={variables}
             units={units}
-            compound={compound}
           />
         </TabPanel>
         <TabPanel>

--- a/frontend-v2/src/features/model/PKPDModelTab.tsx
+++ b/frontend-v2/src/features/model/PKPDModelTab.tsx
@@ -160,7 +160,7 @@ const PKPDModelTab: FC<Props> = ({ model, project, control }: Props) => {
           <SelectField
             size="small"
             label="Species"
-            name="project.species"
+            name="species"
             control={control}
             options={speciesOptions}
             formControlProps={{ sx: { width: "calc(100% - 3rem)" } }}
@@ -180,7 +180,7 @@ const PKPDModelTab: FC<Props> = ({ model, project, control }: Props) => {
             <SelectField
               size="small"
               label="PK Model"
-              name="model.pk_model"
+              name="pk_model"
               control={control}
               options={pk_model_options}
               formControlProps={{ sx: { width: "calc(100% - 3rem)" } }}
@@ -201,7 +201,7 @@ const PKPDModelTab: FC<Props> = ({ model, project, control }: Props) => {
                   <div>
                     <Checkbox
                       label="Saturation"
-                      name="model.has_saturation"
+                      name="has_saturation"
                       control={control}
                       checkboxFieldProps={{
                         disabled: !model.pk_model || isSharedWithMe,
@@ -213,7 +213,7 @@ const PKPDModelTab: FC<Props> = ({ model, project, control }: Props) => {
                   <div style={{ fontSize: "12px !important" }}>
                     <Checkbox
                       label="Effect Compartment"
-                      name="model.has_effect"
+                      name="has_effect"
                       control={control}
                       checkboxFieldProps={{
                         disabled: !model.pk_model || isSharedWithMe,
@@ -225,7 +225,7 @@ const PKPDModelTab: FC<Props> = ({ model, project, control }: Props) => {
                   <div>
                     <Checkbox
                       label="Lag Time"
-                      name="model.has_lag"
+                      name="has_lag"
                       control={control}
                       checkboxFieldProps={{
                         disabled: !model.pk_model || isSharedWithMe,
@@ -237,7 +237,7 @@ const PKPDModelTab: FC<Props> = ({ model, project, control }: Props) => {
                   <div>
                     <Checkbox
                       label="Bioavailability"
-                      name="model.has_bioavailability"
+                      name="has_bioavailability"
                       control={control}
                       checkboxFieldProps={{
                         disabled: !model.pk_model || isSharedWithMe,
@@ -261,7 +261,7 @@ const PKPDModelTab: FC<Props> = ({ model, project, control }: Props) => {
           <SelectField
             size="small"
             label="PD Model"
-            name="model.pd_model"
+            name="pd_model"
             control={control}
             options={pd_model_options}
             formControlProps={{ sx: { width: "calc(100% - 3rem)" } }}
@@ -280,7 +280,7 @@ const PKPDModelTab: FC<Props> = ({ model, project, control }: Props) => {
             <SelectField
               size="small"
               label="Secondary PD Model"
-              name="model.pd_model2"
+              name="pd_model2"
               control={control}
               options={pd_model2_options}
               formControlProps={{ sx: { width: "calc(100% - 3rem)" } }}
@@ -309,7 +309,7 @@ const PKPDModelTab: FC<Props> = ({ model, project, control }: Props) => {
                 <div>
                   <Checkbox
                     label="Hill Coefficient"
-                    name="model.has_hill_coefficient"
+                    name="has_hill_coefficient"
                     control={control}
                     checkboxFieldProps={{
                       disabled: !model.pd_model || isSharedWithMe,

--- a/frontend-v2/src/features/model/ParametersTab.tsx
+++ b/frontend-v2/src/features/model/ParametersTab.tsx
@@ -1,13 +1,11 @@
 import { FC } from "react";
 import {
   CombinedModelRead,
-  CompoundRead,
   ProjectRead,
   UnitRead,
   VariableRead,
   useCombinedModelSetParamsToDefaultsUpdateMutation,
 } from "../../app/backendApi";
-import { Control } from "react-hook-form";
 import {
   TableContainer,
   Table,
@@ -23,7 +21,6 @@ import {
 import ParameterRow from "./ParameterRow";
 import HelpButton from "../../components/HelpButton";
 import { getConstVariables, getNoReset } from "./resetToSpeciesDefaults";
-import { FormData } from "./Model";
 import { defaultHeaderSx } from "../../shared/tableHeadersSx";
 import { useSelector } from "react-redux";
 import { RootState } from "../../app/store";
@@ -37,9 +34,7 @@ import { TableHeader } from "../../components/TableHeader";
 interface Props {
   model: CombinedModelRead;
   project: ProjectRead;
-  control: Control<FormData>;
   variables: VariableRead[];
-  compound: CompoundRead;
   units: UnitRead[];
 }
 

--- a/frontend-v2/src/features/model/variableUtils.ts
+++ b/frontend-v2/src/features/model/variableUtils.ts
@@ -15,8 +15,8 @@ import useEditProtocol from "./useEditProtocol";
 export function useFormData({ control }: { control: Control<FormData> }) {
   const {
     fields: mappings,
-    append: appendMapping,
-    remove: removeMapping,
+    append: mappingsAppend,
+    remove: mappingsRemove,
   } = useFieldArray({
     control,
     name: "mappings",
@@ -31,8 +31,8 @@ export function useFormData({ control }: { control: Control<FormData> }) {
   });
   return {
     mappings,
-    appendMapping,
-    removeMapping,
+    mappingsAppend,
+    mappingsRemove,
     derivedVariables,
     derivedVariablesAppend,
     derivedVariablesRemove,

--- a/frontend-v2/src/features/model/variableUtils.ts
+++ b/frontend-v2/src/features/model/variableUtils.ts
@@ -19,7 +19,7 @@ export function useFormData({ control }: { control: Control<FormData> }) {
     remove: removeMapping,
   } = useFieldArray({
     control,
-    name: "model.mappings",
+    name: "mappings",
   });
   const {
     fields: derivedVariables,
@@ -27,7 +27,7 @@ export function useFormData({ control }: { control: Control<FormData> }) {
     remove: derivedVariablesRemove,
   } = useFieldArray({
     control,
-    name: "model.derived_variables",
+    name: "derived_variables",
   });
   return {
     mappings,


### PR DESCRIPTION
Refactor the Model tab form state to remve complex nested fields. The form state is now a flat object with keys, The form is dirty if any of these keys change:

```js
const formState = {
  name: "",
  project: 0,
  mappings: [],
  derived_variables: [],
  time_intervals: [],
  components: "",
  variables: [],
  mmt: "",
  sbml: "",
  time_unit: 0,
  is_library_model: false,
  species: "M"
}
```

Previously, the form state consisted of two fields, `model` and `project`, both of which were complex objects. Either field would be marked as dirty if its corresponding object changed, which made tracking changes difficult.