### PR TITLE
fix(frontend): catch empty Map Dosing units

### DIFF
--- a/frontend-v2/src/features/data/MapDosing.tsx
+++ b/frontend-v2/src/features/data/MapDosing.tsx
@@ -52,7 +52,10 @@ function useApiQueries() {
     { skip: !model?.id },
   );
 
+  const loading = [projectProtocols, units, variables];
+
   return {
+    isLoading: loading.some((x) => !x),
     amountUnit,
     projectProtocols,
     units,
@@ -74,7 +77,12 @@ const MapDosing: FC<IMapDosing> = ({
   );
 
   // Fetch API data.
-  const { amountUnit, projectProtocols, units, variables } = useApiQueries();
+  const { isLoading, amountUnit, projectProtocols, units, variables } =
+    useApiQueries();
+
+  if (isLoading) {
+    return null;
+  }
 
   const hasInvalidUnits =
     !!amountUnitField &&

--- a/frontend-v2/src/stories/Data.withData.stories.tsx
+++ b/frontend-v2/src/stories/Data.withData.stories.tsx
@@ -123,12 +123,16 @@ export const Default: Story = {
 export const EditDataset: Story = {
   play: async ({ canvasElement, userEvent }) => {
     const canvas = within(canvasElement);
-
     const editDatasetButton = await canvas.findByRole("button", {
       name: /Edit Dataset/i,
     });
-    expect(editDatasetButton).toBeInTheDocument();
-    await waitFor(() => expect(editDatasetButton).toBeEnabled());
+    await waitFor(() =>
+      expect(
+        canvas.getByRole("button", {
+          name: /Edit Dataset/i,
+        }),
+      ).toBeEnabled(),
+    );
     await userEvent.click(editDatasetButton);
 
     const notificationsButton = await canvas.findByRole("button", {


### PR DESCRIPTION
Fix a bug where the unit selects in Map Dosing are empty if the component renders before any API data has loaded.