### PR TITLE
test(frontend): reset RTK query cache for Results

### DIFF
--- a/frontend-v2/src/stories/Results.stories.tsx
+++ b/frontend-v2/src/stories/Results.stories.tsx
@@ -8,6 +8,8 @@ import { project, projectHandlers } from "./project.mock";
 import { simulationData } from "./simulations.mock";
 import { http, delay, HttpResponse } from "msw";
 import { SimulationContext } from "../contexts/SimulationContext";
+import { store } from "../app/store";
+import { api } from "../app/api";
 
 const resultsTables = [
   {
@@ -106,6 +108,7 @@ const meta: Meta<typeof Results> = {
   ],
   beforeEach: () => {
     mockResultsTables = [...resultsTables]; // Reset mock data before each story
+    store.dispatch(api.util.resetApiState()); // Reset API state
   },
 };
 export default meta;
@@ -142,6 +145,11 @@ export const Default: Story = {
 export const AddNewTable: Story = {
   play: async ({ canvasElement, userEvent }) => {
     const canvas = within(canvasElement);
+    const table1Tab = await canvas.findByRole("tab", {
+      name: "Table 1",
+    });
+    expect(table1Tab).toBeInTheDocument();
+
     const addButton = await canvas.findByRole("button", {
       name: /Add Table/i,
     });


### PR DESCRIPTION
Reset the RTK query cache between Results tests, to avoid 'Add Table' also adding a table to the default story.