### PR TITLE
fix(frontend): multiple submissions for Trial Design: Add Row

### DIFF
--- a/frontend-v2/src/features/trial/DoseRow.tsx
+++ b/frontend-v2/src/features/trial/DoseRow.tsx
@@ -11,7 +11,7 @@ import {
   useDoseRetrieveQuery,
   useDoseUpdateMutation,
 } from "../../app/backendApi";
-import { Control, useForm } from "react-hook-form";
+import { Control, useForm, useFormState } from "react-hook-form";
 import useDirty from "../../hooks/useDirty";
 
 type Props = {
@@ -48,11 +48,12 @@ const DoseRow: FC<Props> = ({
   const {
     control: doseControl,
     handleSubmit,
-    formState: { isDirty, submitCount },
+    reset,
   } = useForm<DoseRead>({
     defaultValues: dose,
     values: dose,
   });
+  const { isDirty, isSubmitting } = useFormState({ control: doseControl });
   useDirty(isDirty);
 
   const [updateDose] = useDoseUpdateMutation();
@@ -61,19 +62,20 @@ const DoseRow: FC<Props> = ({
     () =>
       handleSubmit(async (data) => {
         if (JSON.stringify(data) !== JSON.stringify(dose)) {
+          reset(data);
           await updateDose({ id: doseId, dose: data });
           refetchDose();
           onChange();
         }
       }),
-    [dose, handleSubmit, doseId, refetchDose, updateDose, onChange],
+    [dose, handleSubmit, doseId, refetchDose, updateDose, onChange, reset],
   );
 
   useEffect(() => {
-    if (isDirty && submitCount === 0) {
+    if (isDirty && !isSubmitting) {
       handleSave();
     }
-  }, [handleSave, isDirty, submitCount]);
+  }, [handleSave, isDirty, isSubmitting]);
 
   const defaultProps = {
     disabled,


### PR DESCRIPTION
Fix a bug where pressing Add Row once adds multiple doses to a protocol.

- replace `submitCount` with `isSubmitting` to check if the form is currently saving.
- use `reset` to immediately reset the form without waiting for the API.