### PR TITLE
fix(frontend): number fields are strings

### DIFF
--- a/frontend-v2/src/components/FloatField.tsx
+++ b/frontend-v2/src/components/FloatField.tsx
@@ -51,8 +51,7 @@ function FloatField<T extends FieldValues>({
         const handleBlur = (e: FocusEvent<HTMLInputElement>) => {
           const updatedValue = convert(e.target.value);
           if (updatedValue !== value) {
-            e.target.value = updatedValue?.toString() || "";
-            onChange(e);
+            onChange({ target: { value: updatedValue } });
           }
           onBlur();
         };

--- a/frontend-v2/src/components/IntegerField.tsx
+++ b/frontend-v2/src/components/IntegerField.tsx
@@ -41,8 +41,7 @@ function IntegerField<T extends FieldValues>({
         const handleBlur = (e: FocusEvent<HTMLInputElement>) => {
           const updatedValue = convert(e.target.value);
           if (updatedValue !== value) {
-            e.target.value = updatedValue.toString();
-            onChange(e);
+            onChange({ target: { value: updatedValue } });
           }
           onBlur();
         };


### PR DESCRIPTION
Fix a bug where `FloatField` and `IntegerField` inputs both submit their values as strings instead of numbers.