### PR TITLE
fix(frontend): correct AUC variable names in Results

### DIFF
--- a/frontend-v2/src/features/results/useParameters.tsx
+++ b/frontend-v2/src/features/results/useParameters.tsx
@@ -231,8 +231,9 @@ export function useParameters() {
         simulation: SimulateResponse,
         variable: VariableRead,
       ) {
+        const [compartmentName, name] = variable.qname.split(".");
         const aucVariable = variables?.find(
-          (v) => v.name === `calc_${variable.name}_AUC`,
+          (v) => v.qname === `${compartmentName}.calc_${name}_AUC`,
         );
         const [auc] = aucVariable
           ? variablePerInterval(intervals, aucVariable, simulation, interval)


### PR DESCRIPTION
When we're displaying results for effect compartments, the AUC variables will have names like 'EffectCompartment1.calc_Ce_AUC'.