### PR TITLE
fix(backend): MMT files for v3 PD models

### DIFF
--- a/pkpdapp/pkpdapp/migrations/0034_version_3_pd_models.py
+++ b/pkpdapp/pkpdapp/migrations/0034_version_3_pd_models.py
@@ -1,0 +1,69 @@
+#
+# This file is part of PKPDApp (https://github.com/pkpdapp-team/pkpdapp) which
+# is released under the BSD 3-clause license. See accompanying LICENSE.md for
+# copyright notice and full license details.
+#
+
+from django.db import migrations
+import myokit
+import csv
+
+
+# Update the MMT strings for all pharmacodynamic models.
+def update_pd_models(apps, schema_editor):
+    PharmacodynamicModel = apps.get_model("pkpdapp", "PharmacodynamicModel")
+
+    with open("pkpdapp/migrations/models-v3/models.csv", newline="") as csvfile:
+        models = csv.reader(csvfile, delimiter=";")
+        first_row = models.__next__()
+        first_row_expect = [
+            "filename",
+            "type",
+            "1-compartment",
+            "2-compartment",
+            "3-compartment",
+            "PK",
+            "TMDD",
+            "QSS",
+            "MM",
+            "bispecific",
+            "soluble",
+            "constant",
+            "direct",
+            "indirect",
+            "TGI",
+            "DDI",
+        ]
+        for i, col in enumerate(first_row):
+            assert col == first_row_expect[i]
+        for row in models:
+            # tags are 1-compartment to the end
+            filename = row[0]
+            if (
+                row[1] == "PK-Model"
+                or row[1] == "PK-Extravascular"
+                or row[1] == "PK-Effect-Compartment"
+            ):
+                # Ignore PK models.
+                continue
+            else:
+                mmt_filename = f"pkpdapp/migrations/models-v3/{filename}"
+                mmt_string = open(mmt_filename, "r").read()
+                myokit_model = myokit.parse(mmt_string)[0]
+                myokit_model.validate()
+                model_name = myokit_model.meta["name"]
+                model = PharmacodynamicModel.objects.get(name=model_name)
+                print("updating model", model.name)
+                model.mmt = mmt_string
+                model.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("pkpdapp", "0033_alter_project_tags"),
+    ]
+
+    operations = [
+        migrations.RunPython(update_pd_models),
+    ]

--- a/pkpdapp/pkpdapp/migrations/models-v3/PD-Models/Indirect-Effects/DDI/Competitive-inhibition_DDI.mmt
+++ b/pkpdapp/pkpdapp/migrations/models-v3/PD-Models/Indirect-Effects/DDI/Competitive-inhibition_DDI.mmt
@@ -4,19 +4,19 @@ author: Michael Gertz
 
 
 # Initial values:
-PKCompartment.Aa_victim = 0
-PKCompartment.Atr1_victim = 0
-PKCompartment.Atr2_victim = 0
-PKCompartment.Atr3_victim = 0
-PKCompartment.A1_victim = 0
-PKCompartment.A2_victim = 0
-PKCompartment.A3_victim = 0
+PDCompartment.Aa_victim = 0
+PDCompartment.Atr1_victim = 0
+PDCompartment.Atr2_victim = 0
+PDCompartment.Atr3_victim = 0
+PDCompartment.A1_victim = 0
+PDCompartment.A2_victim = 0
+PDCompartment.A3_victim = 0
 
 [environment]
 t = 0 in [h] bind time
 
 
-[PKCompartment]
+[PDCompartment]
 
 Ki = 100000 in [pmol/L]
 	desc: Inhibition constant

--- a/pkpdapp/pkpdapp/migrations/models-v3/PD-Models/Indirect-Effects/DDI/Time-dependent-and-competitive_DDI.mmt
+++ b/pkpdapp/pkpdapp/migrations/models-v3/PD-Models/Indirect-Effects/DDI/Time-dependent-and-competitive_DDI.mmt
@@ -4,20 +4,20 @@ author: Michael Gertz
 
 
 # Initial values:
