### PR TITLE
test(frontend): clean up tests

### DIFF
--- a/frontend-v2/src/features/projects/Projects.tsx
+++ b/frontend-v2/src/features/projects/Projects.tsx
@@ -106,7 +106,6 @@ const ProjectTable: FC = () => {
     useCompoundListQuery();
 
   const projects = projectsUnordered ? [...projectsUnordered] : undefined;
-  console.log(projects);
 
   const { data: units, isLoading: unitsLoading } = useUnitListQuery({});
 

--- a/frontend-v2/src/stories/Drug.stories.tsx
+++ b/frontend-v2/src/stories/Drug.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, within, screen, fn, waitFor } from "storybook/test";
+import { expect, within, fn, waitFor } from "storybook/test";
 import { useDispatch } from "react-redux";
 import { setProject as setReduxProject } from "../features/main/mainSlice";
 
@@ -53,7 +53,7 @@ type Story = StoryObj<typeof Drug>;
 export const Default: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const drugHeading = await screen.findByRole("heading", {
+    const drugHeading = await canvas.findByRole("heading", {
       name: "Drug & Target",
     });
     expect(drugHeading).toBeInTheDocument();

--- a/frontend-v2/src/stories/Results.stories.tsx
+++ b/frontend-v2/src/stories/Results.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, within, screen } from "storybook/test";
+import { expect, within } from "storybook/test";
 import { useDispatch } from "react-redux";
 import { setProject as setReduxProject } from "../features/main/mainSlice";
 
@@ -126,7 +126,7 @@ export const Default: Story = {
     expect(table1Tab).toBeInTheDocument();
 
     ["Columns", "Rows", "Group", "Interval"].forEach((name) => {
-      const combobox = screen.getByRole("combobox", {
+      const combobox = canvas.getByRole("combobox", {
         name,
       });
       expect(combobox).toBeInTheDocument();


### PR DESCRIPTION
- remove a stray `console.log`.
- fix a couple of tests that were using `screen` instead of `canvas`.