### PR TITLE
build(frontend): use Node 24

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -15,11 +15,11 @@ jobs:
       run:
         working-directory: ./frontend-v2
     steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v6
         with:
-          node-version: "lts/jod"
+          node-version: "lts/krypton"
           cache: "yarn"
           cache-dependency-path: ./frontend-v2/yarn.lock
       - name: Install dependencies

--- a/.github/workflows/frontend-coverage.yml
+++ b/.github/workflows/frontend-coverage.yml
@@ -19,12 +19,12 @@ jobs:
       run:
         working-directory: ./frontend-v2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "lts/jod"
+          node-version: "lts/krypton"
           cache: "yarn"
           cache-dependency-path: ./frontend-v2/yarn.lock
 

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -19,12 +19,12 @@ jobs:
       run:
         working-directory: ./frontend-v2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "lts/jod"
+          node-version: "lts/krypton"
           cache: "yarn"
           cache-dependency-path: ./frontend-v2/yarn.lock
 

--- a/.github/workflows/publish-storybook.yml
+++ b/.github/workflows/publish-storybook.yml
@@ -14,12 +14,12 @@ jobs:
       run:
         working-directory: ./frontend-v2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "lts/jod"
+          node-version: "lts/krypton"
           cache: "npm"
           cache-dependency-path: ./frontend-v2/yarn.lock
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Using a 2-stage build. This is the builder for javascript frontend
 
-FROM node:22 AS build
+FROM node:24 AS build
 
 ENV YARN_VERSION=4.2.2
 RUN yarn policies set-version $YARN_VERSION


### PR DESCRIPTION
Node 22 is in maintenance mode. Upgrade the frontend build and CI to Node 24 Active LTS.