### PR TITLE
fix(a11y): support keyboard navigation for tabs

### DIFF
--- a/frontend-v2/src/components/DynamicTabs.tsx
+++ b/frontend-v2/src/components/DynamicTabs.tsx
@@ -125,7 +125,7 @@ export const DynamicTabs: FC<PropsWithChildren<DynamicTabsProps>> = ({
           <Tabs
             value={currentTab}
             onChange={handleChange}
-            aria-label="basic tabs example"
+            selectionFollowsFocus
           >
             {tabNames.map((name, index) => (
               <Tab

--- a/frontend-v2/src/features/data/Data.tsx
+++ b/frontend-v2/src/features/data/Data.tsx
@@ -268,7 +268,7 @@ const Data: FC = () => {
           </Button>
         </Grid>
       </Grid>
-      <Tabs value={tab} onChange={handleTabChange}>
+      <Tabs value={tab} onChange={handleTabChange} selectionFollowsFocus>
         {groups?.map((group, index) => (
           <Tab key={group.id} label={group.name} {...a11yProps(index)} />
         ))}

--- a/frontend-v2/src/features/data/MapObservations.tsx
+++ b/frontend-v2/src/features/data/MapObservations.tsx
@@ -383,7 +383,7 @@ const MapObservations: FC<IMapObservations> = ({
           </Table>
         </TableContainer>
         <TableHeader label="Groups" />
-        <Tabs value={tab} onChange={handleTabChange}>
+        <Tabs value={tab} onChange={handleTabChange} selectionFollowsFocus>
           {groupIDs.map((groupID, index) => (
             <Tab
               key={groupID}

--- a/frontend-v2/src/features/data/Stratification.tsx
+++ b/frontend-v2/src/features/data/Stratification.tsx
@@ -226,7 +226,7 @@ const Stratification: FC<IStratification> = ({
           If you want to move individuals between groups or assign them to a new
           group, select them first and then follow the instructions."
         />
-        <Tabs value={tab} onChange={handleTabChange}>
+        <Tabs value={tab} onChange={handleTabChange} selectionFollowsFocus>
           {groups.map((group, index) => (
             <Tab key={group.name} label={group.name} {...a11yProps(index)} />
           ))}

--- a/frontend-v2/src/features/results/Results.tsx
+++ b/frontend-v2/src/features/results/Results.tsx
@@ -96,6 +96,7 @@ const Results: FC = () => {
           variant="scrollable"
           scrollButtons
           allowScrollButtonsMobile
+          selectionFollowsFocus
           sx={{ width: "fit-content" }}
         >
           {results?.map((table, index) => {

--- a/frontend-v2/src/features/trial/Protocols.tsx
+++ b/frontend-v2/src/features/trial/Protocols.tsx
@@ -256,6 +256,7 @@ export const Protocols: FC<ProtocolsProps> = ({
           variant="scrollable"
           scrollButtons
           allowScrollButtonsMobile
+          selectionFollowsFocus
           sx={{ width: "fit-content" }}
           value={tab}
           onChange={handleTabChange}


### PR DESCRIPTION
Add `selectionFollowsFocus` to all tab lists, so that they can be navigated with the cursor keys.