### PR TITLE
test(frontend): clean up tests

### DIFF
--- a/frontend-v2/src/stories/Data.withData.stories.tsx
+++ b/frontend-v2/src/stories/Data.withData.stories.tsx
@@ -130,6 +130,9 @@ export const EditDataset: Story = {
     );
     await userEvent.click(editDatasetButton);
 
+    await canvas.findByRole("button", {
+      name: /Upload data/i,
+    });
     const notificationsButton = await canvas.findByRole("button", {
       name: "Notifications 1",
     });


### PR DESCRIPTION
- remove unused args from `Protocols.stories``.
- add spies to track PUT requests to `/api/protocol/:id` and `/api/dose/:id`.
- wait for the data stepper to load before running dataset tests.