### PR TITLE
test(frontend): clean RTK query cache globally

### DIFF
--- a/frontend-v2/.storybook/preview.tsx
+++ b/frontend-v2/.storybook/preview.tsx
@@ -2,6 +2,7 @@ import type { Preview } from "@storybook/react-vite";
 import { Provider } from "react-redux";
 import { initialize, mswLoader } from "msw-storybook-addon";
 import { store } from "../src/app/store";
+import { api } from "../src/app/api";
 
 /*
  * Initializes MSW
@@ -9,6 +10,7 @@ import { store } from "../src/app/store";
  * to learn how to customize it
  */
 initialize({
+  quiet: true, // Set to true to avoid logging in the console
   serviceWorker: {
     url: `${import.meta.env.BASE_URL}mockServiceWorker.js`,
   },
@@ -55,6 +57,9 @@ const preview: Preview = {
   ],
   tags: ["autodocs"],
   loaders: [mswLoader],
+  beforeEach: async () => {
+    store.dispatch(api.util.resetApiState());
+  },
 };
 
 export default preview;

--- a/frontend-v2/src/stories/Data.noData.stories.tsx
+++ b/frontend-v2/src/stories/Data.noData.stories.tsx
@@ -8,8 +8,6 @@ import { project, projectHandlers } from "./project.mock";
 import testCSV from "./mockData/Data.File_pkpd.explorer_06.js";
 
 import { HttpResponse, http } from "msw";
-import { store } from "../app/store";
-import { api } from "../app/api";
 
 const datasetHandlers = [
   http.get("/api/dataset/:id", () => {
@@ -53,10 +51,6 @@ const meta: Meta<typeof Data> = {
       return <Story />;
     },
   ],
-  beforeEach: async () => {
-    // Reset the API state before each story
-    store.dispatch(api.util.resetApiState());
-  },
 };
 
 export default meta;

--- a/frontend-v2/src/stories/Data.withData.stories.tsx
+++ b/frontend-v2/src/stories/Data.withData.stories.tsx
@@ -14,8 +14,6 @@ import {
   protocols,
   subjects,
 } from "./dataset.mock";
-import { store } from "../app/store";
-import { api } from "../app/api";
 
 const datasetHandlers = [
   http.get("/api/dataset/:id", async () => {
@@ -65,9 +63,6 @@ const meta: Meta<typeof Data> = {
       return <Story />;
     },
   ],
-  beforeEach: async () => {
-    store.dispatch(api.util.resetApiState());
-  },
 };
 
 export default meta;

--- a/frontend-v2/src/stories/Drug.stories.tsx
+++ b/frontend-v2/src/stories/Drug.stories.tsx
@@ -6,8 +6,6 @@ import { setProject as setReduxProject } from "../features/main/mainSlice";
 import Drug from "../features/drug/Drug";
 import { project, projectHandlers } from "./project.mock";
 import { http, delay, HttpResponse } from "msw";
-import { store } from "../app/store";
-import { api } from "../app/api";
 
 const compoundSpy = fn();
 
@@ -47,9 +45,6 @@ const meta: Meta<typeof Drug> = {
       return <Story />;
     },
   ],
-  beforeEach: async () => {
-    store.dispatch(api.util.resetApiState());
-  },
 };
 export default meta;
 

--- a/frontend-v2/src/stories/Model.stories.tsx
+++ b/frontend-v2/src/stories/Model.stories.tsx
@@ -19,8 +19,6 @@ import {
 } from "./project.mock";
 import { pd_model, pkModels, pdModels } from "./model.mock";
 import { useEffect } from "react";
-import { store } from "../app/store";
-import { api } from "../app/api";
 
 const meta: Meta<typeof TabbedModelForm> = {
   title: "Edit Model",
@@ -98,9 +96,6 @@ const meta: Meta<typeof TabbedModelForm> = {
       );
     },
   ],
-  beforeEach: async () => {
-    store.dispatch(api.util.resetApiState());
-  },
 };
 
 export default meta;

--- a/frontend-v2/src/stories/Projects.stories.tsx
+++ b/frontend-v2/src/stories/Projects.stories.tsx
@@ -8,8 +8,6 @@ import { project, projectHandlers } from "./project.mock";
 import { ProjectDescriptionProvider } from "../shared/contexts/ProjectDescriptionContext";
 import { setProject as setReduxProject } from "../features/main/mainSlice";
 import { useDispatch } from "react-redux";
-import { store } from "../app/store";
-import { api } from "../app/api";
 
 let mockProjects = [project];
 
@@ -130,7 +128,6 @@ const meta: Meta<typeof Projects> = {
   ],
   beforeEach: () => {
     mockProjects = [project];
-    store.dispatch(api.util.resetApiState()); // Reset API state
   },
 };
 type Story = StoryObj<typeof Projects>;

--- a/frontend-v2/src/stories/Protocols.stories.tsx
+++ b/frontend-v2/src/stories/Protocols.stories.tsx
@@ -12,8 +12,6 @@ import {
 } from "./protocols.mock";
 import { DoseRead, ProtocolRead, SubjectGroupRead } from "../app/backendApi";
 import { useState } from "react";
-import { store } from "../app/store";
-import { api } from "../app/api";
 
 let protocolMocks: ProtocolRead[] = [...projectProtocols];
 let groupMocks: SubjectGroupRead[] = [...groups];
@@ -153,7 +151,6 @@ const meta: Meta<typeof Protocols> = {
   beforeEach: () => {
     protocolMocks = [...projectProtocols];
     groupMocks = [...groups];
-    store.dispatch(api.util.resetApiState()); // Reset API state
   },
 };
 

--- a/frontend-v2/src/stories/Results.stories.tsx
+++ b/frontend-v2/src/stories/Results.stories.tsx
@@ -8,8 +8,6 @@ import { project, projectHandlers } from "./project.mock";
 import { simulationData } from "./simulations.mock";
 import { http, delay, HttpResponse } from "msw";
 import { SimulationContext } from "../contexts/SimulationContext";
-import { store } from "../app/store";
-import { api } from "../app/api";
 
 const resultsTables = [
   {
@@ -108,7 +106,6 @@ const meta: Meta<typeof Results> = {
   ],
   beforeEach: () => {
     mockResultsTables = [...resultsTables]; // Reset mock data before each story
-    store.dispatch(api.util.resetApiState()); // Reset API state
   },
 };
 export default meta;

--- a/frontend-v2/src/stories/Simulation.stories.tsx
+++ b/frontend-v2/src/stories/Simulation.stories.tsx
@@ -12,8 +12,6 @@ import { simulationData } from "./simulations.mock";
 
 import Simulations from "../features/simulation/Simulations";
 import { Box } from "@mui/material";
-import { store } from "../app/store";
-import { api } from "../app/api";
 
 const simulationSpy = fn();
 
@@ -72,9 +70,6 @@ const meta: Meta<typeof Simulations> = {
       );
     },
   ],
-  beforeEach: async () => {
-    store.dispatch(api.util.resetApiState());
-  },
 };
 
 export default meta;


### PR DESCRIPTION
Clean the RTK query cache globally, rather than for individual stories.

Turn off console logs for MSW requests, to reduce noise in CI.