### PR TITLE
test(frontend): reset RTK query cache for all beforeEach blocks

### DIFF
--- a/frontend-v2/src/stories/Projects.stories.tsx
+++ b/frontend-v2/src/stories/Projects.stories.tsx
@@ -8,6 +8,8 @@ import { project, projectHandlers } from "./project.mock";
 import { ProjectDescriptionProvider } from "../shared/contexts/ProjectDescriptionContext";
 import { setProject as setReduxProject } from "../features/main/mainSlice";
 import { useDispatch } from "react-redux";
+import { store } from "../app/store";
+import { api } from "../app/api";
 
 let mockProjects = [project];
 
@@ -128,6 +130,7 @@ const meta: Meta<typeof Projects> = {
   ],
   beforeEach: () => {
     mockProjects = [project];
+    store.dispatch(api.util.resetApiState()); // Reset API state
   },
 };
 type Story = StoryObj<typeof Projects>;

--- a/frontend-v2/src/stories/Protocols.stories.tsx
+++ b/frontend-v2/src/stories/Protocols.stories.tsx
@@ -12,6 +12,8 @@ import {
 } from "./protocols.mock";
 import { DoseRead, ProtocolRead, SubjectGroupRead } from "../app/backendApi";
 import { useState } from "react";
+import { store } from "../app/store";
+import { api } from "../app/api";
 
 let protocolMocks: ProtocolRead[] = [...projectProtocols];
 let groupMocks: SubjectGroupRead[] = [...groups];
@@ -151,6 +153,7 @@ const meta: Meta<typeof Protocols> = {
   beforeEach: () => {
     protocolMocks = [...projectProtocols];
     groupMocks = [...groups];
+    store.dispatch(api.util.resetApiState()); // Reset API state
   },
 };
 


### PR DESCRIPTION
Reset the RTK query cache between tests for Projects and Protocols.