-PKCompartment.Aa_victim = 0
-PKCompartment.Atr1_victim = 0
-PKCompartment.Atr2_victim = 0
-PKCompartment.Atr3_victim = 0
-PKCompartment.A1_victim = 0
-PKCompartment.A2_victim = 0
-PKCompartment.A3_victim = 0
-PKCompartment.Enzyme = 1
+PDCompartment.Aa_victim = 0
+PDCompartment.Atr1_victim = 0
+PDCompartment.Atr2_victim = 0
+PDCompartment.Atr3_victim = 0
+PDCompartment.A1_victim = 0
+PDCompartment.A2_victim = 0
+PDCompartment.A3_victim = 0
+PDCompartment.Enzyme = 1
 
 [environment]
 t = 0 in [h] bind time
 
 
-[PKCompartment]
+[PDCompartment]
 
 Ki = 100000 in [pmol/L]
 	desc: Inhibition constant

--- a/pkpdapp/pkpdapp/migrations/models-v3/PD-Models/Indirect-Effects/DDI/Time-dependent-induction_DDI.mmt
+++ b/pkpdapp/pkpdapp/migrations/models-v3/PD-Models/Indirect-Effects/DDI/Time-dependent-induction_DDI.mmt
@@ -4,20 +4,20 @@ author: Michael Gertz
 
 
 # Initial values:
-PKCompartment.Aa_victim = 0
-PKCompartment.Atr1_victim = 0
-PKCompartment.Atr2_victim = 0
-PKCompartment.Atr3_victim = 0
-PKCompartment.A1_victim = 0
-PKCompartment.A2_victim = 0
-PKCompartment.A3_victim = 0
-PKCompartment.Enzyme = 1
+PDCompartment.Aa_victim = 0
+PDCompartment.Atr1_victim = 0
+PDCompartment.Atr2_victim = 0
+PDCompartment.Atr3_victim = 0
+PDCompartment.A1_victim = 0
+PDCompartment.A2_victim = 0
+PDCompartment.A3_victim = 0
+PDCompartment.Enzyme = 1
 
 [environment]
 t = 0 in [h] bind time
 
 
-[PKCompartment]
+[PDCompartment]
 
 C50_IND = 100000 in [pmol/L]
 	desc: Time-dependent induction constant

--- a/pkpdapp/pkpdapp/migrations/models-v3/PD-Models/Indirect-Effects/DDI/Time-dependent-inhibition_DDI.mmt
+++ b/pkpdapp/pkpdapp/migrations/models-v3/PD-Models/Indirect-Effects/DDI/Time-dependent-inhibition_DDI.mmt
@@ -4,20 +4,20 @@ author: Michael Gertz
 
 
 # Initial values:
-PKCompartment.Aa_victim = 0
-PKCompartment.Atr1_victim = 0
-PKCompartment.Atr2_victim = 0
-PKCompartment.Atr3_victim = 0
-PKCompartment.A1_victim = 0
-PKCompartment.A2_victim = 0
-PKCompartment.A3_victim = 0
-PKCompartment.Enzyme = 1
+PDCompartment.Aa_victim = 0
+PDCompartment.Atr1_victim = 0
+PDCompartment.Atr2_victim = 0
+PDCompartment.Atr3_victim = 0
+PDCompartment.A1_victim = 0
+PDCompartment.A2_victim = 0
+PDCompartment.A3_victim = 0
+PDCompartment.Enzyme = 1
 
 [environment]
 t = 0 in [h] bind time
 
 
-[PKCompartment]
+[PDCompartment]
 
 KI_TDI = 100000 in [pmol/L]
 	desc: Time-dependent inhibition constant

