### PR TITLE
test(frontend): reset Protocols stories between runs

### DIFF
--- a/frontend-v2/src/stories/Protocols.stories.tsx
+++ b/frontend-v2/src/stories/Protocols.stories.tsx
@@ -91,6 +91,9 @@ const meta: Meta<typeof Protocols> = {
       );
     },
   ],
+  beforeEach: () => {
+    protocolMocks = [...projectProtocols];
+  },
 };
 
 export default meta;


### PR DESCRIPTION
Reset Protocols stories between runs, so that rerunning the tests doesn't fail because the expected number of table rows has changed.