### PR TITLE
test(frontend): console warnings in Results tab

### DIFF
--- a/frontend-v2/src/features/results/Results.tsx
+++ b/frontend-v2/src/features/results/Results.tsx
@@ -51,7 +51,7 @@ const Results: FC = () => {
       groupIndex: 0,
       intervalIndex: 0,
     };
-    createResults({ resultsTable: newTable });
+    await createResults({ resultsTable: newTable });
     setTab(results.length);
   };
 
@@ -62,7 +62,7 @@ const Results: FC = () => {
   const handleTabRemove = async (table: ResultsTableRead) => {
     if (window.confirm("Are you sure you want to delete the current Table?")) {
       const removedIndex = results?.map(({ id }) => id).indexOf(table.id) || -1;
-      deleteResults({ id: table.id });
+      await deleteResults({ id: table.id });
 
       if (removedIndex === tab) {
         setTab(removedIndex - 1);

--- a/frontend-v2/src/features/results/ResultsTab.tsx
+++ b/frontend-v2/src/features/results/ResultsTab.tsx
@@ -69,6 +69,15 @@ const ResultsTab: FC<{ table: ResultsTableRead }> = ({ table }) => {
   );
   const { updateResults } = useResults();
 
+  const loaded =
+    (groups.length &&
+      intervals.length &&
+      concentrationVariables.length &&
+      parameters.length) > 0;
+  if (!loaded) {
+    return <div>Loading...</div>;
+  }
+
   const groupIndex: FilterIndex =
     columns === "groups" ? "columns" : rows === "groups" ? "rows" : group;
   const variableIndex: FilterIndex =

--- a/frontend-v2/src/stories/Results.stories.tsx
+++ b/frontend-v2/src/stories/Results.stories.tsx
@@ -158,8 +158,8 @@ export const Default: Story = {
     });
     expect(table1Tab).toBeInTheDocument();
 
-    ["Columns", "Rows", "Group", "Interval"].forEach((name) => {
-      const combobox = canvas.getByRole("combobox", {
+    ["Columns", "Rows", "Group", "Interval"].forEach(async (name) => {
+      const combobox = await canvas.findByRole("combobox", {
         name,
       });
       expect(combobox).toBeInTheDocument();


### PR DESCRIPTION
Results prints warnings in the console if a results table renders before its API data is ready. This fixes that by adding a loading state and waiting for some async requests to complete before updating state.