### PR TITLE
fix(frontend): slow Model variable forms

### DIFF
--- a/frontend-v2/src/features/model/Model.tsx
+++ b/frontend-v2/src/features/model/Model.tsx
@@ -127,7 +127,7 @@ function useModelFormState({
     reset,
     handleSubmit,
     control,
-    formState: { isDirty },
+    formState: { isDirty, submitCount },
   } = useForm<FormData>({
     defaultValues,
   });
@@ -203,15 +203,11 @@ function useModelFormState({
   );
 
   useEffect(() => {
-    const intervalId = setInterval(() => {
-      if (isDirty) {
-        const submit = handleSubmit(handleFormData);
-        submit();
-      }
-    }, 1000);
-
-    return () => clearInterval(intervalId);
-  }, [handleSubmit, handleFormData, isDirty]);
+    if (isDirty && submitCount === 0) {
+      const submit = handleSubmit(handleFormData);
+      submit();
+    }
+  }, [handleSubmit, handleFormData, isDirty, submitCount]);
 
   return { control };
 }

--- a/frontend-v2/src/features/model/variableUtils.ts
+++ b/frontend-v2/src/features/model/variableUtils.ts
@@ -55,7 +55,7 @@ export function useVariableFormState({
   const {
     handleSubmit,
     reset,
-    formState: { isDirty: isDirtyForm },
+    formState: { isDirty: isDirtyForm, submitCount },
     setValue,
     watch,
   } = useForm<Variable>({ defaultValues: variable || { id: 0, name: "" } });
@@ -77,23 +77,20 @@ export function useVariableFormState({
   }, [variable, reset]);
 
   useEffect(() => {
-    const intervalId = setInterval(() => {
-      if (isDirty) {
-        handleSubmit((data) => {
-          // @ts-expect-error - lower_bound and upper_bound can be null
-          if (data.lower_bound === "") {
-            data.lower_bound = null;
-          }
-          // @ts-expect-error - lower_bound and upper_bound can be null
-          if (data.upper_bound === "") {
-            data.upper_bound = null;
-          }
-          updateVariable({ id: variable.id, variable: data });
-        })();
-      }
-    }, 1000);
-    return () => clearInterval(intervalId);
-  }, [handleSubmit, isDirty, updateVariable, variable.id]);
+    if (isDirty && submitCount === 0) {
+      handleSubmit((data) => {
+        // @ts-expect-error - lower_bound and upper_bound can be null
+        if (data.lower_bound === "") {
+          data.lower_bound = null;
+        }
+        // @ts-expect-error - lower_bound and upper_bound can be null
+        if (data.upper_bound === "") {
+          data.upper_bound = null;
+        }
+        updateVariable({ id: variable.id, variable: data });
+      })();
+    }
+  }, [handleSubmit, isDirty, submitCount, updateVariable, variable.id]);
 
   return {
     handleSubmit,


### PR DESCRIPTION
- add `submitCount` to the Model tab forms. Only submit if the form has not already been submitted. `submitCount` resets whenever the model updates form the backend.
- remove the 1s delay from saves.
- towards #710.