### PR TITLE
fix(frontend): Dose Row project version

### DIFF
--- a/frontend-v2/src/features/trial/DoseRow.tsx
+++ b/frontend-v2/src/features/trial/DoseRow.tsx
@@ -26,6 +26,7 @@ type Props = {
   removeDose: (index: number) => void;
   selectedAmountLabel: string;
   timeUnit?: UnitRead;
+  version_greater_than_2?: boolean;
 };
 
 const DoseRow: FC<Props> = ({
@@ -40,6 +41,7 @@ const DoseRow: FC<Props> = ({
   removeDose,
   selectedAmountLabel,
   timeUnit,
+  version_greater_than_2 = false,
 }) => {
   const { data: dose, refetch: refetchDose } = useDoseRetrieveQuery(
     { id: doseId },
@@ -110,6 +112,7 @@ const DoseRow: FC<Props> = ({
             baseUnit={baseUnit}
             isPreclinicalPerKg={isPreclinical}
             selectProps={defaultProps}
+            version_greater_than_2={version_greater_than_2}
           />
         ) : (
           <Typography>{selectedAmountLabel}</Typography>

--- a/frontend-v2/src/features/trial/Doses.tsx
+++ b/frontend-v2/src/features/trial/Doses.tsx
@@ -195,6 +195,7 @@ const Doses: FC<Props> = ({ onChange, project, protocol, units }) => {
           removeDose={removeDose}
           selectedAmountLabel={selectedAmountLabel}
           timeUnit={units.find((u) => u.id === protocol.time_unit)}
+          version_greater_than_2={version_greater_than_2}
         />
       ))}
     </>


### PR DESCRIPTION
Pass the project version down to `DoseRow`, in Trial Design, so that it can be used by the `UnitField` component.