### PR TITLE
ci: add eslint to frontend CI checks

### DIFF
--- a/frontend-v2/eslint.config.js
+++ b/frontend-v2/eslint.config.js
@@ -6,13 +6,19 @@ import reactHooks from "eslint-plugin-react-hooks";
 import typescript from "typescript-eslint";
 import pluginJsxA11y from "eslint-plugin-jsx-a11y";
 
-export default [
+export default typescript.config(
   js.configs.recommended,
+  typescript.configs.recommended,
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": "warn",
+      "@typescript-eslint/no-explicit-any": "warn",
+    },
+  },
   reactRecommended,
   reactJSXRuntime,
   reactHooks.configs["recommended-latest"],
   pluginJsxA11y.flatConfigs.recommended,
-  ...typescript.configs.recommended,
   prettier,
   {
     settings: {
@@ -24,4 +30,4 @@ export default [
   {
     ignores: ["src/app/api.ts", "src/app/backendApi.ts"],
   },
-];
+);

--- a/frontend-v2/package.json
+++ b/frontend-v2/package.json
@@ -26,8 +26,8 @@
     "rehype-react": "^8.0.0"
   },
   "scripts": {
-    "start": "npx tsc && vite",
-    "build": "npx tsc && vite build",
+    "start": "npx tsc && eslint src && vite",
+    "build": "npx tsc && eslint src && vite build",
     "serve": "vite preview",
     "lint": "eslint src",
     "format": "prettier --write ./src",

--- a/frontend-v2/src/contexts/SimulationContext.ts
+++ b/frontend-v2/src/contexts/SimulationContext.ts
@@ -1,7 +1,11 @@
 import { createContext } from "react";
 import { SimulateResponse } from "../app/backendApi";
 
-export const SimulationContext = createContext({
-  simulations: [] as SimulateResponse[],
-  setSimulations: (_simulations: SimulateResponse[]) => {},
+interface SimulationContextType {
+  simulations: SimulateResponse[];
+  setSimulations: (simulations: SimulateResponse[]) => void;
+}
+export const SimulationContext = createContext<SimulationContextType>({
+  simulations: [],
+  setSimulations: () => {},
 });

--- a/frontend-v2/src/features/data/protocolUtils.ts
+++ b/frontend-v2/src/features/data/protocolUtils.ts
@@ -68,7 +68,7 @@ export function getSubjectDoses(state: StepperState): SubjectDoses[] {
 export function stripDoses(subjectDosing: IDose[] = []) {
   // strip subject ID from dosing rows.
   return subjectDosing.map((dose: IDose) => {
-    const { subject, ...rest } = dose;
+    const { subject: _s, ...rest } = dose;
     return rest;
   });
 }

--- a/frontend-v2/src/shared/contexts/CollapsibleSidebarContext.tsx
+++ b/frontend-v2/src/shared/contexts/CollapsibleSidebarContext.tsx
@@ -7,9 +7,7 @@ const CollapsibleSidebarContext = createContext({
   onExpand: () => {
     return;
   },
-  setHasSimulationsExpandedChanged: (_isChanged: boolean) => {
-    return;
-  },
+  setHasSimulationsExpandedChanged: (_isChanged: boolean) => {},
   isExpanded: true,
   animationClasses: "",
   simulationAnimationClasses: "",

--- a/frontend-v2/src/shared/contexts/ProjectDescriptionContext.tsx
+++ b/frontend-v2/src/shared/contexts/ProjectDescriptionContext.tsx
@@ -10,7 +10,7 @@ type ProjectDescriptionContextType = {
 const ProjectDescriptionContext = createContext<ProjectDescriptionContextType>({
   isDescriptionModalOpen: false,
   descriptionProjectId: null,
-  onOpenDescriptionModal: (_id: number | null) => {
+  onOpenDescriptionModal: () => {
     return;
   },
   onCloseDescriptionModal: () => {


### PR DESCRIPTION
- run ESLint along with tsc before builds. Fail on errors.
- downgrade 'no-unused-vars' and 'no-explicit-any' to warnings, not errors.
- fix a few unused var warnings.