### PR TITLE
refactor(frontend): clean up merged observations code

### DIFF
--- a/frontend-v2/src/features/data/dataValidation.ts
+++ b/frontend-v2/src/features/data/dataValidation.ts
@@ -1,4 +1,4 @@
-import { Field } from "./LoadData";
+import { Field, Row } from "./LoadData";
 import { StepperState } from "./LoadDataStepper";
 
 const normalisation = {
@@ -342,4 +342,34 @@ export function normaliseHeader(header: string): [Field, string] {
     }
   }
   return [header, "Ignore"];
+}
+
+/**
+ * Extract a list of unique field names from all rows in a CSV dataset.
+ * @param data CSV dataset
+ * @returns Array of field names
+ */
+export function csvFieldsFromData(data: Row[]): string[] {
+  const fieldSet = new Set<string>(data.map((row) => Object.keys(row)).flat());
+  return Array.from(fieldSet);
+}
+
+/**
+ * Generate a new normalised fields mapping based on the provided data and existing normalised fields.
+ * @param data CSV dataset
+ * @param normalisedFields Current normalised fields mapping
+ * @returns Updated normalised fields mapping
+ */
+export function normalisedFieldsFromData(
+  data: Row[],
+  normalisedFields: Map<string, string>,
+): Map<string, string> {
+  const fields = csvFieldsFromData(data);
+  return new Map(
+    fields.map((field) =>
+      normalisedFields.has(field)
+        ? [field, normalisedFields.get(field)]
+        : normaliseHeader(field),
+    ),
+  ) as Map<string, string>;
 }

--- a/frontend-v2/src/features/data/useObservationRows.ts
+++ b/frontend-v2/src/features/data/useObservationRows.ts
@@ -1,5 +1,5 @@
 import { StepperState } from "./LoadDataStepper";
-import { normaliseHeader } from "./dataValidation";
+import { normalisedFieldsFromData } from "./dataValidation";
 import { Row } from "./LoadData";
 
 const DEFAULT_VARIABLE_FIELD = "Observation Variable";
@@ -39,7 +39,7 @@ function mergeObservationColumns(
 
 export default function useObservationRows(state: StepperState, tab: string) {
   const fields = state.fields;
-  let normalisedFields = state.normalisedFields;
+  const { normalisedFields } = state;
   const observationFields =
     fields.filter((field) => normalisedFields.get(field) === "Observation") ||
     [];
@@ -52,25 +52,22 @@ export default function useObservationRows(state: StepperState, tab: string) {
     rows = mergeObservationColumns(state, observationFields);
     observationField = "Observation";
     observationIdField = "Observation ID";
-    const mergedFields = new Set<string>(
-      rows.map((row) => Object.keys(row)).flat(),
+    const newNormalisedFields = normalisedFieldsFromData(
+      rows,
+      state.normalisedFields,
     );
-    normalisedFields = new Map(
-      Array.from(mergedFields).map((field) =>
-        state.normalisedFields.has(field)
-          ? [field, state.normalisedFields.get(field)]
-          : normaliseHeader(field),
-      ),
-    ) as Map<string, string>;
-    normalisedFields.set("Observation", "Observation");
-    normalisedFields.set("Observation ID", "Observation ID");
-    state.normalisedFields = normalisedFields;
+    newNormalisedFields.set("Observation", "Observation");
+    newNormalisedFields.set("Observation ID", "Observation ID");
+    state.normalisedFields = newNormalisedFields;
     state.data = rows;
   }
   const observationRows = observationField
     ? rows.filter(
-      (row) => row["Group ID"] === tab && observationField in row && row[observationField] !== ".",
-    )
+        (row) =>
+          row["Group ID"] === tab &&
+          observationField in row &&
+          row[observationField] !== ".",
+      )
     : [];
   const observationIds = observationIdField
     ? observationRows.map((row) => row[observationIdField || "Observation ID"])


### PR DESCRIPTION
- Add helper functions to generate a new normalised fields mapping after a dataset has changed.
- update `useObservationRows` to use the new helper function after merging multiple observation columns into a single column.