### PR TITLE
refactor(frontend): data stepper state updates

### DIFF
--- a/frontend-v2/src/features/data/LoadData.tsx
+++ b/frontend-v2/src/features/data/LoadData.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Stack, Typography } from "@mui/material";
 import Papa from "papaparse";
-import { FC, useCallback } from "react";
+import { FC, useCallback, useEffect } from "react";
 import { useDropzone } from "react-dropzone";
 import MapHeaders from "./MapHeaders";
 import {
@@ -125,6 +125,28 @@ const LoadData: FC<ILoadDataProps> = ({ state, notificationsInfo }) => {
 
   const { isProjectLoading, isSharedWithMe } = useApiQueries();
 
+  useEffect(() => {
+    if (!normalisedHeaders.includes("ID")) {
+      createDefaultSubjects(state);
+    }
+    if (!normalisedHeaders.includes("Cat Covariate")) {
+      createDefaultSubjectGroup(state);
+    }
+
+    if (normalisedHeaders.includes("Infusion Duration")) {
+      const infusionTimeField =
+        state.fields.find(
+          (field) => state.normalisedFields.get(field) === "Infusion Duration",
+        ) || "Infusion Duration";
+      const hasZeroInfusionTime = state.data.some(
+        (row) => parseFloat(row[infusionTimeField]) === 0,
+      );
+      if (hasZeroInfusionTime) {
+        setMinimumInfusionTime(state, infusionTimeField);
+      }
+    }
+  }, [normalisedHeaders, state]);
+
   const onDrop = useCallback(
     (acceptedFiles: File[]) => {
       state.timeUnit = "";
@@ -181,27 +203,6 @@ const LoadData: FC<ILoadDataProps> = ({ state, notificationsInfo }) => {
     onDrop,
     noClick: true,
   });
-
-  if (!normalisedHeaders.includes("ID")) {
-    createDefaultSubjects(state);
-  }
-  if (!normalisedHeaders.includes("Cat Covariate")) {
-    createDefaultSubjectGroup(state);
-  }
-
-  if (normalisedHeaders.includes("Infusion Duration")) {
-    const infusionTimeField =
-      state.fields.find(
-        (field) => state.normalisedFields.get(field) === "Infusion Duration",
-      ) || "Infusion Duration";
-    const hasZeroInfusionTime = state.data.some(
-      (row) => parseFloat(row[infusionTimeField]) === 0,
-    );
-    if (hasZeroInfusionTime) {
-      setMinimumInfusionTime(state, infusionTimeField);
-      return <Typography>Loading…</Typography>;
-    }
-  }
 
   const setNormalisedFields = (normalisedFields: Map<Field, string>) => {
     state.normalisedFields = normalisedFields;

--- a/frontend-v2/src/features/data/MapDosing.tsx
+++ b/frontend-v2/src/features/data/MapDosing.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, useEffect } from "react";
 import DosingProtocols from "./DosingProtocols";
 import CreateDosingProtocols from "./CreateDosingProtocols";
 import { StepperState } from "./LoadDataStepper";
@@ -80,24 +80,27 @@ const MapDosing: FC<IMapDosing> = ({
   const { isLoading, amountUnit, projectProtocols, units, variables } =
     useApiQueries();
 
+  useEffect(() => {
+    const hasInvalidUnits =
+      !!amountUnitField &&
+      state.data
+        .map((row) => row[amountUnitField])
+        .some((symbol) => !units?.find((unit) => unit.symbol === symbol));
+    if (
+      !isLoading &&
+      hasInvalidUnits &&
+      amountUnitField !== "Amount Unit" &&
+      state.normalisedFields.get(amountUnitField) !== "Ignore"
+    ) {
+      const newNormalisedFields = new Map(state.normalisedFields);
+      newNormalisedFields.set(amountUnitField, "Ignore");
+      newNormalisedFields.set("Amount Unit", "Amount Unit");
+      state.normalisedFields = newNormalisedFields;
+    }
+  }, [amountUnitField, isLoading, state, units]);
+
   if (isLoading) {
     return null;
-  }
-
-  const hasInvalidUnits =
-    !!amountUnitField &&
-    state.data
-      .map((row) => row[amountUnitField])
-      .some((symbol) => !units?.find((unit) => unit.symbol === symbol));
-  if (
-    hasInvalidUnits &&
-    amountUnitField !== "Amount Unit" &&
-    state.normalisedFields.get(amountUnitField) !== "Ignore"
-  ) {
-    const newNormalisedFields = new Map(state.normalisedFields);
-    newNormalisedFields.set(amountUnitField, "Ignore");
-    newNormalisedFields.set("Amount Unit", "Amount Unit");
-    state.normalisedFields = newNormalisedFields;
   }
 
   const dosingCompartments = projectProtocols

--- a/frontend-v2/src/features/data/MapObservations.tsx
+++ b/frontend-v2/src/features/data/MapObservations.tsx
@@ -1,4 +1,4 @@
-import { FC, SyntheticEvent, useState } from "react";
+import { FC, SyntheticEvent, useEffect, useState } from "react";
 import { DataGrid } from "@mui/x-data-grid";
 import {
   Box,
@@ -125,16 +125,17 @@ const MapObservations: FC<IMapObservations> = ({
   } = useObservationRows(state, selectedGroup);
   const uniqueObservationIds = [...new Set(observationIds)];
 
-  const [firstRow] = state.data;
-  if (!firstRow["Group ID"]) {
-    const newData = groupDataRows(state.data, state.groupColumn);
-    state.data = newData;
-    state.normalisedFields = new Map([
-      ...state.normalisedFields.entries(),
-      ["Group ID", "Group ID"],
-    ]);
-    return <Typography>Loading...</Typography>;
-  }
+  useEffect(() => {
+    const [firstRow] = state.data;
+    if (!firstRow["Group ID"]) {
+      const newData = groupDataRows(state.data, state.groupColumn);
+      state.data = newData;
+      state.normalisedFields = new Map([
+        ...state.normalisedFields.entries(),
+        ["Group ID", "Group ID"],
+      ]);
+    }
+  }, [state]);
 
   if (!variables || !units) {
     return <Typography>Loading...</Typography>;

--- a/frontend-v2/src/features/data/PreviewData.tsx
+++ b/frontend-v2/src/features/data/PreviewData.tsx
@@ -1,5 +1,5 @@
-import { FC } from "react";
-import { Box, Typography } from "@mui/material";
+import { FC, useEffect } from "react";
+import { Box } from "@mui/material";
 import { DataGrid } from "@mui/x-data-grid";
 import { StepperState } from "./LoadDataStepper";
 import { validateDataRow } from "./dataValidation";
@@ -65,14 +65,13 @@ const PreviewData: FC<IPreviewData> = ({
       (header) =>
         !["Cat Covariate", "Cont Covariate", "Ignore"].includes(header),
     );
-  let dataChanged = false;
-  normalisedHeaders.forEach((header) => {
-    const newData = normaliseDataColumn(state, header);
-    dataChanged = dataChanged || newData !== state.data;
-  });
-  if (dataChanged) {
-    return <Typography>Loading…</Typography>;
-  }
+
+  useEffect(() => {
+    normalisedHeaders.forEach((header) => {
+      normaliseDataColumn(state, header);
+    });
+  }, [normalisedHeaders, state]);
+
   const { data, fields } = state;
   const visibleFields = fields.filter(
     (field) =>

--- a/frontend-v2/src/features/data/Stratification.tsx
+++ b/frontend-v2/src/features/data/Stratification.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FC, SyntheticEvent, useState } from "react";
+import { ChangeEvent, FC, SyntheticEvent, useEffect, useState } from "react";
 import {
   Box,
   Radio,
@@ -91,45 +91,47 @@ const Stratification: FC<IStratification> = ({
   const { groupColumn } = state;
 
   const groups = groupsFromCatCovariate(state, groupColumn);
-  const isValidGrouping = validateGroupMembers(groups);
-  const groupErrorMessage =
-    "Invalid group subjects. Each subject ID can only belong to a single cohort.";
-  if (!isValidGrouping && !state.errors.includes(groupErrorMessage)) {
-    const newErrors = [...state.errors, groupErrorMessage];
-    state.errors = newErrors;
-  }
 
-  if (isValidGrouping && state.errors.includes(groupErrorMessage)) {
-    const newErrors = state.errors.filter(
-      (error) => error !== groupErrorMessage,
-    );
-    state.errors = newErrors;
-  }
+  useEffect(() => {
+    const isValidGrouping = validateGroupMembers(groups);
+    const groupErrorMessage =
+      "Invalid group subjects. Each subject ID can only belong to a single cohort.";
+    if (!isValidGrouping && !state.errors.includes(groupErrorMessage)) {
+      const newErrors = [...state.errors, groupErrorMessage];
+      state.errors = newErrors;
+    }
 
-  const isValidDosing = validateGroupProtocols(groups, protocols);
-  const doseErrorMessage =
-    "Doses within a group are inconsistent. Please choose another grouping or ignore administration columns and enter the dosing information in Trial Design.";
+    if (isValidGrouping && state.errors.includes(groupErrorMessage)) {
+      const newErrors = state.errors.filter(
+        (error) => error !== groupErrorMessage,
+      );
+      state.errors = newErrors;
+    }
 
-  if (isValidDosing && state.errors.includes(doseErrorMessage)) {
-    const newErrors = state.errors.filter(
-      (error) => error !== doseErrorMessage,
-    );
-    state.errors = newErrors;
-  }
-  if (!isValidDosing && !state.errors.includes(doseErrorMessage)) {
-    const newErrors = [...state.errors, doseErrorMessage];
-    state.errors = newErrors;
-  }
+    const isValidDosing = validateGroupProtocols(groups, protocols);
+    const doseErrorMessage =
+      "Doses within a group are inconsistent. Please choose another grouping or ignore administration columns and enter the dosing information in Trial Design.";
 
-  if (!firstRow["Group ID"]) {
-    const newData = groupDataRows(state.data, groupColumn);
-    state.data = newData;
-    state.normalisedFields = new Map([
-      ...state.normalisedFields.entries(),
-      ["Group ID", "Group ID"],
-    ]);
-    return <Typography>Loading…</Typography>;
-  }
+    if (isValidDosing && state.errors.includes(doseErrorMessage)) {
+      const newErrors = state.errors.filter(
+        (error) => error !== doseErrorMessage,
+      );
+      state.errors = newErrors;
+    }
+    if (!isValidDosing && !state.errors.includes(doseErrorMessage)) {
+      const newErrors = [...state.errors, doseErrorMessage];
+      state.errors = newErrors;
+    }
+
+    if (!firstRow["Group ID"]) {
+      const newData = groupDataRows(state.data, groupColumn);
+      state.data = newData;
+      state.normalisedFields = new Map([
+        ...state.normalisedFields.entries(),
+        ["Group ID", "Group ID"],
+      ]);
+    }
+  }, [groupColumn, groups, protocols, state, firstRow]);
 
   const handleTabChange = (
     event: SyntheticEvent<Element, Event>,


### PR DESCRIPTION
Individual data stepper step components set `LoadDataStepper` state during render, which generates console warnings during the tests and can lead to subtle bugs. Fixed here by moving stepper state updates into `useEffect` hooks.