### PR TITLE
fix(frontend): delete tab breaks active tab

### DIFF
--- a/frontend-v2/src/features/results/Results.tsx
+++ b/frontend-v2/src/features/results/Results.tsx
@@ -56,12 +56,23 @@ const Results: FC = () => {
   };
 
   const handleTabChange = async (event: SyntheticEvent, newValue: number) => {
+    if ((event.target as HTMLButtonElement).name === "remove") {
+      return; // Prevent tab change when clicking on the remove icon
+    }
     setTab(newValue);
   };
 
-  const handleTabRemove = async (table: ResultsTableRead) => {
+  interface HandleTabRemove {
+    (
+      table: ResultsTableRead,
+    ): (event: React.MouseEvent<HTMLButtonElement>) => Promise<void>;
+  }
+
+  const handleTabRemove: HandleTabRemove = (table) => async (event) => {
+    event.stopPropagation();
+    event.preventDefault();
     if (window.confirm("Are you sure you want to delete the current Table?")) {
-      const removedIndex = results?.map(({ id }) => id).indexOf(table.id) || -1;
+      const removedIndex = results?.findIndex((t) => t.id === table.id);
       await deleteResults({ id: table.id });
 
       if (removedIndex === tab) {
@@ -108,12 +119,7 @@ const Results: FC = () => {
                 sx={{ maxHeight: "48px", minHeight: 0 }}
                 icon={
                   index === 0 ? undefined : (
-                    <IconButton
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleTabRemove(table);
-                      }}
-                    >
+                    <IconButton name="remove" onClick={handleTabRemove(table)}>
                       <RemoveCircleOutlineIcon fontSize="small" />
                     </IconButton>
                   )

--- a/frontend-v2/src/features/results/useResults.ts
+++ b/frontend-v2/src/features/results/useResults.ts
@@ -27,13 +27,13 @@ export function useResults() {
     async createResults({ resultsTable }: { resultsTable: ResultsTableRead }) {
       await createResults({ resultsTable });
       if (projectId) {
-        refetch();
+        return refetch();
       }
     },
     async deleteResults({ id }: { id: number }) {
       await deleteResults({ id });
       if (projectId) {
-        refetch();
+        return refetch();
       }
     },
   };


### PR DESCRIPTION
Deleting a tab also selects that tab, because tabs are using invalid nested buttons. This works around that by ignoring clicks on the remove button in `handleTabChange`.

Fix some bugs in the way that tab changes were handled by Trial Design.