### PR TITLE
refactor(frontend): code cleanup

### DIFF
--- a/frontend-v2/src/features/drug/Drug.tsx
+++ b/frontend-v2/src/features/drug/Drug.tsx
@@ -96,12 +96,13 @@ const Drug: FC = () => {
   // create a form for the compound data using react-hook-form
   const { reset, handleSubmit, control, setValue, getValues } =
     useForm<Compound>({
-      defaultValues: compound || {
+      defaultValues: {
         name: "",
         description: "",
         compound_type: "SM",
         efficacy_experiments: [],
       },
+      values: compound,
     });
   const { isDirty } = useFormState({ control });
   useDirty(isDirty);
@@ -115,10 +116,6 @@ const Drug: FC = () => {
     name: "efficacy_experiments",
     keyName: "theKey",
   });
-
-  useEffect(() => {
-    reset(compound);
-  }, [compound, reset]);
 
   const dispatch = useDispatch();
 
@@ -156,7 +153,7 @@ const Drug: FC = () => {
             .then(() => dispatch(decrementDirtyCount()));
         }
       }),
-    [compound, handleSubmit, updateCompound],
+    [compound, handleSubmit, updateCompound, dispatch],
   );
 
   useEffect(() => {
@@ -265,15 +262,19 @@ const Drug: FC = () => {
       <div
         style={{ display: "flex", paddingTop: "1rem", flexDirection: "column" }}
       >
-        <Grid container size={{
-          xl: 12
-        }}>
+        <Grid
+          container
+          size={{
+            xl: 12,
+          }}
+        >
           <Grid
             sx={{ paddingRight: "2rem" }}
             size={{
               xl: 3,
-              xs: 7
-            }}>
+              xs: 7,
+            }}
+          >
             <Typography variant="h6" component="h2" gutterBottom>
               Drug Properties
             </Typography>
@@ -298,15 +299,20 @@ const Drug: FC = () => {
             </Stack>
           </Grid>
         </Grid>
-        <Grid sx={{ paddingTop: ".5rem" }} container size={{
-          xl: 12
-        }}>
+        <Grid
+          sx={{ paddingTop: ".5rem" }}
+          container
+          size={{
+            xl: 12,
+          }}
+        >
           <Grid
             sx={{ paddingRight: "2rem" }}
             size={{
               xl: 3,
-              xs: 7
-            }}>
+              xs: 7,
+            }}
+          >
             <Typography variant="h6" component="h2" gutterBottom>
               Target Properties
             </Typography>
@@ -334,14 +340,19 @@ const Drug: FC = () => {
           </Grid>
         </Grid>
       </div>
-      <Grid container sx={{ paddingTop: "3rem" }} size={{
-        xl: 12
-      }}>
+      <Grid
+        container
+        sx={{ paddingTop: "3rem" }}
+        size={{
+          xl: 12,
+        }}
+      >
         <Grid
           size={{
             xl: 4,
-            xs: 7
-          }}>
+            xs: 7,
+          }}
+        >
           <Box sx={{ display: "flex" }}>
             <Typography variant="h6" component="h2" gutterBottom>
               Efficacy-Safety Data

--- a/frontend-v2/src/features/model/ParameterRow.tsx
+++ b/frontend-v2/src/features/model/ParameterRow.tsx
@@ -25,16 +25,12 @@ const ParameterRow: FC<Props> = ({ project, variable, units }) => {
   const {
     control,
     handleSubmit,
-    reset,
-    formState: { isDirty: isDirtyForm, submitCount },
-  } = useForm<Variable>({ defaultValues: variable || { id: 0, name: "" } });
+    formState: { isDirty, submitCount },
+  } = useForm<Variable>({
+    defaultValues: variable || { id: 0, name: "" },
+    values: variable,
+  });
   const [updateVariable] = useVariableUpdateMutation();
