### PR TITLE
build: upgrade to Django 4.2

### DIFF
--- a/frontend-v2/src/features/login/loginSlice.ts
+++ b/frontend-v2/src/features/login/loginSlice.ts
@@ -10,8 +10,14 @@ export const fetchCsrf = createAsyncThunk<string, undefined>(
       method: "GET",
       credentials: "include",
     }).then((response) => response.json());
-    localStorage.setItem("csrf", csrfResponse["X-CSRFToken"]);
-    return csrfResponse["X-CSRFToken"];
+
+    const csrf = csrfResponse["X-CSRFToken"];
+    if (csrf) {
+      localStorage.setItem("csrf", csrf);
+      return csrf;
+    }
+
+    return "";
   },
 );
 

--- a/pkpdapp/pkpdapp/settings.py
+++ b/pkpdapp/pkpdapp/settings.py
@@ -414,8 +414,9 @@ DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL", default="webmaster@loc
 
 CACHES = {
     "default": {
-        "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+        "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
         "LOCATION": "127.0.0.1:11211",
+        "OPTIONS": {"ignore_exc": True},
     }
 }
 
@@ -441,3 +442,14 @@ CELERY_BROKER_TRANSPORT_OPTIONS = {
 }
 
 TEST_RUNNER = "snapshottest.django.TestRunner"
+
+_csrf_trusted_origins = os.environ.get("CSRF_TRUSTED_ORIGINS", "").split(",")
+CSRF_TRUSTED_ORIGINS = [
+    origin.strip()
+    for origin in [
+        *_csrf_trusted_origins,
+        "http://localhost:5173",
+        "http://127.0.0.1:5173"
+    ]
+    if origin.strip()
+]

--- a/pkpdapp/pkpdapp/tests/test_models/test_other.py
+++ b/pkpdapp/pkpdapp/tests/test_models/test_other.py
@@ -73,17 +73,17 @@ class TestProjectModel(TestCase):
             description='description for my cool dataset',
         )
         p.datasets.add(d)
-        self.assertQuerysetEqual(p.datasets.all(), [repr(d)])
+        self.assertQuerysetEqual(p.datasets.all(), [d])
 
         m = PharmacodynamicModel.objects.create(
             name='my_cool_model',
             description='description for my cool model',
         )
         p.pd_models.add(m)
-        self.assertQuerysetEqual(p.pd_models.all(), [repr(m)])
+        self.assertQuerysetEqual(p.pd_models.all(), [m])
 
         u = User.objects.create_user(
             'john', 'lennon@thebeatles.com', 'johnpassword'
         )
         p.users.add(u)
-        self.assertQuerysetEqual(p.users.all(), [repr(u)])
+        self.assertQuerysetEqual(p.users.all(), [u])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 gunicorn
-Django==3.2.25
+Django~=4.2.0
 setuptools<=65.5.1
 django-cors-headers>=3.7.0
 dpd-static-support>=0.0.5
@@ -13,7 +13,7 @@ django-extensions>=3.1.1
 jsonfield>=3.1.0
 djangorestframework>=3.12.4
 djoser>=2.1.0
-python-memcached>=1.16,<=1.59
+pymemcache>=3.5.0
 psycopg2-binary>=2.9.1
 dj-database-url>=0.5.0
 django-polymorphic>=3.1.0


### PR DESCRIPTION
- Upgrade the backend build to Django 4.2.
- Update the cache to `pymemcache`.
- Send the CSRF token with POST requests.
- Set `CSRF_TRUSTED_ORIGINS` to allow requests from the frontend.
- Update test assertions to match Django 4.2 method signatures.