### PR TITLE
ci: rename frontend coverage script

### DIFF
--- a/.github/workflows/frontend-coverage.yml
+++ b/.github/workflows/frontend-coverage.yml
@@ -32,7 +32,7 @@ jobs:
         run: yarn install --immutable
 
       - name: Run frontend coverage
-        run: yarn test --coverage
+        run: yarn test:coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -32,4 +32,4 @@ jobs:
         run: yarn install --immutable
 
       - name: Run tests
-        run: yarn test-storybook
+        run: yarn test

--- a/frontend-v2/package.json
+++ b/frontend-v2/package.json
@@ -36,7 +36,7 @@
     "cypress:e2e": "start-server-and-test 'yarn start' http://127.0.0.1:3000 \"cypress run --e2e\"",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "test-storybook": "vitest --project=storybook"
+    "test:coverage": "vitest --project=storybook --coverage"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
- run `yarn test` to lint, typecheck and run tests.
- run `yarn test:coverage` to generate a coverage report.