### PR TITLE
refactor(frontend): edit efficacy experiment form

### DIFF
--- a/frontend-v2/src/features/drug/Drug.tsx
+++ b/frontend-v2/src/features/drug/Drug.tsx
@@ -413,6 +413,8 @@ const DrugForm: FC<DrugFormProps> = ({ project, compound, units }) => {
                   <EfficacyExperimentForm
                     key={experimentId}
                     efficacyExperiment={efficacyExperiment}
+                    project={project}
+                    units={units}
                     isSelected={isSelected}
                     isEditing={isEditIndex === index}
                     disabled={isEditIndex !== null && isEditIndex !== index}

--- a/frontend-v2/src/features/drug/EfficacyExperimentForm.tsx
+++ b/frontend-v2/src/features/drug/EfficacyExperimentForm.tsx
@@ -15,9 +15,10 @@ import Delete from "@mui/icons-material/Delete";
 import FloatField from "../../components/FloatField";
 import SelectField from "../../components/SelectField";
 import TextField from "../../components/TextField";
-import { compound, project, units } from "../../stories/project.mock";
 import {
   EfficacyExperimentRead,
+  ProjectRead,
+  UnitListApiResponse,
   useEfficacyExperimentUpdateMutation,
 } from "../../app/backendApi";
 import { useForm, useFormState } from "react-hook-form";
@@ -28,6 +29,8 @@ import { selectIsProjectShared } from "../login/loginSlice";
 
 interface Props {
   efficacyExperiment: EfficacyExperimentRead;
+  project: ProjectRead;
+  units: UnitListApiResponse;
   isSelected: boolean;
   isEditing: boolean;
   disabled: boolean;
@@ -39,6 +42,8 @@ interface Props {
 
 export function EfficacyExperimentForm({
   efficacyExperiment,
+  project,
+  units,
   isSelected,
   isEditing,
   disabled,


### PR DESCRIPTION
Refactor the Drug tab to use individual forms for each efficacy-safety experiment, so that efficacy data can be edited without updating the parent compound (and triggering extra GET requests.)