### PR TITLE
feat: per kg observation units

### DIFF
--- a/frontend-v2/src/features/data/MapObservations.tsx
+++ b/frontend-v2/src/features/data/MapObservations.tsx
@@ -1,4 +1,4 @@
-import { FC, SyntheticEvent, useEffect, useState } from "react";
+import { ChangeEvent, FC, SyntheticEvent, useEffect, useState } from "react";
 import { DataGrid } from "@mui/x-data-grid";
 import {
   Box,
@@ -17,16 +17,21 @@ import {
   SelectChangeEvent,
   Stack,
   TableContainer,
+  Checkbox,
 } from "@mui/material";
 import { StepperState } from "./LoadDataStepper";
 import { useSelector } from "react-redux";
 import { RootState } from "../../app/store";
 import {
   UnitListApiResponse,
+  UnitRead,
   useCombinedModelListQuery,
   useProjectRetrieveQuery,
   useUnitListQuery,
   useVariableListQuery,
+  useVariableRetrieveQuery,
+  useVariableUpdateMutation,
+  VariableRead,
 } from "../../app/backendApi";
 import useObservationRows from "./useObservationRows";
 import { validateState } from "./dataValidation";
@@ -38,6 +43,7 @@ import {
 } from "../../shared/calculateTableHeights";
 import { TableHeader } from "../../components/TableHeader";
 import { groupDataRows } from "./Stratification";
+import { hasPerWeightOption } from "../../shared/hasPerWeightOption";
 
 interface IMapObservations {
   state: StepperState;
@@ -104,6 +110,172 @@ function useApiQueries() {
   return { model, variables, units };
 }
 
+function findFieldByType(name: string, state: StepperState) {
+  return (
+    state.fields.find((field) => state.normalisedFields.get(field) === name) ||
+    name
+  );
+}
+
+type ObservationIDRowProps = {
+  obsId: string;
+  obsVariable?: VariableRead;
+  obsUnit?: UnitRead;
+  handleObservationChange: (event: SelectChangeEvent) => void;
+  handleUnitChange: (symbol: string) => void;
+  modelOutputs?: VariableRead[];
+};
+
+/**
+ * An editable table row for a single observation ID (from the uploaded CSV.)
+ */
+const ObservationIDRow: FC<ObservationIDRowProps> = ({
+  obsId,
+  obsVariable,
+  obsUnit,
+  handleObservationChange,
+  handleUnitChange,
+  modelOutputs,
+}) => {
+  const { variables, units } = useApiQueries();
+  const [updateVariable] = useVariableUpdateMutation();
+  const [variable, setVariable] = useState(obsVariable);
+  // refetch single variables, not the whole list.
+  const { data: variableRead } = useVariableRetrieveQuery(
+    {
+      id: variable?.id || -1,
+    },
+    { skip: !variable?.id },
+  );
+  const selectedVariable = variableRead || variable;
+
+  let selectedUnitSymbol = obsUnit?.symbol;
+  const compatibleUnits = selectedVariable
+    ? units?.find((unit) => unit.id === selectedVariable?.unit)
+        ?.compatible_units
+    : units;
+  ["%", "fraction", "ratio"].forEach((token) => {
+    if (selectedUnitSymbol?.toLowerCase().includes(token)) {
+      selectedUnitSymbol = "";
+    }
+  });
+  const hasPerKgUnits = hasPerWeightOption(obsUnit, obsVariable);
+  const selectedPerBodyWeight =
+    hasPerKgUnits && selectedVariable?.unit_per_body_weight;
+
+  function onVariableChange(event: SelectChangeEvent) {
+    const { value } = event.target;
+    const nextVariable = variables?.find(
+      (variable) => variable.qname === value,
+    );
+    if (!nextVariable) {
+      handleObservationChange(event);
+      setVariable(undefined);
+      return;
+    }
+    let unit_per_body_weight = nextVariable.unit_per_body_weight || false;
+    if (obsUnit?.symbol.endsWith("/kg")) {
+      const baseUnitSymbol = obsUnit.symbol.replace("/kg", "");
+      handleUnitChange(baseUnitSymbol);
+      unit_per_body_weight = true;
+    }
+    setVariable({
+      ...nextVariable,
+      unit_per_body_weight,
+    });
+    handleObservationChange(event);
+  }
+
+  function onUnitChange(event: SelectChangeEvent) {
+    const { value } = event.target;
+    handleUnitChange(value);
+  }
+
+  function handlePerWeightChange(event: ChangeEvent<HTMLInputElement>) {
+    if (!selectedVariable) {
+      return;
+    }
+    const { checked } = event.target;
+    updateVariable({
+      id: selectedVariable.id,
+      variable: {
+        ...selectedVariable,
+        unit_per_body_weight: checked,
+      },
+    });
+    setVariable({
+      ...selectedVariable,
+      unit_per_body_weight: checked,
+    });
+  }
+
+  return (
+    <TableRow key={obsId}>
+      <TableCell>{obsId}</TableCell>
+      <TableCell>
+        <FormControl fullWidth>
+          <InputLabel size="small" id={`select-var-${obsId}-label`}>
+            Variable
+          </InputLabel>
+          <Select
+            labelId={`select-var-${obsId}-label`}
+            id={`select-var-${obsId}`}
+            label="Variable"
+            value={selectedVariable?.qname || ""}
+            onChange={onVariableChange}
+            size="small"
+            margin="dense"
+          >
+            <MenuItem value="">None</MenuItem>
+            {modelOutputs?.map((variable) => (
+              <MenuItem key={variable.name} value={variable.qname}>
+                {variable.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </TableCell>
+      <TableCell>
+        <FormControl sx={{ width: "15rem" }}>
+          <InputLabel size="small" id={`select-unit-${obsId}-label`}>
+            Units
+          </InputLabel>
+          <Select
+            labelId={`select-unit-${obsId}-label`}
+            id={`select-unit-${obsId}`}
+            label="Units"
+            value={displayUnitSymbol(selectedUnitSymbol)}
+            onChange={onUnitChange}
+            size="small"
+            margin="dense"
+          >
+            <MenuItem value="">None</MenuItem>
+            {compatibleUnits?.map((unit) => (
+              <MenuItem key={unit.id} value={displayUnitSymbol(unit.symbol)}>
+                {displayUnitSymbol(unit.symbol)}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </TableCell>
+      <TableCell>
+        <FormControl>
+          <Checkbox
+            checked={selectedPerBodyWeight}
+            disabled={!hasPerKgUnits || !selectedVariable}
+            onChange={handlePerWeightChange}
+            slotProps={{
+              input: {
+                "aria-label": `Per Body Weight(kg) for ${selectedVariable?.name}`,
+              },
+            }}
+          />
+        </FormControl>
+      </TableCell>
+    </TableRow>
+  );
+};
+
 const MapObservations: FC<IMapObservations> = ({
   state,
   notificationsInfo,
@@ -111,6 +283,7 @@ const MapObservations: FC<IMapObservations> = ({
   const [tab, setTab] = useState(0);
   const groupIDs = [...new Set(state.data.map((row) => row["Group ID"]))];
   const selectedGroup = groupIDs[tab];
+  const perKgField = findFieldByType("Per Body Weight(kg)", state);
 
   const { model, variables, units } = useApiQueries();
 
@@ -187,6 +360,7 @@ const MapObservations: FC<IMapObservations> = ({
         ...state.normalisedFields.entries(),
         [observationVariableField, "Observation Variable"],
         [observationUnitField, "Observation Unit"],
+        [perKgField, "Per Body Weight(kg)"],
       ]);
       state.data = nextData;
       state.normalisedFields = newNormalisedFields;
@@ -201,15 +375,14 @@ const MapObservations: FC<IMapObservations> = ({
       state.errors = errors;
       state.warnings = warnings;
     };
-  const handleUnitChange = (id: string) => (event: SelectChangeEvent) => {
+  const handleUnitChange = (id: string) => (symbol: string) => {
     const nextData = [...state.data];
-    const { value } = event.target;
     nextData
       .filter((row) =>
         observationIdField ? row[observationIdField] === id : true,
       )
       .forEach((row) => {
-        row[observationUnitField] = value;
+        row[observationUnitField] = symbol;
       });
     state.data = nextData;
     const { errors, warnings } = validateState({
@@ -306,6 +479,9 @@ const MapObservations: FC<IMapObservations> = ({
                 <TableCell>
                   <Typography>Unit</Typography>
                 </TableCell>
+                <TableCell>
+                  <Typography>Per Body Weight(kg)</Typography>
+                </TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
@@ -313,85 +489,23 @@ const MapObservations: FC<IMapObservations> = ({
                 .sort((a, b) => (a > b ? 1 : -1))
                 .map((obsId) => {
                   const currentRow = observationIds.indexOf(obsId);
-                  const obsVariable = observationVariables[currentRow];
-                  const obsUnit = observationUnits[currentRow];
-                  const selectedVariable = variables?.find(
-                    (variable) => variable.qname === obsVariable,
+                  const obsVariable = variables?.find(
+                    (variable) =>
+                      variable.qname === observationVariables[currentRow],
                   );
-                  let selectedUnitSymbol = units?.find(
-                    (unit) => unit.symbol === obsUnit,
-                  )?.symbol;
-                  const compatibleUnits = selectedVariable
-                    ? units?.find((unit) => unit.id === selectedVariable?.unit)
-                        ?.compatible_units
-                    : units;
-                  ["%", "fraction", "ratio"].forEach((token) => {
-                    if (selectedUnitSymbol?.toLowerCase().includes(token)) {
-                      selectedUnitSymbol = "";
-                    }
-                  });
+                  const obsUnit = units.find(
+                    (unit) => unit.symbol === observationUnits[currentRow],
+                  );
                   return (
-                    <TableRow key={obsId}>
-                      <TableCell>{obsId}</TableCell>
-                      <TableCell>
-                        <FormControl fullWidth>
-                          <InputLabel
-                            size="small"
-                            id={`select-var-${obsId}-label`}
-                          >
-                            Variable
-                          </InputLabel>
-                          <Select
-                            labelId={`select-var-${obsId}-label`}
-                            id={`select-var-${obsId}`}
-                            label="Variable"
-                            value={selectedVariable?.qname || ""}
-                            onChange={handleObservationChange(obsId)}
-                            size="small"
-                            margin="dense"
-                          >
-                            <MenuItem value="">None</MenuItem>
-                            {modelOutputs?.map((variable) => (
-                              <MenuItem
-                                key={variable.name}
-                                value={variable.qname}
-                              >
-                                {variable.name}
-                              </MenuItem>
-                            ))}
-                          </Select>
-                        </FormControl>
-                      </TableCell>
-                      <TableCell>
-                        <FormControl sx={{ width: "15rem" }}>
-                          <InputLabel
-                            size="small"
-                            id={`select-unit-${obsId}-label`}
-                          >
-                            Units
-                          </InputLabel>
-                          <Select
-                            labelId={`select-unit-${obsId}-label`}
-                            id={`select-unit-${obsId}`}
-                            label="Units"
-                            value={displayUnitSymbol(selectedUnitSymbol)}
-                            onChange={handleUnitChange(obsId)}
-                            size="small"
-                            margin="dense"
-                          >
-                            <MenuItem value="">None</MenuItem>
-                            {compatibleUnits?.map((unit) => (
-                              <MenuItem
-                                key={unit.id}
-                                value={displayUnitSymbol(unit.symbol)}
-                              >
-                                {displayUnitSymbol(unit.symbol)}
-                              </MenuItem>
-                            ))}
-                          </Select>
-                        </FormControl>
-                      </TableCell>
-                    </TableRow>
+                    <ObservationIDRow
+                      key={obsVariable?.qname}
+                      obsId={obsId}
+                      obsVariable={obsVariable}
+                      obsUnit={obsUnit}
+                      handleObservationChange={handleObservationChange(obsId)}
+                      handleUnitChange={handleUnitChange(obsId)}
+                      modelOutputs={modelOutputs}
+                    />
                   );
                 })}
             </TableBody>

--- a/frontend-v2/src/features/data/useObservationRows.ts
+++ b/frontend-v2/src/features/data/useObservationRows.ts
@@ -5,6 +5,10 @@ import { Row } from "./LoadData";
 const DEFAULT_VARIABLE_FIELD = "Observation Variable";
 const DEFAULT_UNIT_FIELD = "Observation Unit";
 
+type ObservationRow = Row & {
+  id: number;
+};
+
 function mergeObservationColumns(
   state: StepperState,
   observationFields: string[],
@@ -86,12 +90,13 @@ export default function useObservationRows(state: StepperState, tab: string) {
   const observationVariables = observationRows.map(
     (row) => row[observationVariableField],
   );
+  const observationRowsWithIds = observationRows.map((row, index) => ({
+    ...row,
+    id: index,
+  })) as ObservationRow[];
 
   return {
-    observationRows: observationRows.map((row, index) => ({
-      ...row,
-      id: index,
-    })),
+    observationRows: observationRowsWithIds,
     observationField,
     observationIdField,
     observationUnitField,

--- a/frontend-v2/src/features/model/parameters/ParameterRow.tsx
+++ b/frontend-v2/src/features/model/parameters/ParameterRow.tsx
@@ -28,7 +28,7 @@ import { selectIsProjectShared } from "../../login/loginSlice";
 import { useSelector } from "react-redux";
 import { RootState } from "../../../app/store";
 import { DerivedVariableType } from "../derivedVariable";
-
+import { hasPerWeightOption } from "../../../shared/hasPerWeightOption";
 interface Props {
   model: CombinedModelRead;
   project: ProjectRead;
@@ -111,10 +111,6 @@ const ParameterRow: FC<Props> = ({
       : units.find((u) => u.id === variable.unit);
   const isPreclinicalPerKg =
     project?.species !== "H" && unit?.symbol.endsWith("/kg");
-
-  const isPKandVol = isPK && unit?.m === 3;
-  const is_Ref_D_or_D50 =
-    variable.name.startsWith("Ref_D") || variable.name.startsWith("D50");
 
   const defaultProps = {
     disabled: isSharedWithMe,
@@ -309,7 +305,7 @@ const ParameterRow: FC<Props> = ({
         />
       </TableCell>
       <TableCell size="small" sx={{ width: "10rem" }}>
-        {(isPKandVol || is_Ref_D_or_D50) && (
+        {hasPerWeightOption(unit, variable) && (
           <Checkbox
             label=""
             name="unit_per_body_weight"

--- a/frontend-v2/src/shared/hasPerWeightOption.ts
+++ b/frontend-v2/src/shared/hasPerWeightOption.ts
@@ -1,0 +1,23 @@
+import { UnitRead, VariableRead } from "../app/backendApi";
+
+/**
+ * PK variables with volume units (m³) and variables named "Ref_D*" or "D50"
+ * can have a per body weight option (`variable.unit_per_body_weight`).
+ * @param unit
+ * @param variable
+ * @returns boolean true if the variable can have a per body weight option.
+ */
+export function hasPerWeightOption(
+  unit?: UnitRead,
+  variable?: VariableRead,
+): boolean {
+  if (!unit || !variable) {
+    return false;
+  }
+  const isPK =
+    variable.qname.startsWith("PK") || variable.qname.startsWith("Extra");
+  const isPKandVol = isPK && unit?.m === 3;
+  const is_Ref_D_or_D50 =
+    variable.name.startsWith("Ref_D") || variable.name.startsWith("D50");
+  return isPKandVol || is_Ref_D_or_D50;
+}

--- a/frontend-v2/src/stories/Data.noData.stories.tsx
+++ b/frontend-v2/src/stories/Data.noData.stories.tsx
@@ -202,7 +202,7 @@ export const MapObservations: Story = {
     });
     expect(mapObservationsHeading).toBeInTheDocument();
 
-    const variableSelect = canvas.getByRole("combobox", {
+    let variableSelect = canvas.getByRole("combobox", {
       name: "Variable",
     });
     expect(variableSelect).toBeInTheDocument();
@@ -212,12 +212,21 @@ export const MapObservations: Story = {
       name: "C1",
     });
     await userEvent.selectOptions(listbox, observationOption);
+    variableSelect = canvas.getByRole("combobox", {
+      name: "Variable",
+    });
     expect(variableSelect).toHaveTextContent("C1");
     const unitSelect = canvas.getByRole("combobox", {
       name: "Units",
     });
     expect(unitSelect).toBeInTheDocument();
     expect(unitSelect).toHaveTextContent("mg/L");
+    const perKgCheckbox = canvas.getByRole("checkbox", {
+      name: "Per Body Weight(kg) for C1",
+    });
+    expect(perKgCheckbox).toBeInTheDocument();
+    expect(perKgCheckbox).not.toBeChecked();
+    expect(perKgCheckbox).toBeDisabled();
   },
 };
 

--- a/pkpdapp/pkpdapp/models/dataset.py
+++ b/pkpdapp/pkpdapp/models/dataset.py
@@ -81,6 +81,7 @@ class Dataset(models.Model):
                 "OBSERVATION_UNIT",
                 "OBSERVATION_VARIABLE",
                 "TIME_UNIT",
+                "PER_BODY_WEIGHT_KG",
             ]
         ].drop_duplicates()
         biomarker_types = {}


### PR DESCRIPTION
Add the `variable.unit_per_body_weight` option to observation units in uploaded datasets.
- refactor observation mapping to use a `ObservationIDRow` component for each observation ID in the dataset.
- update `variable.use_per_body_weight` in the backend whenever an observation variable is changed.