### PR TITLE
fix(frontend): sort protocol doses by ID

### DIFF
--- a/frontend-v2/src/features/trial/Doses.tsx
+++ b/frontend-v2/src/features/trial/Doses.tsx
@@ -120,6 +120,8 @@ const Doses: FC<Props> = ({ onChange, project, protocol, units }) => {
 
   const protocolName = mappedVariable.split(".").pop();
 
+  const sortedDoses = [...protocol.doses].sort((a, b) => a.id - b.id);
+
   return (
     <>
       <TableRow>
@@ -178,7 +180,7 @@ const Doses: FC<Props> = ({ onChange, project, protocol, units }) => {
           </Box>
         </TableCell>
       </TableRow>
-      {protocol.doses.map((dose, index) => (
+      {sortedDoses.map((dose, index) => (
         <DoseRow
           key={dose.id}
           index={index}
@@ -188,7 +190,7 @@ const Doses: FC<Props> = ({ onChange, project, protocol, units }) => {
           control={control}
           isPreclinical={isPreclinical}
           minStartTime={
-            doses[index - 1]?.start_time + 1e4 * Number.EPSILON || 0
+            sortedDoses[index - 1]?.start_time + 1e4 * Number.EPSILON || 0
           }
           onChange={onChange}
           removeDose={removeDose}


### PR DESCRIPTION
In Trial Design, display protocol doses ordered by dose ID, to avoid display bugs where the order returned by the backend API might change between requests.