### PR TITLE
fix(frontend): duplicate variable names in Results

### DIFF
--- a/frontend-v2/src/features/results/useConcentrationVariables.ts
+++ b/frontend-v2/src/features/results/useConcentrationVariables.ts
@@ -5,6 +5,7 @@ import { SimulationContext } from "../../contexts/SimulationContext";
 import { RootState } from "../../app/store";
 import { useCombinedModelListQuery } from "../../app/backendApi";
 import { useVariables } from "./useVariables";
+import { renameVariable } from "../simulation/Simulations";
 
 export function useConcentrationVariables() {
   const { simulations } = useContext(SimulationContext);
@@ -16,18 +17,20 @@ export function useConcentrationVariables() {
     { projectId: projectIdOrZero },
     { skip: !projectId },
   );
-  const model = models?.[0] || null;
+  const model = models?.[0];
   const variables = useVariables();
   const simulationVariableIDs = simulations?.[0]?.outputs
     ? Object.keys(simulations[0].outputs).map((key) => parseInt(key))
     : [];
   return (
-    variables?.filter(
-      (variable) =>
-        simulationVariableIDs.includes(variable.id) &&
-        model?.derived_variables?.find(
-          (dv) => dv.pk_variable === variable.id && dv.type === "AUC",
-        ),
-    ) || []
+    variables
+      ?.filter(
+        (variable) =>
+          simulationVariableIDs.includes(variable.id) &&
+          model?.derived_variables?.find(
+            (dv) => dv.pk_variable === variable.id && dv.type === "AUC",
+          ),
+      )
+      .map((v) => renameVariable(v, model)) || []
   );
 }

--- a/frontend-v2/src/features/simulation/Simulations.tsx
+++ b/frontend-v2/src/features/simulation/Simulations.tsx
@@ -74,7 +74,7 @@ function getVariableName(
   return variableName;
 }
 
-function renameVariable(
+export function renameVariable(
   variable: VariableRead,
   model?: CombinedModelRead,
 ): VariableRead {


### PR DESCRIPTION
Display effect compartment variables as Ce1, Ce2, Ce3… in the Results view.

<img width=900 alt="The results tab, showing dervided variables for all variables. Effect compartment concentrations are shown as Ce1, Ce2, Ce3 etc." src="https://github.com/user-attachments/assets/55973165-d68d-4571-9957-7011450b3eb1" />
