### PR TITLE
fix(frontend): merge fields from all rows of dataset

### DIFF
--- a/frontend-v2/src/features/data/useObservationRows.ts
+++ b/frontend-v2/src/features/data/useObservationRows.ts
@@ -52,9 +52,11 @@ export default function useObservationRows(state: StepperState, tab: string) {
     rows = mergeObservationColumns(state, observationFields);
     observationField = "Observation";
     observationIdField = "Observation ID";
-    const mergedFields = Object.keys(rows[0]);
+    const mergedFields = new Set<string>(
+      rows.map((row) => Object.keys(row)).flat(),
+    );
     normalisedFields = new Map(
-      mergedFields.map((field) =>
+      Array.from(mergedFields).map((field) =>
         state.normalisedFields.has(field)
           ? [field, state.normalisedFields.get(field)]
           : normaliseHeader(field),


### PR DESCRIPTION
When merging observation columns, the merged dataset should include fields from all rows of the original, as dosing rows may be at the end of the original.