### PR TITLE
refactor(frontend): custom hooks for parameters

### DIFF
--- a/frontend-v2/src/features/model/parameters/ParametersTab.tsx
+++ b/frontend-v2/src/features/model/parameters/ParametersTab.tsx
@@ -21,7 +21,7 @@ import {
 } from "@mui/material";
 import ParameterRow from "./ParameterRow";
 import HelpButton from "../../../components/HelpButton";
-import { getConstVariables, getNoReset } from "./getConstVariables";
+import { useConstVariables, useNoReset } from "./getConstVariables";
 import { defaultHeaderSx } from "../../../shared/tableHeadersSx";
 import { useSelector } from "react-redux";
 import { FormData } from "../Model";
@@ -55,8 +55,8 @@ const ParametersTab: FC<Props> = ({
     selectIsProjectShared(state, project),
   );
 
-  const constVariables = getConstVariables(variables, model);
-  const noReset = getNoReset(project);
+  const constVariables = useConstVariables();
+  const noReset = useNoReset();
 
   const myResetToSpeciesDefaults = () => {
     setParamsToDefault({ id: model.id, combinedModel: model });

--- a/frontend-v2/src/features/model/parameters/getConstVariables.ts
+++ b/frontend-v2/src/features/model/parameters/getConstVariables.ts
@@ -1,8 +1,13 @@
+import { useSelector } from "react-redux";
 import {
   CombinedModelRead,
   ProjectRead,
+  useCombinedModelListQuery,
+  useProjectRetrieveQuery,
+  useVariableListQuery,
   VariableRead,
 } from "../../../app/backendApi";
+import { RootState } from "../../../app/store";
 import paramPriority from "./paramPriority";
 
 // filter out parameters from all variables, and sort them by priority
@@ -43,5 +48,40 @@ export const getConstVariables = (
   return constVariables;
 };
 
+export function useConstVariables() {
+  const projectId = useSelector(
+    (state: RootState) => state.main.selectedProject,
+  );
+  const projectIdOrZero = projectId || 0;
+  const { data: models } = useCombinedModelListQuery(
+    { projectId: projectIdOrZero },
+    { skip: !projectId },
+  );
+  const model = models?.[0];
+  const { data: variables } = useVariableListQuery(
+    { dosedPkModelId: model?.id || 0 },
+    { skip: !model?.id },
+  );
+  if (!model || !variables) {
+    return [];
+  }
+  return getConstVariables(variables, model);
+}
+
 export const getNoReset = (project: ProjectRead) =>
   !project.species || project.species === "O";
+
+export function useNoReset() {
+  const projectId = useSelector(
+    (state: RootState) => state.main.selectedProject,
+  );
+  const projectIdOrZero = projectId || 0;
+  const { data: project } = useProjectRetrieveQuery(
+    { id: projectIdOrZero },
+    { skip: !projectId },
+  );
+  if (!project) {
+    return true;
+  }
+  return getNoReset(project);
+}

--- a/frontend-v2/src/features/simulation/Simulations.tsx
+++ b/frontend-v2/src/features/simulation/Simulations.tsx
@@ -43,7 +43,7 @@ import useSimulationInputs from "./useSimulationInputs";
 import useDirty from "../../hooks/useDirty";
 import paramPriority from "../model/parameters/paramPriority";
 import { selectIsProjectShared } from "../login/loginSlice";
-import { getConstVariables } from "../model/parameters/getConstVariables";
+import { useConstVariables } from "../model/parameters/getConstVariables";
 import useSubjectGroups from "../../hooks/useSubjectGroups";
 import useExportSimulation from "./useExportSimulation";
 import { SimulationsSidePanel } from "./SimulationsSidePanel";
@@ -173,6 +173,8 @@ const Simulations: FC = () => {
       { skip: !project?.compound },
     );
   const [updateVariable] = useVariableUpdateMutation();
+
+  const constVariables = useConstVariables();
 
   const [sliderValues, setSliderValues] = useState<SliderValues | undefined>(
     undefined,
@@ -409,8 +411,6 @@ const Simulations: FC = () => {
       [groupName]: !prevState[groupName],
     }));
   };
-
-  const constVariables = model ? getConstVariables(variables || [], model) : [];
 
   const sliderVarIds = sliders.map((v) => v.variable);
   const addSliderOptions = constVariables


### PR DESCRIPTION
Add a couple of custom hooks to wrap helper functions for the Parameters tab;
- `useConstVariables`: get constant variables for the current model.
- `useNoReset`: determine if parameters can be reset based on project species.