### PR TITLE
test(frontend): simulation with subject groups

### DIFF
--- a/frontend-v2/src/stories/project.mock.ts
+++ b/frontend-v2/src/stories/project.mock.ts
@@ -6116,21 +6116,25 @@ export const projectHandlers = [
     //@ts-expect-error params.id is a string
     const projectId = parseInt(params.id, 10);
     const projectData = await request.json();
-    //@ts-expect-error projectData is DefaultBodyType
-    mockProject = { ...projectData, id: projectId };
-    return HttpResponse.json(project, {
-      status: 200,
-    });
+    return HttpResponse.json(
+      // @ts-expect-error projectData is DefaultBodyType
+      { id: projectId, ...projectData },
+      {
+        status: 200,
+      },
+    );
   }),
   http.put("/api/simulation/:id", async ({ params, request }) => {
     await delay();
     //@ts-expect-error params.id is a string
     const simulationId = parseInt(params.id, 10);
     const simulationData = await request.json();
-    //@ts-expect-error projectData is DefaultBodyType
-    mockSimulation = { ...simulationData, id: simulationId };
-    return HttpResponse.json(simulation, {
-      status: 200,
-    });
+    return HttpResponse.json(
+      // @ts-expect-error simulationData is DefaultBodyType
+      { id: simulationId, ...simulationData },
+      {
+        status: 200,
+      },
+    );
   }),
 ];


### PR DESCRIPTION
Add subject groups to the Simulation stories, with tests for the Groups button in the sidebar.