### PR TITLE
fix: support derived variables for effect compartments

### DIFF
--- a/frontend-v2/src/features/simulation/useSimulationInputs.ts
+++ b/frontend-v2/src/features/simulation/useSimulationInputs.ts
@@ -95,7 +95,8 @@ const getSimulateInput = (
   );
   results?.forEach((v) => {
     outputs.push(v.qname);
-    outputs.push(`PKCompartment.calc_${v.name}_${derivedType}`);
+    const [compartmentName, name] = v.qname.split(".");
+    outputs.push(`${compartmentName}.calc_${name}_${derivedType}`);
   });
 
   return {


### PR DESCRIPTION
- Refactor `combined_model.py` to fix an issue where adding derived variables to effect compartments would error with 'Variable EffectCompartment1.Ce not found in model.'
- Fix a bug where `simInputs.outputs` always used `PkCompartment` for derived variables.