### PR TITLE
test(frontend): add lag time to model variables

### DIFF
--- a/frontend-v2/src/features/model/variables/AdditionalParametersRow.tsx
+++ b/frontend-v2/src/features/model/variables/AdditionalParametersRow.tsx
@@ -235,6 +235,7 @@ const AdditionalParametersRow: FC<Props> = ({
                   onClick={onClickDerived("TLG")}
                   data-cy={`checkbox-tlag-${variable.name}`}
                   disabled={isSharedWithMe}
+                  aria-label={`Lag time: ${variable.name}`}
                 />
               }
               label=""

--- a/frontend-v2/src/stories/Model.stories.tsx
+++ b/frontend-v2/src/stories/Model.stories.tsx
@@ -208,7 +208,7 @@ export const Default: Story = {
   },
 };
 
-export const ShowMMTModel: Story = {
+export const ShowMMTCode: Story = {
   play: async ({ canvasElement, userEvent }) => {
     const canvas = within(canvasElement);
     await canvas.findByRole("tab", { name: /PK\/PD Model/i });
@@ -294,6 +294,42 @@ export const PDModel: Story = {
     expect(pdModelList).toHaveTextContent(
       "indirect_effects_stimulation_elimination",
     );
+  },
+};
+
+export const LagTime: Story = {
+  play: async ({ canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByRole("tab", { name: /PK\/PD Model/i });
+
+    const lagTimeCheckbox = await canvas.findByRole("checkbox", {
+      name: /Lag time/i,
+    });
+    expect(lagTimeCheckbox).toBeInTheDocument();
+    expect(lagTimeCheckbox).not.toBeChecked();
+    await userEvent.click(lagTimeCheckbox);
+    expect(lagTimeCheckbox).toBeChecked();
+
+    await delay(1000); // Wait for the model to update
+    const errorTab = await canvas.findByRole("tab", {
+      name: /Map Variables Please select a lag time variable/i,
+    });
+    expect(errorTab).toBeInTheDocument();
+    await userEvent.click(errorTab);
+
+    const lagTimeCheckbox2 = await canvas.findByRole("checkbox", {
+      name: /Lag time: A1/i,
+    });
+    expect(lagTimeCheckbox2).toBeInTheDocument();
+    expect(lagTimeCheckbox2).not.toBeChecked();
+    await userEvent.click(lagTimeCheckbox2);
+    expect(lagTimeCheckbox2).toBeChecked();
+
+    // Test that the error message has disappeared.
+    const mapVariablesTab = await canvas.findByRole("tab", {
+      name: "Map Variables",
+    });
+    expect(mapVariablesTab).toBeInTheDocument();
   },
 };
 


### PR DESCRIPTION
Add a story to test adding a lag time to the dosing compartment. Fix a bug where the lag time checkbox isn't labelled, under Map Variables.