### PR TITLE
test(frontend): reset RTK query cache for Data stories

### DIFF
--- a/frontend-v2/src/stories/Data.noData.stories.tsx
+++ b/frontend-v2/src/stories/Data.noData.stories.tsx
@@ -8,6 +8,8 @@ import { project, projectHandlers } from "./project.mock";
 import testCSV from "./mockData/Data.File_pkpd.explorer_06.js";
 
 import { HttpResponse, http } from "msw";
+import { store } from "../app/store";
+import { api } from "../app/api";
 
 const datasetHandlers = [
   http.get("/api/dataset/:id", () => {
@@ -51,6 +53,10 @@ const meta: Meta<typeof Data> = {
       return <Story />;
     },
   ],
+  beforeEach: async () => {
+    // Reset the API state before each story
+    store.dispatch(api.util.resetApiState());
+  },
 };
 
 export default meta;


### PR DESCRIPTION
Reset the RTK query cache between tests for Data stories. 