### PR TITLE
test(frontend): update mock models

### DIFF
--- a/frontend-v2/src/components/DynamicTabs.tsx
+++ b/frontend-v2/src/components/DynamicTabs.tsx
@@ -70,7 +70,7 @@ export const DynamicTabs: FC<PropsWithChildren<DynamicTabsProps>> = ({
   for (const key in tabErrors) {
     errors[key] = (
       <Tooltip title={tabErrors[key]}>
-        <ErrorIcon color="error" />
+        <ErrorIcon color="error" titleAccess={tabErrors[key]} />
       </Tooltip>
     );
   }


### PR DESCRIPTION
- Update `TabbedModelForm` to add `uppdateModel` and `updateProject` props.
- Update `Model` stories to mock PUT requests for models and projects.
- Update `Model` stories to rerender after PUT requests.
- Add tests for error states after clearing the PK and PD models.