### PR TITLE
fix(frontend): updating compound refetches units

### DIFF
--- a/frontend-v2/src/app/api.ts
+++ b/frontend-v2/src/app/api.ts
@@ -64,7 +64,7 @@ export const api = backendApi.enhanceEndpoints({
     compoundUpdate: {
       invalidatesTags: (result, error, { id }) => [
         { type: "Compound", id },
-        { type: "Unit", id: "LIST" },
+        { type: "Compound", id: "LIST" },
       ],
     },
     compoundCreate: {


### PR DESCRIPTION
Don't invalidate cached unit lists after compound updates. Fixes a bug where editing efficacy-safety data for a drug would issue GET requests for all fetched unit lists.