### PR TITLE
fix(backend): unique biomarker types

### DIFF
--- a/pkpdapp/pkpdapp/models/dataset.py
+++ b/pkpdapp/pkpdapp/models/dataset.py
@@ -81,7 +81,6 @@ class Dataset(models.Model):
                 "OBSERVATION_UNIT",
                 "OBSERVATION_VARIABLE",
                 "TIME_UNIT",
-                "PER_BODY_WEIGHT_KG",
             ]
         ].drop_duplicates()
         biomarker_types = {}


### PR DESCRIPTION
Remove the unused `PER_BODY_WEIGHT_KG` column from biomarker types.