### PR TITLE
refactor(frontend): Model variables form performance

### DIFF
--- a/frontend-v2/src/features/model/Model.tsx
+++ b/frontend-v2/src/features/model/Model.tsx
@@ -100,14 +100,16 @@ function useApiQueries() {
   };
 }
 
-function useModelFormState({
+function useModelFormDataCallback({
   model,
   project,
   simulation,
+  reset,
 }: {
   model?: CombinedModelRead | null;
   project?: ProjectRead;
   simulation?: SimulationRead;
+  reset: (values?: Partial<FormData>) => void;
 }) {
   const [updateModel] = useCombinedModelUpdateMutation();
   const [updateSimulation] = useSimulationUpdateMutation();
@@ -115,23 +117,6 @@ function useModelFormState({
 
   const [setParamsToDefault] =
     useCombinedModelSetParamsToDefaultsUpdateMutation();
-
-  const species = project?.species;
-  const defaultValues: FormData = {
-    ...DEFAULT_MODEL,
-    project: project?.id || 0,
-    species,
-  };
-  const values = getFormValues(model, species);
-  const { reset, handleSubmit, control } = useForm<FormData>({
-    defaultValues,
-    values,
-  });
-  const { isDirty, isSubmitting } = useFormState({
-    control,
-  });
-
-  useDirty(isDirty);
 
   const handleFormData = useCallback(
     (data: FormData) => {
@@ -197,15 +182,34 @@ function useModelFormState({
       reset,
     ],
   );
+  return handleFormData;
+}
 
-  useEffect(() => {
-    if (isDirty && !isSubmitting) {
-      const submit = handleSubmit(handleFormData);
-      submit();
-    }
-  }, [handleSubmit, handleFormData, isDirty, isSubmitting]);
+function useModelFormState({
+  model,
+  project,
+}: {
+  model?: CombinedModelRead | null;
+  project?: ProjectRead;
+}) {
+  const species = project?.species;
+  const defaultValues: FormData = {
+    ...DEFAULT_MODEL,
+    project: project?.id || 0,
+    species,
+  };
+  const values = getFormValues(model, species);
+  const { reset, handleSubmit, control } = useForm<FormData>({
+    defaultValues,
+    values,
+  });
+  const { isDirty } = useFormState({
+    control,
+  });
 
-  return { control };
+  useDirty(isDirty);
+
+  return { control, reset, handleSubmit };
 }
 
 const DEFAULT_MODEL: CombinedModelRead = {
@@ -253,7 +257,30 @@ const Model: FC = () => {
     variables,
   } = useApiQueries();
 
-  const { control } = useModelFormState({ model, project, simulation });
+  const { control, reset, handleSubmit } = useModelFormState({
+    model,
+    project,
+  });
+  const handleFormData = useModelFormDataCallback({
+    model,
+    project,
+    simulation,
+    reset,
+  });
+
+  /* 
+  Submit whenever the form is dirty
+  and previous updates have finished (or reset).
+  */
+  const { isDirty, isSubmitting } = useFormState({
+    control,
+  });
+  useEffect(() => {
+    if (isDirty && !isSubmitting) {
+      const submit = handleSubmit(handleFormData);
+      submit();
+    }
+  }, [handleSubmit, handleFormData, isDirty, isSubmitting]);
 
   if (isLoading) {
     return <div>Loading...</div>;

--- a/frontend-v2/src/features/model/variableUtils.ts
+++ b/frontend-v2/src/features/model/variableUtils.ts
@@ -54,13 +54,15 @@ export function useVariableFormState({
 }) {
   const {
     handleSubmit,
-    reset,
-    formState: { isDirty: isDirtyForm, submitCount },
+    formState: { isDirty: isDirtyVariable, submitCount },
     setValue,
     watch,
-  } = useForm<Variable>({ defaultValues: variable || { id: 0, name: "" } });
+  } = useForm<Variable>({
+    defaultValues: variable || { id: 0, name: "" },
+    values: variable,
+  });
   const watchProtocolId = watch("protocol");
-  const isDirty = watchProtocolId !== variable?.protocol || isDirtyForm;
+  const isDirty = watchProtocolId !== variable?.protocol || isDirtyVariable;
   useDirty(isDirty);
   const [updateVariable] = useVariableUpdateMutation();
   const { addProtocol, removeProtocol, hasProtocol } = useEditProtocol({
@@ -71,10 +73,6 @@ export function useVariableFormState({
     variable,
     watchProtocolId,
   });
-
-  useEffect(() => {
-    reset(variable);
-  }, [variable, reset]);
 
   useEffect(() => {
     if (isDirty && submitCount === 0) {


### PR DESCRIPTION
- use `values` with `useForm`, to reset the form when the model changes.
- use `isSubmitting` to avoid duplicate form submissions.
- manually reset the form after submission, to allow for multiple updates in quick succession.