### PR TITLE
fix(frontend): save edits to model and projects

### DIFF
--- a/frontend-v2/src/features/model/Model.tsx
+++ b/frontend-v2/src/features/model/Model.tsx
@@ -130,7 +130,8 @@ function useModelFormDataCallback({
       if (!model || !project) {
         return;
       }
-      const { species, species_weight, species_weight_unit, ...modelData } = data;
+      const { species, species_weight, species_weight_unit, ...modelData } =
+        data;
       // if tlag checkbox is unchecked, then remove tlag derived variables
       if (modelData.has_lag !== model.has_lag && !modelData.has_lag) {
         modelData.derived_variables = modelData.derived_variables.filter(
@@ -143,7 +144,11 @@ function useModelFormDataCallback({
       }
 
       // if species, species_weight, species_weight_unit changed then update project
-      if (species !== project.species || species_weight !== project.species_weight || species_weight_unit !== project.species_weight_unit) {
+      if (
+        species !== project.species ||
+        species_weight !== project.species_weight ||
+        species_weight_unit !== project.species_weight_unit
+      ) {
         updateProject({
           id: project.id,
           project: { ...project, species, species_weight, species_weight_unit },
@@ -155,11 +160,7 @@ function useModelFormDataCallback({
       }
 
       // Reset form isDirty and isSubmitting state from previous submissions.
-      reset({
-        ...modelData,
-        project: project.id,
-        species,
-      });
+      reset(data);
       return updateModel({ id: model.id, combinedModel: modelData }).then(
         (response) => {
           if (response?.data) {

--- a/frontend-v2/src/features/projects/Project.tsx
+++ b/frontend-v2/src/features/projects/Project.tsx
@@ -142,6 +142,7 @@ const ProjectEditorRow: FC<Props> = ({
 
   const submitForm = useCallback(
     (data: FormData) => {
+      console.log(isDirty, data);
       if (compound && project) {
         if (compound.name !== data.compound.name) {
           dispatch(incrementDirtyCount());
@@ -321,7 +322,7 @@ const ProjectEditorRow: FC<Props> = ({
               getOptionLabel={(option) => option}
               defaultValue={tags}
               onChange={(event, value) =>
-                setValue("project.tags", value.join(","))
+                setValue("project.tags", value.join(","), { shouldDirty: true })
               }
               renderInput={(params) => (
                 <MaterialTextField {...params} variant="standard" />

--- a/frontend-v2/src/features/projects/Project.tsx
+++ b/frontend-v2/src/features/projects/Project.tsx
@@ -142,7 +142,6 @@ const ProjectEditorRow: FC<Props> = ({
 
   const submitForm = useCallback(
     (data: FormData) => {
-      console.log(isDirty, data);
       if (compound && project) {
         if (compound.name !== data.compound.name) {
           dispatch(incrementDirtyCount());


### PR DESCRIPTION
- fix a bug where changes to new form fields aren't immediately reflected in the model form.
- fix a bug where updating project tags didn't mark the project form as dirty.