### PR TITLE
fix(frontend): complex expression in dependency array

### DIFF
--- a/frontend-v2/src/features/simulation/useSimulation.ts
+++ b/frontend-v2/src/features/simulation/useSimulation.ts
@@ -34,9 +34,11 @@ export default function useSimulation(
       : { error: "Unknown error" }
     : undefined;
   const page = useSelector((state: RootState) => state.main.selectedPage);
+  const serialisedInputs = JSON.stringify(simInputs);
 
   useEffect(() => {
     let ignore = false;
+    const simInputs = JSON.parse(serialisedInputs);
     if (
       runSimulation &&
       simInputs.outputs?.length > 1 &&
@@ -70,7 +72,7 @@ export default function useSimulation(
     model,
     protocols,
     simulate,
-    JSON.stringify(simInputs),
+    serialisedInputs,
     page,
     runSimulation,
     setSimulations,


### PR DESCRIPTION
Fix a linter error where the dependencies of `useEffect` must be static values.