### PR TITLE
refactor(frontend): data stepper state

### DIFF
--- a/frontend-v2/src/features/data/CreateDosingProtocols.tsx
+++ b/frontend-v2/src/features/data/CreateDosingProtocols.tsx
@@ -119,17 +119,15 @@ function createDosingRows(
     });
   });
   newRows.sort((a, b) => parseInt(a[idField]) - parseInt(b[idField]));
-  state.setData([...nextData, ...newRows]);
-  state.setNormalisedFields(
-    new Map([
-      ...state.normalisedFields.entries(),
-      ["Amount Variable", "Amount Variable"],
-      ["Amount Unit", "Amount Unit"],
-      ["Infusion Duration", "Infusion Duration"],
-      ["Additional Doses", "Additional Doses"],
-      ["Interdose Interval", "Interdose Interval"],
-    ]),
-  );
+  state.data = [...nextData, ...newRows];
+  state.normalisedFields = new Map([
+    ...state.normalisedFields.entries(),
+    ["Amount Variable", "Amount Variable"],
+    ["Amount Unit", "Amount Unit"],
+    ["Infusion Duration", "Infusion Duration"],
+    ["Additional Doses", "Additional Doses"],
+    ["Interdose Interval", "Interdose Interval"],
+  ]);
 }
 
 type NumericTableCellProps = {
@@ -215,8 +213,8 @@ const CreateDosingProtocols: FC<IDosingProtocols> = ({
       ["Amount", "Amount"],
     ]);
     const newData = state.data.map((row) => ({ ...row, Amount: "." }));
-    state.setNormalisedFields(newNormalisedFields);
-    state.setData(newData);
+    state.normalisedFields = newNormalisedFields;
+    state.data = newData;
   }
   const missingAdministrationIds = dosingRows.some(
     (row) => !(administrationIdField in row),
@@ -243,7 +241,7 @@ const CreateDosingProtocols: FC<IDosingProtocols> = ({
         .forEach((row) => {
           row[field] = value;
         });
-      state.setData(nextData);
+      state.data = nextData;
     };
 
   return (

--- a/frontend-v2/src/features/data/DosingProtocols.tsx
+++ b/frontend-v2/src/features/data/DosingProtocols.tsx
@@ -104,13 +104,11 @@ const DosingProtocols: FC<IDosingProtocols> = ({
         .forEach((row) => {
           row[amountVariableField] = value;
         });
-      state.setData(nextData);
-      state.setNormalisedFields(
-        new Map([
-          ...state.normalisedFields.entries(),
-          [amountVariableField, "Amount Variable"],
-        ]),
-      );
+      state.data = nextData;
+      state.normalisedFields = new Map([
+        ...state.normalisedFields.entries(),
+        [amountVariableField, "Amount Variable"],
+      ]);
     };
   const handleAmountUnitChange = (id: string) => (event: SelectChangeEvent) => {
     const nextData = [...state.data];
@@ -126,15 +124,15 @@ const DosingProtocols: FC<IDosingProtocols> = ({
       ...state.normalisedFields.entries(),
       [amountUnitField, "Amount Unit"],
     ]);
-    state.setData(nextData);
-    state.setNormalisedFields(newNormalisedFields);
+    state.data = nextData;
+    state.normalisedFields = newNormalisedFields;
     const { errors, warnings } = validateState({
       ...state,
       data: nextData,
       normalisedFields: newNormalisedFields,
     });
-    state.setErrors(errors);
-    state.setWarnings(warnings);
+    state.errors = errors;
+    state.warnings = warnings;
   };
 
   return (

--- a/frontend-v2/src/features/data/LoadData.tsx
+++ b/frontend-v2/src/features/data/LoadData.tsx
@@ -54,9 +54,9 @@ interface ILoadDataProps {
 function updateDataAndResetFields(state: StepperState, data: Data) {
   if (data.length > 0) {
     const newFields = Object.keys(data[0]);
-    state.setData(data);
+    state.data = data;
     const normalisedFields = new Map(newFields.map(normaliseHeader));
-    state.setNormalisedFields(normalisedFields);
+    state.normalisedFields = normalisedFields;
   }
 }
 
@@ -101,7 +101,7 @@ function setMinimumInfusionTime(
     row[infusionTimeField] =
       infusionTime === 0 ? "0.0833" : row[infusionTimeField];
   });
-  state.setData(newData);
+  state.data = newData;
 }
 
 function useApiQueries() {
@@ -127,30 +127,30 @@ const LoadData: FC<ILoadDataProps> = ({ state, notificationsInfo }) => {
 
   const onDrop = useCallback(
     (acceptedFiles: File[]) => {
-      state.setTimeUnit("");
-      state.setAmountUnit("");
-      state.setErrors([]);
-      state.setWarnings([]);
+      state.timeUnit = "";
+      state.amountUnit = "";
+      state.errors = [];
+      state.warnings = [];
       acceptedFiles.forEach((file) => {
         const reader = new FileReader();
 
-        reader.onabort = () => state.setErrors(["file reading was aborted"]);
-        reader.onerror = () => state.setErrors(["file reading has failed"]);
+        reader.onabort = () => (state.errors = ["file reading was aborted"]);
+        reader.onerror = () => (state.errors = ["file reading has failed"]);
         reader.onload = () => {
           if (!ALLOWED_TYPES.includes(file.type)) {
-            state.setErrors([
+            state.errors = [
               "Only CSV files are supported. Please upload a CSV file.",
-            ]);
+            ];
             return;
           }
-          state.setFileName(file.name);
+          state.fileName = file.name;
           // Parse the CSV data
           const rawCsv = reader.result as string;
           const csvData = Papa.parse(rawCsv.trim(), { header: true });
           const fields = csvData.meta.fields || [];
           const normalisedFields = new Map(fields.map(normaliseHeader));
-          state.setData(csvData.data as Data);
-          state.setNormalisedFields(normalisedFields);
+          state.data = csvData.data as Data;
+          state.normalisedFields = normalisedFields;
           // Make a copy of the new state that we can pass to validators.
           const csvState = {
             ...state,
@@ -160,7 +160,7 @@ const LoadData: FC<ILoadDataProps> = ({ state, notificationsInfo }) => {
             normalisedHeaders: [...normalisedFields.values()],
           };
           const fieldValidation = validateState(csvState);
-          state.setHasDosingRows(validateDosingRows(csvState));
+          state.hasDosingRows = validateDosingRows(csvState);
           const groupColumn =
             fields.find(
               (field) => normalisedFields.get(field) === "Cat Covariate",
@@ -168,9 +168,9 @@ const LoadData: FC<ILoadDataProps> = ({ state, notificationsInfo }) => {
           const errors = csvData.errors
             .map((e) => e.message)
             .concat(fieldValidation.errors);
-          state.setGroupColumn(groupColumn);
-          state.setErrors(errors);
-          state.setWarnings(fieldValidation.warnings);
+          state.groupColumn = groupColumn;
+          state.errors = errors;
+          state.warnings = fieldValidation.warnings;
         };
         reader.readAsText(file);
       });
@@ -204,14 +204,14 @@ const LoadData: FC<ILoadDataProps> = ({ state, notificationsInfo }) => {
   }
 
   const setNormalisedFields = (normalisedFields: Map<Field, string>) => {
-    state.setNormalisedFields(normalisedFields);
+    state.normalisedFields = normalisedFields;
     const { errors, warnings } = validateState({
       ...state,
       normalisedFields,
       normalisedHeaders: [...normalisedFields.values()],
     });
-    state.setErrors(errors);
-    state.setWarnings(warnings);
+    state.errors = errors;
+    state.warnings = warnings;
   };
 
   return (

--- a/frontend-v2/src/features/data/LoadDataStepper.tsx
+++ b/frontend-v2/src/features/data/LoadDataStepper.tsx
@@ -56,25 +56,16 @@ type Field = string;
 
 export type StepperState = {
   fileName: string;
-  setFileName: (fileName: string) => void;
   fields: Field[];
   normalisedHeaders: Field[];
   normalisedFields: Map<Field, string>;
-  setNormalisedFields: (normalisedFields: Map<Field, string>) => void;
   data: Data;
-  setData: (data: Data) => void;
   errors: string[];
-  setErrors: (errors: string[]) => void;
   warnings: string[];
-  setWarnings: (warnings: string[]) => void;
   timeUnit?: string;
-  setTimeUnit: (timeUnit: string) => void;
   amountUnit?: string;
-  setAmountUnit: (amountUnit: string) => void;
   groupColumn: string;
-  setGroupColumn: (primaryCohort: string) => void;
   hasDosingRows: boolean;
-  setHasDosingRows: (hasDosingRows: boolean) => void;
 };
 
 function validateSubjectProtocols(protocols: IProtocol[]) {
@@ -119,24 +110,60 @@ const LoadDataStepper: FC<IStepper> = ({ csv = "", onCancel, onFinish }) => {
     setIsNotificationsOpen(!isNotificationsOpen);
 
   const state = {
-    fileName,
-    setFileName,
-    normalisedFields,
-    setNormalisedFields,
-    data,
-    setData,
-    errors,
-    setErrors,
-    warnings,
-    setWarnings,
-    timeUnit,
-    setTimeUnit,
-    amountUnit,
-    setAmountUnit,
-    groupColumn,
-    setGroupColumn,
-    hasDosingRows,
-    setHasDosingRows,
+    get fileName() {
+      return fileName;
+    },
+    set fileName(newFileName: string) {
+      setFileName(newFileName);
+    },
+    get normalisedFields() {
+      return normalisedFields;
+    },
+    set normalisedFields(newNormalisedFields: Map<Field, string>) {
+      setNormalisedFields(newNormalisedFields);
+    },
+    get data() {
+      return data;
+    },
+    set data(newData: Data) {
+      setData(newData);
+    },
+    get errors() {
+      return errors;
+    },
+    set errors(newErrors: string[]) {
+      setErrors(newErrors);
+    },
+    get warnings() {
+      return warnings;
+    },
+    set warnings(newWarnings: string[]) {
+      setWarnings(newWarnings);
+    },
+    get timeUnit() {
+      return timeUnit;
+    },
+    set timeUnit(newTimeUnit: string | undefined) {
+      setTimeUnit(newTimeUnit);
+    },
+    get amountUnit() {
+      return amountUnit;
+    },
+    set amountUnit(newAmountUnit: string | undefined) {
+      setAmountUnit(newAmountUnit);
+    },
+    get groupColumn() {
+      return groupColumn;
+    },
+    set groupColumn(newGroupColumn: string) {
+      setGroupColumn(newGroupColumn);
+    },
+    get hasDosingRows() {
+      return hasDosingRows;
+    },
+    set hasDosingRows(newHasDosingRows: boolean) {
+      setHasDosingRows(newHasDosingRows);
+    },
     get fields() {
       return [...normalisedFields.keys()];
     },

--- a/frontend-v2/src/features/data/MapDosing.tsx
+++ b/frontend-v2/src/features/data/MapDosing.tsx
@@ -97,7 +97,7 @@ const MapDosing: FC<IMapDosing> = ({
     const newNormalisedFields = new Map(state.normalisedFields);
     newNormalisedFields.set(amountUnitField, "Ignore");
     newNormalisedFields.set("Amount Unit", "Amount Unit");
-    state.setNormalisedFields(newNormalisedFields);
+    state.normalisedFields = newNormalisedFields;
   }
 
   const dosingCompartments = projectProtocols

--- a/frontend-v2/src/features/data/MapObservations.tsx
+++ b/frontend-v2/src/features/data/MapObservations.tsx
@@ -128,10 +128,11 @@ const MapObservations: FC<IMapObservations> = ({
   const [firstRow] = state.data;
   if (!firstRow["Group ID"]) {
     const newData = groupDataRows(state.data, state.groupColumn);
-    state.setData(newData);
-    state.setNormalisedFields(
-      new Map([...state.normalisedFields.entries(), ["Group ID", "Group ID"]]),
-    );
+    state.data = newData;
+    state.normalisedFields = new Map([
+      ...state.normalisedFields.entries(),
+      ["Group ID", "Group ID"],
+    ]);
     return <Typography>Loading...</Typography>;
   }
 
@@ -183,8 +184,8 @@ const MapObservations: FC<IMapObservations> = ({
         [observationVariableField, "Observation Variable"],
         [observationUnitField, "Observation Unit"],
       ]);
-      state.setData(nextData);
-      state.setNormalisedFields(newNormalisedFields);
+      state.data = nextData;
+      state.normalisedFields = newNormalisedFields;
       const { errors, warnings } = validateState({
         ...state,
         data: nextData,
@@ -193,8 +194,8 @@ const MapObservations: FC<IMapObservations> = ({
       if (!validUnit) {
         errors.push("Mapped observation variables must have units.");
       }
-      state.setErrors(errors);
-      state.setWarnings(warnings);
+      state.errors = errors;
+      state.warnings = warnings;
     };
   const handleUnitChange = (id: string) => (event: SelectChangeEvent) => {
     const nextData = [...state.data];
@@ -206,7 +207,7 @@ const MapObservations: FC<IMapObservations> = ({
       .forEach((row) => {
         row[observationUnitField] = value;
       });
-    state.setData(nextData);
+    state.data = nextData;
     const { errors, warnings } = validateState({
       ...state,
       data: nextData,
@@ -224,8 +225,8 @@ const MapObservations: FC<IMapObservations> = ({
     if (!validUnit) {
       errors.push("Mapped observation variables must have units.");
     }
-    state.setErrors(errors);
-    state.setWarnings(warnings);
+    state.errors = errors;
+    state.warnings = warnings;
   };
 
   function handleTabChange(

--- a/frontend-v2/src/features/data/PreviewData.tsx
+++ b/frontend-v2/src/features/data/PreviewData.tsx
@@ -44,8 +44,8 @@ function normaliseDataColumn(state: StepperState, type: string) {
       delete newRow[field];
       return newRow;
     });
-    state.setData(newData);
-    state.setNormalisedFields(newNormalisedFields);
+    state.data = newData;
+    state.normalisedFields = newNormalisedFields;
     return newData;
   }
   return state.data;

--- a/frontend-v2/src/features/data/SetUnits.tsx
+++ b/frontend-v2/src/features/data/SetUnits.tsx
@@ -64,7 +64,7 @@ const SetUnits: FC<IMapObservations> = ({
     ) || "Time Unit";
 
   function setTimeUnit(event: SelectChangeEvent) {
-    state.setTimeUnit(event.target?.value);
+    state.timeUnit = event.target?.value;
     const newData = state.data.map((row) => ({
       ...row,
       "Time Unit": event.target?.value,
@@ -74,14 +74,14 @@ const SetUnits: FC<IMapObservations> = ({
       [timeUnitField, "Ignore"],
       ["Time Unit", "Time Unit"],
     ]);
-    state.setData(newData);
-    state.setNormalisedFields(newNormalisedFields);
+    state.data = newData;
+    state.normalisedFields = newNormalisedFields;
     const { errors, warnings } = validateState({
       ...state,
       normalisedFields: newNormalisedFields,
     });
-    state.setErrors(errors);
-    state.setWarnings(warnings);
+    state.errors = errors;
+    state.warnings = warnings;
     setIsChanged(true);
     setHasTimeUnitChanged(true);
   }

--- a/frontend-v2/src/features/data/Stratification.tsx
+++ b/frontend-v2/src/features/data/Stratification.tsx
@@ -88,7 +88,7 @@ const Stratification: FC<IStratification> = ({
 
   const [firstRow] = state.data;
   const [tab, setTab] = useState(0);
-  const { groupColumn, setGroupColumn } = state;
+  const { groupColumn } = state;
 
   const groups = groupsFromCatCovariate(state, groupColumn);
   const isValidGrouping = validateGroupMembers(groups);
@@ -96,14 +96,14 @@ const Stratification: FC<IStratification> = ({
     "Invalid group subjects. Each subject ID can only belong to a single cohort.";
   if (!isValidGrouping && !state.errors.includes(groupErrorMessage)) {
     const newErrors = [...state.errors, groupErrorMessage];
-    state.setErrors(newErrors);
+    state.errors = newErrors;
   }
 
   if (isValidGrouping && state.errors.includes(groupErrorMessage)) {
     const newErrors = state.errors.filter(
       (error) => error !== groupErrorMessage,
     );
-    state.setErrors(newErrors);
+    state.errors = newErrors;
   }
 
   const isValidDosing = validateGroupProtocols(groups, protocols);
@@ -114,19 +114,20 @@ const Stratification: FC<IStratification> = ({
     const newErrors = state.errors.filter(
       (error) => error !== doseErrorMessage,
     );
-    state.setErrors(newErrors);
+    state.errors = newErrors;
   }
   if (!isValidDosing && !state.errors.includes(doseErrorMessage)) {
     const newErrors = [...state.errors, doseErrorMessage];
-    state.setErrors(newErrors);
+    state.errors = newErrors;
   }
 
   if (!firstRow["Group ID"]) {
     const newData = groupDataRows(state.data, groupColumn);
-    state.setData(newData);
-    state.setNormalisedFields(
-      new Map([...state.normalisedFields.entries(), ["Group ID", "Group ID"]]),
-    );
+    state.data = newData;
+    state.normalisedFields = new Map([
+      ...state.normalisedFields.entries(),
+      ["Group ID", "Group ID"],
+    ]);
     return <Typography>Loading…</Typography>;
   }
 
@@ -140,8 +141,8 @@ const Stratification: FC<IStratification> = ({
   const handleGroupChange = (event: ChangeEvent<HTMLInputElement>) => {
     const newGroup = event.target.value;
     const newData = groupDataRows(state.data, newGroup);
-    setGroupColumn(newGroup);
-    state.setData(newData);
+    state.groupColumn = newGroup;
+    state.data = newData;
   };
 
   function a11yProps(index: number) {

--- a/frontend-v2/src/features/data/SubjectGroupForm.tsx
+++ b/frontend-v2/src/features/data/SubjectGroupForm.tsx
@@ -37,7 +37,7 @@ const SubjectGroupForm: FC<ISubjectGroupForm> = ({
           row["Group ID"] = newValue;
         });
     });
-    state.setData(newData);
+    state.data = newData;
   }
 
   return (

--- a/frontend-v2/src/features/data/useObservationRows.ts
+++ b/frontend-v2/src/features/data/useObservationRows.ts
@@ -62,8 +62,8 @@ export default function useObservationRows(state: StepperState, tab: string) {
     ) as Map<string, string>;
     normalisedFields.set("Observation", "Observation");
     normalisedFields.set("Observation ID", "Observation ID");
-    state.setNormalisedFields(normalisedFields);
-    state.setData(rows);
+    state.normalisedFields = normalisedFields;
+    state.data = rows;
   }
   const observationRows = observationField
     ? rows.filter(


### PR DESCRIPTION
Clean up data stepper state by using getters and setters for properties of the `state` object.