### PR TITLE
fix(frontend): ensure uploaded data has a Group ID column

### DIFF
--- a/frontend-v2/src/features/data/MapObservations.tsx
+++ b/frontend-v2/src/features/data/MapObservations.tsx
@@ -37,6 +37,7 @@ import {
   getTableHeight,
 } from "../../shared/calculateTableHeights";
 import { TableHeader } from "../../components/TableHeader";
+import { groupDataRows } from "./Stratification";
 
 interface IMapObservations {
   state: StepperState;
@@ -116,6 +117,15 @@ const MapObservations: FC<IMapObservations> = ({
     observationVariables,
   } = useObservationRows(state, selectedGroup);
   const uniqueObservationIds = [...new Set(observationIds)];
+
+  const [firstRow] = state.data;
+  if (!firstRow["Group ID"]) {
+    const newData = groupDataRows(state.data, state.groupColumn);
+    state.setData(newData);
+    state.setNormalisedFields(
+      new Map([...state.normalisedFields.entries(), ["Group ID", "Group ID"]]),
+    );
+  }
 
   if (!variables || !units) {
     return <Typography>Loading...</Typography>;

--- a/frontend-v2/src/features/data/Stratification.tsx
+++ b/frontend-v2/src/features/data/Stratification.tsx
@@ -49,7 +49,10 @@ function validateGroupProtocols(groups: Group[], protocols: IProtocol[]) {
  * @param columnName
  * @returns data with group ID and administration ID columns.
  */
-function groupDataRows(data: { [key: string]: string }[], columnName: string) {
+export function groupDataRows(
+  data: { [key: string]: string }[],
+  columnName: string,
+) {
   const newData = data.map((row) => ({ ...row }));
   newData.forEach((row) => {
     row["Group ID"] = row[columnName] || "1";

--- a/frontend-v2/src/stories/Data.withData.stories.tsx
+++ b/frontend-v2/src/stories/Data.withData.stories.tsx
@@ -172,15 +172,6 @@ export const MapObservations: Story = {
 
     await EditDataset.play?.(context);
 
-    // There's a bug where you need to stratify a dataset before editing observations.
-    const stratificationButton = await canvas.findByRole("button", {
-      name: /Stratification/i,
-    });
-    expect(stratificationButton).toBeInTheDocument();
-    await userEvent.click(stratificationButton);
-
-    await delay(1000);
-
     const mapObservationsButton = await canvas.findByRole("button", {
       name: /Map Observations/i,
     });


### PR DESCRIPTION
There's a bug in the Map Observations tab where uploaded data isn't divided into groups if you go straight to that tab without going through the Stratification step. This fixes that bug by passing the uploaded CSV once through the `groupDataRows` function.