### PR TITLE
fix(frontend): infinite loop for reference simulations

### DIFF
--- a/frontend-v2/src/features/simulation/useSimulation.ts
+++ b/frontend-v2/src/features/simulation/useSimulation.ts
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import useProtocols from "./useProtocols";
 import { SimulationContext } from "../../contexts/SimulationContext";
 
@@ -40,7 +40,6 @@ export default function useSimulation(
     let ignore = false;
     const simInputs = JSON.parse(serialisedInputs);
     if (
-      runSimulation &&
       simInputs.outputs?.length > 1 &&
       simInputs.time_max &&
       model &&
@@ -48,12 +47,12 @@ export default function useSimulation(
       compound &&
       SIMULATION_PAGES.includes(page)
     ) {
-      setLoadingSimulate(true);
-      console.log("Simulating with params", simInputs.variables);
-      simulate({
-        id: model.id,
-        simulate: simInputs,
-      }).then((response) => {
+      const runSimulation = async () => {
+        setLoadingSimulate(true);
+        const response = await simulate({
+          id: model.id,
+          simulate: simInputs,
+        });
         if (!ignore) {
           setLoadingSimulate(false);
           if ("data" in response) {
@@ -62,7 +61,9 @@ export default function useSimulation(
             setSimulations(responseData);
           }
         }
-      });
+      };
+      console.log("Simulating with params", simInputs.variables);
+      runSimulation();
     }
     return () => {
       ignore = true;
@@ -76,7 +77,6 @@ export default function useSimulation(
     page,
     runSimulation,
     setSimulations,
-    simInputs,
   ]);
 
   return {

--- a/frontend-v2/src/stories/Simulation.stories.tsx
+++ b/frontend-v2/src/stories/Simulation.stories.tsx
@@ -152,6 +152,27 @@ export const Parameters: Story = {
   },
 };
 
+export const Reference: Story = {
+  play: async ({ canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+    const referenceButton = await canvas.findByRole("button", {
+      name: "Reference",
+    });
+    expect(referenceButton).toBeInTheDocument();
+    await userEvent.click(referenceButton);
+
+    const showReferenceCheckbox = await screen.findByRole("checkbox", {
+      name: /Show reference/,
+    });
+    expect(showReferenceCheckbox).toBeInTheDocument();
+    await userEvent.click(showReferenceCheckbox);
+    expect(showReferenceCheckbox).toBeChecked();
+    await waitFor(() => {
+      expect(simulationSpy).toHaveBeenCalledTimes(2);
+    });
+  },
+};
+
 export const AddNewPlot: Story = {
   play: async ({ canvasElement, userEvent }) => {
     const canvas = within(canvasElement);


### PR DESCRIPTION
FIx a bug where checking 'Show reference' will cause `simulate` to be called in an infinite loop.

- refactor `useSimulation` to add a `runSimulation` function.
- remove the `simInputs` effect dependency, which triggers the bug.
- add a story and tests.