### PR TITLE
refactor(frontend): add onChange to ModelVariablesTab

### DIFF
--- a/frontend-v2/src/features/model/AdditionalParametersRow.tsx
+++ b/frontend-v2/src/features/model/AdditionalParametersRow.tsx
@@ -1,4 +1,3 @@
-// src/components/ProjectTable.tsx
 import { FC, useEffect } from "react";
 import { Control } from "react-hook-form";
 import {
@@ -37,6 +36,7 @@ interface Props {
   isAnyLinkToPdSelected: boolean;
   updateLagTimes: (key: number, value: boolean) => void;
   isAnyLagTimeSelected: boolean;
+  onChange: () => void;
 }
 
 type DerivedVariableType = "AUC" | "RO" | "FUP" | "BPR" | "TLG";
@@ -57,6 +57,7 @@ const AdditionalParametersRow: FC<Props> = ({
   isAnyLinkToPdSelected,
   updateLagTimes,
   isAnyLagTimeSelected,
+  onChange,
 }) => {
   const {
     mappings,
@@ -86,7 +87,12 @@ const AdditionalParametersRow: FC<Props> = ({
 
   const onClickDerived = (type: DerivedVariableType) => () => {
     const index = derivedIndex(type);
-    return index >= 0 ? removeDerived(index) : addDerived(type);
+    if (index >= 0) {
+      removeDerived(index);
+    } else {
+      addDerived(type);
+    }
+    onChange();
   };
 
   const derivedIndex = (type: DerivedVariableType) => {
@@ -151,6 +157,7 @@ const AdditionalParametersRow: FC<Props> = ({
         pkpd_model: model.id,
       });
     }
+    onChange();
   };
 
   const removePDMapping = () => {
@@ -160,6 +167,7 @@ const AdditionalParametersRow: FC<Props> = ({
     if (mapping_index >= 0) {
       mappingsRemove(mapping_index);
     }
+    onChange();
   };
 
   const addDerived = (type: DerivedVariableType) => {

--- a/frontend-v2/src/features/model/MapVariablesTab.tsx
+++ b/frontend-v2/src/features/model/MapVariablesTab.tsx
@@ -60,6 +60,7 @@ interface Props {
   variables: VariableRead[];
   units: UnitRead[];
   compound: CompoundRead;
+  onChange: () => void;
 }
 
 const MapVariablesTab: FC<Props> = ({
@@ -69,6 +70,7 @@ const MapVariablesTab: FC<Props> = ({
   variables,
   units,
   compound,
+  onChange,
 }: Props) => {
   const [dosings, setDosing] = useState<
     {
@@ -478,6 +480,7 @@ const MapVariablesTab: FC<Props> = ({
                 isAnyLinkToPdSelected={isAnyLinkToPdSelected}
                 updateLagTimes={updateLagTimes}
                 isAnyLagTimeSelected={isAnyLagTimeSelected}
+                onChange={onChange}
               />
             ))}
           </TableBody>

--- a/frontend-v2/src/features/model/Model.tsx
+++ b/frontend-v2/src/features/model/Model.tsx
@@ -275,6 +275,7 @@ const Model: FC = () => {
   const { isDirty, isSubmitting } = useFormState({
     control,
   });
+
   useEffect(() => {
     if (isDirty && !isSubmitting) {
       const submit = handleSubmit(handleFormData);
@@ -346,6 +347,7 @@ const Model: FC = () => {
             variables={variables}
             units={units}
             compound={compound}
+            onChange={handleSubmit(handleFormData)}
           />
         </TabPanel>
         <TabPanel>


### PR DESCRIPTION
Add an `onChange` handler to `ModelVariablesTab` and use it to handle changes to additional parameters, rather than using `useEffect`.