--- a/pkpdapp/pkpdapp/migrations/models-v3/PD-Models/Indirect-Effects/TGI/Inhibition/TGI_signal-distribution_Emax-kill.mmt
+++ b/pkpdapp/pkpdapp/migrations/models-v3/PD-Models/Indirect-Effects/TGI/Inhibition/TGI_signal-distribution_Emax-kill.mmt
@@ -15,30 +15,33 @@ t = 0 in [h] bind time
 
 
 [PDCompartment]
-	
+
 TS0 = 0.1 in [mL]
 	desc: Initial tumor volume/ size
 	
-kmax = 0.015 in [1/h]
+kmax = 0.05 in [1/h]
 	desc: Maximal kill rate constant
 	
 C50 = 1000000 in [pmol/L]
 	desc: Concentration of half-maximal effect
-
+	
+HC = 1 in [dimensionless]
+	desc: Hill coefficient
+	
 Mtt = 72 in [h]
 	desc: Average duration of transduction
 	
-tau = Mtt/3 in [h]
+tau = Mtt/3 in [h] 
   desc: Delay in treatment effect
 
-C_Drug = 1 in [pmol/L]
+C_Drug = 1 in [pmol/L]	
 	desc: Drug concentration causing tumor killing
 
-Kill = kmax * (1 - exp(-log(2)/C50 * C_Drug)) in [1/h]
+Kill = kmax * C_Drug^HC / (C50^HC + C_Drug^HC) in [1/h]
 	desc: Tumor kill rate constant
 
 dot(TS) = -K3*TS in [mL]
-	desc: Tumor size/ size 
+	desc: Tumor volume/ size 
 	
 dot(K1) = (Kill-K1)/tau in [1/h]
 	desc: Transit compartment 1 (delay of killing due to signal distribution) 

--- a/pkpdapp/pkpdapp/migrations/models-v3/PD-Models/Indirect-Effects/TGI/Inhibition/TGI_signal-distribution_Emax-kill.mmt
+++ b/pkpdapp/pkpdapp/migrations/models-v3/PD-Models/Indirect-Effects/TGI/Inhibition/TGI_signal-distribution_Emax-kill.mmt
@@ -1,5 +1,5 @@
 [[model]]
-name: TGI signal distribution model (exp(conc) prop kill)
+name: TGI signal distribution model (Emax kill)
 author: Michael Gertz, Soledad Castano
 
 
@@ -15,33 +15,30 @@ t = 0 in [h] bind time
 
 
 [PDCompartment]
-
+	
 TS0 = 0.1 in [mL]
 	desc: Initial tumor volume/ size
 	
-kmax = 0.05 in [1/h]
+kmax = 0.015 in [1/h]
 	desc: Maximal kill rate constant
 	
 C50 = 1000000 in [pmol/L]
 	desc: Concentration of half-maximal effect
-	
-HC = 1 in [dimensionless]
-	desc: Hill coefficient
-	
+
 Mtt = 72 in [h]
 	desc: Average duration of transduction
 	
-tau = Mtt/3 in [h] 
+tau = Mtt/3 in [h]
   desc: Delay in treatment effect
 
-C_Drug = 1 in [pmol/L]	
+C_Drug = 1 in [pmol/L]
 	desc: Drug concentration causing tumor killing
 
-Kill = kmax * C_Drug^HC / (C50^HC + C_Drug^HC) in [1/h]
+Kill = kmax * (1 - exp(-log(2)/C50 * C_Drug)) in [1/h]
 	desc: Tumor kill rate constant
 
 dot(TS) = -K3*TS in [mL]
-	desc: Tumor volume/ size 
+	desc: Tumor size/ size 
 	
 dot(K1) = (Kill-K1)/tau in [1/h]
 	desc: Transit compartment 1 (delay of killing due to signal distribution) 