-
-  useEffect(() => {
-    reset(variable);
-  }, [variable, reset]);
-
-  const isDirty = isDirtyForm;
   useDirty(isDirty);
 
   const isSharedWithMe = useSelector((state: RootState) =>

--- a/frontend-v2/src/features/projects/Project.tsx
+++ b/frontend-v2/src/features/projects/Project.tsx
@@ -121,9 +121,11 @@ const ProjectRow: FC<Props> = ({
     molecular_mass: 100,
     target_molecular_mass: 100,
   };
+  const formValues = project && compound ? { project, compound } : undefined;
   const { reset, handleSubmit, control, setValue, register } =
     useForm<FormData>({
       defaultValues: { project, compound: defaultCompound },
+      values: formValues,
     });
 
   const [userAccessOpen, setUserAccessOpen] = useState<boolean>(false);
@@ -145,10 +147,6 @@ const ProjectRow: FC<Props> = ({
   );
   const [projectAccessDestroy] = useProjectAccessDestroyMutation();
 
-  useEffect(() => {
-    reset({ project, compound });
-  }, [project, compound, reset]);
-
   const handleSave = useMemo(
     () =>
       handleSubmit((data: FormData) => {
@@ -167,7 +165,7 @@ const ProjectRow: FC<Props> = ({
           }
         }
       }),
-    [handleSubmit, compound, project, updateCompound, updateProject],
+    [handleSubmit, compound, project, updateCompound, updateProject, dispatch],
   );
 
   const onCancel = () => {

--- a/frontend-v2/src/features/simulation/SimulationSliderView.tsx
+++ b/frontend-v2/src/features/simulation/SimulationSliderView.tsx
@@ -68,7 +68,7 @@ const SimulationSliderView: FC<SimulationSliderProps> = ({
       setValue(defaultValue);
       onChange(slider.variable, defaultValue);
     }
-  }, [onChange, defaultValue, variable]);
+  }, [onChange, defaultValue, variable, slider.variable]);
 
   const handleSliderChange = (
     event: Event | SyntheticEvent<Element, Event>,
@@ -121,9 +121,12 @@ const SimulationSliderView: FC<SimulationSliderProps> = ({
 
   const commitChanges = () => {
     commitChangesWithValue(new Event("commit"), value);
-  }
+  };
 
-  const commitChangesWithValue = (_event: React.SyntheticEvent | Event, value: number | number[]) => {
+  const commitChangesWithValue = (
+    _event: React.SyntheticEvent | Event,
+    value: number | number[],
+  ) => {
     // value should always be a number
     if (typeof value !== "number") {
       return;

--- a/frontend-v2/src/features/simulation/useSimulation.ts
+++ b/frontend-v2/src/features/simulation/useSimulation.ts
@@ -73,6 +73,8 @@ export default function useSimulation(
     JSON.stringify(simInputs),
     page,
     runSimulation,
+    setSimulations,
+    simInputs,
   ]);
 
   return {

--- a/frontend-v2/src/features/simulation/useSimulationInputs.ts
+++ b/frontend-v2/src/features/simulation/useSimulationInputs.ts
@@ -124,6 +124,6 @@ export default function useSimulationInputs(
             simulationInputMode.ALL_OUTPUTS_NO_AMOUNTS,
           )
         : DEFAULT_INPUTS,
-    [simulation, sliderValues, variables, timeMax],
+    [model, simulation, sliderValues, variables, timeMax],
   );
 }

--- a/frontend-v2/src/features/trial/DoseRow.tsx
+++ b/frontend-v2/src/features/trial/DoseRow.tsx
@@ -49,15 +49,11 @@ const DoseRow: FC<Props> = ({
     control: doseControl,
     handleSubmit,
     formState: { isDirty, submitCount },
-    reset,
   } = useForm<DoseRead>({
     defaultValues: dose,
+    values: dose,
   });
   useDirty(isDirty);
-
-  useEffect(() => {
-    reset(dose);
-  }, [dose, reset]);
 
   const [updateDose] = useDoseUpdateMutation();
 
@@ -70,7 +66,7 @@ const DoseRow: FC<Props> = ({
           onChange();
         }
       }),
-    [dose, handleSubmit, doseId, refetchDose, updateDose],
+    [dose, handleSubmit, doseId, refetchDose, updateDose, onChange],
   );
 
   useEffect(() => {

--- a/frontend-v2/src/features/trial/Doses.tsx
+++ b/frontend-v2/src/features/trial/Doses.tsx
@@ -41,11 +41,11 @@ const Doses: FC<Props> = ({ onChange, project, protocol, units }) => {
   const {
     control,
     handleSubmit,
-    reset,
     formState: { isDirty, submitCount },
     getValues,
   } = useForm<Protocol>({
     defaultValues: protocol,
+    values: protocol,
   });
   useDirty(isDirty);
   const [updateProtocol] = useProtocolUpdateMutation();
@@ -61,10 +61,6 @@ const Doses: FC<Props> = ({ onChange, project, protocol, units }) => {
     control,
     name: "doses",
   });
-
-  useEffect(() => {
-    reset(protocol);
-  }, [protocol, reset]);
 
   const handleSave = useMemo(
     () =>


### PR DESCRIPTION
- fix missing dependency warnings for hooks.
- use `values` with `useForm` to avoid manually resetting form state.