### PR TITLE
test(frontend): reset RTK query cache between tests

### DIFF
--- a/frontend-v2/src/stories/Data.withData.stories.tsx
+++ b/frontend-v2/src/stories/Data.withData.stories.tsx
@@ -14,6 +14,8 @@ import {
   protocols,
   subjects,
 } from "./dataset.mock";
+import { store } from "../app/store";
+import { api } from "../app/api";
 
 const datasetHandlers = [
   http.get("/api/dataset/:id", async () => {
@@ -63,6 +65,9 @@ const meta: Meta<typeof Data> = {
       return <Story />;
     },
   ],
+  beforeEach: async () => {
+    store.dispatch(api.util.resetApiState());
+  },
 };
 
 export default meta;
@@ -123,6 +128,7 @@ export const EditDataset: Story = {
       name: /Edit Dataset/i,
     });
     expect(editDatasetButton).toBeInTheDocument();
+    await waitFor(() => expect(editDatasetButton).toBeEnabled());
     await userEvent.click(editDatasetButton);
 
     const notificationsButton = await canvas.findByRole("button", {

--- a/frontend-v2/src/stories/Drug.stories.tsx
+++ b/frontend-v2/src/stories/Drug.stories.tsx
@@ -6,6 +6,8 @@ import { setProject as setReduxProject } from "../features/main/mainSlice";
 import Drug from "../features/drug/Drug";
 import { project, projectHandlers } from "./project.mock";
 import { http, delay, HttpResponse } from "msw";
+import { store } from "../app/store";
+import { api } from "../app/api";
 
 const compoundSpy = fn();
 
@@ -45,6 +47,9 @@ const meta: Meta<typeof Drug> = {
       return <Story />;
     },
   ],
+  beforeEach: async () => {
+    store.dispatch(api.util.resetApiState());
+  },
 };
 export default meta;
 

--- a/frontend-v2/src/stories/Model.stories.tsx
+++ b/frontend-v2/src/stories/Model.stories.tsx
@@ -19,6 +19,8 @@ import {
 } from "./project.mock";
 import { pd_model, pkModels, pdModels } from "./model.mock";
 import { useEffect } from "react";
+import { store } from "../app/store";
+import { api } from "../app/api";
 
 const meta: Meta<typeof TabbedModelForm> = {
   title: "Edit Model",
@@ -96,6 +98,9 @@ const meta: Meta<typeof TabbedModelForm> = {
       );
     },
   ],
+  beforeEach: async () => {
+    store.dispatch(api.util.resetApiState());
+  },
 };
 
 export default meta;
@@ -135,7 +140,7 @@ export const ShowMMTModel: Story = {
   play: async ({ canvasElement, userEvent }) => {
     const canvas = within(canvasElement);
 
-    const showMMTButton = canvas.getByRole("button", {
+    const showMMTButton = await canvas.findByRole("button", {
       name: /Show MMT Code/i,
     });
     expect(showMMTButton).toBeInTheDocument();


### PR DESCRIPTION
Make sure the RTK query cache is clean before each Drug, Model, and Data (edit dataset) test.