### PR TITLE
fix(frontend): flashes of outdated Model variable state

### DIFF
--- a/frontend-v2/src/features/model/Model.tsx
+++ b/frontend-v2/src/features/model/Model.tsx
@@ -193,15 +193,9 @@ function useModelFormState({
   project?: ProjectRead;
 }) {
   const species = project?.species;
-  const defaultValues: FormData = {
-    ...DEFAULT_MODEL,
-    project: project?.id || 0,
-    species,
-  };
-  const values = getFormValues(model, species);
+  const defaultValues = getFormValues(model, species);
   const { reset, handleSubmit, control } = useForm<FormData>({
     defaultValues,
-    values,
   });
   const { isDirty } = useFormState({
     control,

--- a/frontend-v2/src/features/model/variableUtils.ts
+++ b/frontend-v2/src/features/model/variableUtils.ts
@@ -59,7 +59,6 @@ export function useVariableFormState({
     watch,
   } = useForm<Variable>({
     defaultValues: variable || { id: 0, name: "" },
-    values: variable,
   });
   const watchProtocolId = watch("protocol");
   const isDirty = watchProtocolId !== variable?.protocol || isDirtyVariable;


### PR DESCRIPTION
Remove `values` from the variable forms in the Model tab. I think this will fix flashes of outdated state, where you'd see a checkbox blink on and off again. Those happen when multiple API updates are triggered in quick succession, and the form state updates after each response. This fixes that by resetting form state before each request, not after.