### PR TITLE
refactor: fix linter warnings

### DIFF
--- a/frontend-v2/src/features/model/Model.tsx
+++ b/frontend-v2/src/features/model/Model.tsx
@@ -8,7 +8,6 @@ import {
   ProjectRead,
   ProjectSpeciesEnum,
   ProtocolListApiResponse,
-  SimulationRead,
   TagRead,
   UnitListApiResponse,
   useCombinedModelListQuery,
@@ -20,7 +19,6 @@ import {
   useProjectUpdateMutation,
   useProtocolListQuery,
   useSimulationListQuery,
-  useSimulationUpdateMutation,
   useTagListQuery,
   useUnitListQuery,
   useVariableListQuery,
@@ -123,7 +121,6 @@ function useApiQueries() {
 function useModelFormDataCallback({
   model,
   project,
-  simulation,
   reset,
   updateModel,
   updateProject,
@@ -131,13 +128,11 @@ function useModelFormDataCallback({
 }: {
   model: CombinedModelRead;
   project: ProjectRead;
-  simulation?: SimulationRead;
   reset: (values?: Partial<FormData>) => void;
   updateModel: CombinedModelUpdate;
   updateProject: ProjectUpdate;
   units: UnitListApiResponse;
 }) {
-  const [updateSimulation] = useSimulationUpdateMutation();
 
   const [setParamsToDefault] =
     useCombinedModelSetParamsToDefaultsUpdateMutation();
@@ -215,10 +210,8 @@ function useModelFormDataCallback({
     [
       model,
       project,
-      simulation,
       updateModel,
       updateProject,
-      updateSimulation,
       setParamsToDefault,
       reset,
       units,
@@ -276,14 +269,12 @@ interface TabbedModelFormProps {
   updateProject: ProjectUpdate;
   tagsData?: TagRead[];
   pd_model?: PharmacodynamicRead;
-  simulation?: SimulationRead;
 }
 
 export const TabbedModelForm: FC<TabbedModelFormProps> = ({
   model,
   pd_model,
   project,
-  simulation,
   variables,
   protocols,
   compound,
@@ -299,7 +290,6 @@ export const TabbedModelForm: FC<TabbedModelFormProps> = ({
   const handleFormData = useModelFormDataCallback({
     model,
     project,
-    simulation,
     reset,
     updateModel,
     updateProject,
@@ -412,7 +402,6 @@ const Model: FC = () => {
     pd_model,
     project,
     protocols,
-    simulation,
     tagsData,
     units,
     variables,
@@ -434,7 +423,6 @@ const Model: FC = () => {
       model={model}
       pd_model={pd_model}
       project={project}
-      simulation={simulation}
       variables={variables}
       protocols={protocols}
       compound={compound}

--- a/frontend-v2/src/features/model/parameters/getConstVariables.ts
+++ b/frontend-v2/src/features/model/parameters/getConstVariables.ts
@@ -1,23 +1,9 @@
-// @ts-expect-error MutationTrigger isn't exported from Redux any more.
-import { MutationTrigger } from "@reduxjs/toolkit/dist/query/react/buildHooks";
 import {
   CombinedModelRead,
-  CompoundRead,
-  PharmacokineticRead,
   ProjectRead,
-  UnitRead,
   VariableRead,
-  VariableUpdateApiArg,
 } from "../../../app/backendApi";
 import paramPriority from "./paramPriority";
-import { param_default as paramDefaults } from "./param_default";
-import {
-  MutationDefinition,
-  BaseQueryFn,
-  FetchArgs,
-  FetchBaseQueryError,
-  FetchBaseQueryMeta,
-} from "@reduxjs/toolkit/dist/query";
 
 // filter out parameters from all variables, and sort them by priority
 export const getConstVariables = (
@@ -56,18 +42,3 @@ export const getConstVariables = (
 export const getNoReset = (project: ProjectRead) =>
   !project.species || project.species === "O";
 
-type VariableMutation = MutationTrigger<
-  MutationDefinition<
-    VariableUpdateApiArg,
-    BaseQueryFn<
-      string | FetchArgs,
-      unknown,
-      FetchBaseQueryError,
-      unknown,
-      FetchBaseQueryMeta
-    >,
-    never,
-    VariableRead,
-    "api"
-  >
->;

--- a/frontend-v2/src/features/trial/Doses.tsx
+++ b/frontend-v2/src/features/trial/Doses.tsx
@@ -53,7 +53,7 @@ const Doses: FC<Props> = ({ onChange, project, protocol, units }) => {
         await updateProtocol({ id: protocol.id, protocol: data });
       }
     },
-    [protocol, protocol.id, onChange, updateProtocol, reset],
+    [protocol, updateProtocol, reset],
   );
 
   useEffect(() => {


### PR DESCRIPTION
Remove unused variables and unused dependencies from React hooks.