### PR TITLE
test(frontend): reset RTK cache for simulations

### DIFF
--- a/frontend-v2/src/stories/Simulation.stories.tsx
+++ b/frontend-v2/src/stories/Simulation.stories.tsx
@@ -12,6 +12,8 @@ import { simulationData } from "./simulations.mock";
 
 import Simulations from "../features/simulation/Simulations";
 import { Box } from "@mui/material";
+import { store } from "../app/store";
+import { api } from "../app/api";
 
 const simulationSpy = fn();
 
@@ -70,6 +72,9 @@ const meta: Meta<typeof Simulations> = {
       );
     },
   ],
+  beforeEach: async () => {
+    store.dispatch(api.util.resetApiState());
+  },
 };
 
 export default meta;
@@ -146,11 +151,10 @@ export const AddNewPlot: Story = {
 
 export const EditPlot: Story = {
   play: async ({ canvasElement, userEvent }) => {
-    let plot = canvasElement.querySelector("svg.main-svg");
-    await waitFor(() => {
-      plot = canvasElement.querySelector("svg.main-svg");
-      expect(plot).toBeInTheDocument();
-    });
+    // Wait for Plotly to load the plots.
+    await delay(2000);
+    const plot = canvasElement.querySelector("svg.main-svg");
+    expect(plot).toBeInTheDocument();
     const dragLayer = plot?.querySelector("rect.drag");
     await userEvent.hover(dragLayer!);
     const editButton = canvasElement.querySelector(


### PR DESCRIPTION
Clear the RTK query cache between tests for Simulations. Add an artificial delay when waiting for plotly to render simulation plots.