### PR TITLE
refactor(frontend): remove 1s autosave delay

### DIFF
--- a/frontend-v2/src/features/model/ParameterRow.tsx
+++ b/frontend-v2/src/features/model/ParameterRow.tsx
@@ -10,7 +10,6 @@ import {
 } from "../../app/backendApi";
 import UnitField from "../../components/UnitField";
 import useDirty from "../../hooks/useDirty";
-import useInterval from "../../hooks/useInterval";
 import FloatField from "../../components/FloatField";
 import { selectIsProjectShared } from "../login/loginSlice";
 import { useSelector } from "react-redux";
@@ -27,7 +26,7 @@ const ParameterRow: FC<Props> = ({ project, variable, units }) => {
     control,
     handleSubmit,
     reset,
-    formState: { isDirty: isDirtyForm },
+    formState: { isDirty: isDirtyForm, submitCount },
   } = useForm<Variable>({ defaultValues: variable || { id: 0, name: "" } });
   const [updateVariable] = useVariableUpdateMutation();
 
@@ -52,11 +51,11 @@ const ParameterRow: FC<Props> = ({ project, variable, units }) => {
     [handleSubmit, updateVariable, variable],
   );
 
-  useInterval({
-    callback: submit,
-    delay: 1000,
-    isDirty,
-  });
+  useEffect(() => {
+    if (isDirty && submitCount === 0) {
+      submit();
+    }
+  }, [isDirty, submitCount, submit]);
 
   if (variable.constant !== true) {
     return null;

--- a/frontend-v2/src/features/simulation/Simulations.tsx
+++ b/frontend-v2/src/features/simulation/Simulations.tsx
@@ -293,7 +293,7 @@ const Simulations: FC = () => {
       const submit = handleSubmit(onSubmit);
       submit();
     }
-  }, [handleSubmit, isDirty, simulation, updateSimulation]);
+  }, [handleSubmit, isDirty, submitCount, simulation, updateSimulation]);
 
   const filterOutputs = model?.is_library_model
     ? ["environment.t", "PDCompartment.C_Drug"]

--- a/frontend-v2/src/features/trial/DoseRow.tsx
+++ b/frontend-v2/src/features/trial/DoseRow.tsx
@@ -13,7 +13,6 @@ import {
 } from "../../app/backendApi";
 import { Control, useForm } from "react-hook-form";
 import useDirty from "../../hooks/useDirty";
-import useInterval from "../../hooks/useInterval";
 
 type Props = {
   baseUnit?: UnitRead;
@@ -49,7 +48,7 @@ const DoseRow: FC<Props> = ({
   const {
     control: doseControl,
     handleSubmit,
-    formState: { isDirty },
+    formState: { isDirty, submitCount },
     reset,
   } = useForm<DoseRead>({
     defaultValues: dose,
@@ -74,12 +73,11 @@ const DoseRow: FC<Props> = ({
     [dose, handleSubmit, doseId, refetchDose, updateDose],
   );
 
-  // save dose every second if dirty
-  useInterval({
-    callback: handleSave,
-    delay: 1000,
-    isDirty,
-  });
+  useEffect(() => {
+    if (isDirty && submitCount === 0) {
+      handleSave();
+    }
+  }, [handleSave, isDirty, submitCount]);
 
   const defaultProps = {
     disabled,

--- a/frontend-v2/src/features/trial/Doses.tsx
+++ b/frontend-v2/src/features/trial/Doses.tsx
@@ -17,7 +17,6 @@ import {
 } from "../../app/backendApi";
 import { useFieldArray, useForm } from "react-hook-form";
 import useDirty from "../../hooks/useDirty";
-import useInterval from "../../hooks/useInterval";
 import { useSelector } from "react-redux";
 import { RootState } from "../../app/store";
 import { selectIsProjectShared } from "../login/loginSlice";
@@ -43,7 +42,7 @@ const Doses: FC<Props> = ({ onChange, project, protocol, units }) => {
     control,
     handleSubmit,
     reset,
-    formState: { isDirty },
+    formState: { isDirty, submitCount },
     getValues,
   } = useForm<Protocol>({
     defaultValues: protocol,
@@ -78,12 +77,11 @@ const Doses: FC<Props> = ({ onChange, project, protocol, units }) => {
     [handleSubmit, onChange, protocol, updateProtocol],
   );
 
-  // save protocol every second if dirty
-  useInterval({
-    callback: handleSave,
-    delay: 1000,
-    isDirty,
-  });
+  useEffect(() => {
+    if (isDirty && submitCount === 0) {
+      handleSave();
+    }
+  }, [isDirty, submitCount, handleSave]);
 
   const isPreclinical = project.species !== "H";
   const defaultSymbol = isPreclinical ? "mg/kg" : "mg";


### PR DESCRIPTION
Replace the 1s autosave interval with code that checks `formState.submitCount` to see whether a save is already in progress.
- towards #710.