--- a/pkpdapp/pkpdapp/migrations/models-v3/PD-Models/Indirect-Effects/TGI/Inhibition/TGI_signal-distribution_econc-prop-kill.mmt
+++ b/pkpdapp/pkpdapp/migrations/models-v3/PD-Models/Indirect-Effects/TGI/Inhibition/TGI_signal-distribution_econc-prop-kill.mmt
@@ -15,33 +15,30 @@ t = 0 in [h] bind time
 
 
 [PDCompartment]
-
+	
 TS0 = 0.1 in [mL]
 	desc: Initial tumor volume/ size
 	
-kmax = 0.05 in [1/h]
+kmax = 0.015 in [1/h]
 	desc: Maximal kill rate constant
 	
 C50 = 1000000 in [pmol/L]
 	desc: Concentration of half-maximal effect
-	
-HC = 1 in [dimensionless]
-	desc: Hill coefficient
-	
+
 Mtt = 72 in [h]
 	desc: Average duration of transduction
 	
-tau = Mtt/3 in [h] 
+tau = Mtt/3 in [h]
   desc: Delay in treatment effect
 
-C_Drug = 1 in [pmol/L]	
+C_Drug = 1 in [pmol/L]
 	desc: Drug concentration causing tumor killing
 
-Kill = kmax * C_Drug^HC / (C50^HC + C_Drug^HC) in [1/h]
+Kill = kmax * (1 - exp(-log(2)/C50 * C_Drug)) in [1/h]
 	desc: Tumor kill rate constant
 
 dot(TS) = -K3*TS in [mL]
-	desc: Tumor volume/ size 
+	desc: Tumor size/ size 
 	
 dot(K1) = (Kill-K1)/tau in [1/h]
 	desc: Transit compartment 1 (delay of killing due to signal distribution) 

--- a/pkpdapp/pkpdapp/migrations/models-v3/PD-Models/Indirect-Effects/TGI/Inhibition/TGI_signal-distribution_econc-prop-kill.mmt
+++ b/pkpdapp/pkpdapp/migrations/models-v3/PD-Models/Indirect-Effects/TGI/Inhibition/TGI_signal-distribution_econc-prop-kill.mmt
@@ -1,5 +1,5 @@
 [[model]]
-name: TGI signal distribution model (Emax kill)
+name: TGI signal distribution model (exp(conc) prop kill)
 author: Michael Gertz, Soledad Castano
 
 
@@ -15,30 +15,33 @@ t = 0 in [h] bind time
 
 
 [PDCompartment]
-	
+
 TS0 = 0.1 in [mL]
 	desc: Initial tumor volume/ size
 	
-kmax = 0.015 in [1/h]
+kmax = 0.05 in [1/h]
 	desc: Maximal kill rate constant
 	
 C50 = 1000000 in [pmol/L]
 	desc: Concentration of half-maximal effect
-
+	
+HC = 1 in [dimensionless]
+	desc: Hill coefficient
+	
 Mtt = 72 in [h]
 	desc: Average duration of transduction
 	
-tau = Mtt/3 in [h]
+tau = Mtt/3 in [h] 
   desc: Delay in treatment effect
 
-C_Drug = 1 in [pmol/L]
+C_Drug = 1 in [pmol/L]	
 	desc: Drug concentration causing tumor killing
 
-Kill = kmax * (1 - exp(-log(2)/C50 * C_Drug)) in [1/h]
+Kill = kmax * C_Drug^HC / (C50^HC + C_Drug^HC) in [1/h]
 	desc: Tumor kill rate constant
 
 dot(TS) = -K3*TS in [mL]
-	desc: Tumor size/ size 
+	desc: Tumor volume/ size 
 	
 dot(K1) = (Kill-K1)/tau in [1/h]
 	desc: Transit compartment 1 (delay of killing due to signal distribution) 


### PR DESCRIPTION
- Change `PKCompartment` to `PDCompartment` for DDI models.
- Change TGI model names to match their filenames.

TODO:
- [x] migrate MMT changes to the models in the database.