### PR TITLE
build: bump Django to 6.0

### DIFF
--- a/.github/workflows/copyright-test.yml
+++ b/.github/workflows/copyright-test.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           architecture: x64
 
       - name: install ldap

--- a/.github/workflows/coverage-test.yml
+++ b/.github/workflows/coverage-test.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           architecture: x64
           cache: pip
           cache-dependency-path: requirements.txt

--- a/.github/workflows/style-test.yml
+++ b/.github/workflows/style-test.yml
@@ -1,4 +1,3 @@
-
 name: Style tests (flake8)
 
 on:
@@ -7,10 +6,9 @@ on:
       - master
   pull_request:
     branches:
-      - '**'
+      - "**"
 
 jobs:
-
   build-and-test:
     name: style test
     runs-on: ubuntu-latest
@@ -18,13 +16,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.12"
           architecture: x64
 
-      - name: install ldap 
+      - name: install ldap
         run: |
           sudo apt-get update
           sudo apt-get install libsasl2-dev python3-dev libldap2-dev libssl-dev

--- a/.github/workflows/unit-test-os-versions.yml
+++ b/.github/workflows/unit-test-os-versions.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           architecture: x64
           cache: pip
           cache-dependency-path: requirements.txt

--- a/.github/workflows/unit-test-python-versions.yml
+++ b/.github/workflows/unit-test-python-versions.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV VITE_APP_VERSION=$GIT_COMMIT_ID
 
 RUN yarn build
 
-FROM python:3.10-bookworm
+FROM python:3.12-bookworm
 
 # install libsundials-dev
 RUN apt-get update && apt-get upgrade -y

--- a/pkpdapp/pkpdapp/migrations/0001_initial.py
+++ b/pkpdapp/pkpdapp/migrations/0001_initial.py
@@ -522,7 +522,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AddConstraint(
             model_name='dosebase',
-            constraint=models.CheckConstraint(check=models.Q(('duration__gt', 0)), name='Duration must be greater than 0'),
+            constraint=models.CheckConstraint(condition=models.Q(('duration__gt', 0)), name='Duration must be greater than 0'),
         ),
         migrations.AddField(
             model_name='derivedvariable',
@@ -636,11 +636,11 @@ class Migration(migrations.Migration):
         ),
         migrations.AddConstraint(
             model_name='variable',
-            constraint=models.CheckConstraint(check=models.Q(models.Q(('is_log', True), ('lower_bound__gt', 0)), ('is_log', False), _connector='OR'), name='variable: log scale must have a lower bound greater than zero'),
+            constraint=models.CheckConstraint(condition=models.Q(models.Q(('is_log', True), ('lower_bound__gt', 0)), ('is_log', False), _connector='OR'), name='variable: log scale must have a lower bound greater than zero'),
         ),
         migrations.AddConstraint(
             model_name='variable',
-            constraint=models.CheckConstraint(check=models.Q(models.Q(('pk_model__isnull', True), ('dosed_pk_model__isnull', True), ('pd_model__isnull', False)), models.Q(('pk_model__isnull', False), ('dosed_pk_model__isnull', True), ('pd_model__isnull', True)), models.Q(('pk_model__isnull', True), ('dosed_pk_model__isnull', False), ('pd_model__isnull', True)), _connector='OR'), name='variable: variable must belong to a model'),
+            constraint=models.CheckConstraint(condition=models.Q(models.Q(('pk_model__isnull', True), ('dosed_pk_model__isnull', True), ('pd_model__isnull', False)), models.Q(('pk_model__isnull', False), ('dosed_pk_model__isnull', True), ('pd_model__isnull', True)), models.Q(('pk_model__isnull', True), ('dosed_pk_model__isnull', False), ('pd_model__isnull', True)), _connector='OR'), name='variable: variable must belong to a model'),
         ),
         migrations.AddConstraint(
             model_name='subject',
@@ -652,15 +652,15 @@ class Migration(migrations.Migration):
         ),
         migrations.AddConstraint(
             model_name='loglikelihood',
-            constraint=models.CheckConstraint(check=models.Q(('form', 'F'), ('value__isnull', True), ('biomarker_type__isnull', True), _negated=True), name='loglikelihood: fixed log_likelihood must have a value or biomarker_type'),
+            constraint=models.CheckConstraint(condition=models.Q(('form', 'F'), ('value__isnull', True), ('biomarker_type__isnull', True), _negated=True), name='loglikelihood: fixed log_likelihood must have a value or biomarker_type'),
         ),
         migrations.AddConstraint(
             model_name='loglikelihood',
-            constraint=models.CheckConstraint(check=models.Q(('form', 'M'), ('variable__isnull', True), _negated=True), name='loglikelihood: model log_likelihood must have a variable'),
+            constraint=models.CheckConstraint(condition=models.Q(('form', 'M'), ('variable__isnull', True), _negated=True), name='loglikelihood: model log_likelihood must have a variable'),
         ),
         migrations.AddConstraint(
             model_name='loglikelihood',
-            constraint=models.CheckConstraint(check=models.Q(models.Q(('form', 'F'), ('form', 'S'), ('form', 'M'), _connector='OR'), ('biomarker_type__isnull', False), ('protocol_filter', False), _negated=True), name='loglikelihood: deterministic log_likelihoods cannot have data'),
+            constraint=models.CheckConstraint(condition=models.Q(models.Q(('form', 'F'), ('form', 'S'), ('form', 'M'), _connector='OR'), ('biomarker_type__isnull', False), ('protocol_filter', False), _negated=True), name='loglikelihood: deterministic log_likelihoods cannot have data'),
         ),
         migrations.AddField(
             model_name='dose',

--- a/pkpdapp/pkpdapp/models/combined_model.py
+++ b/pkpdapp/pkpdapp/models/combined_model.py
@@ -351,7 +351,8 @@ class CombinedModel(MyokitModelMixin, StoredModel):
             ec_myokit = self.pk_effect_model.create_myokit_model()
             for i in range(self.number_of_effect_compartments):
                 pk_model.import_component(
-                    ec_myokit.get("PKCompartment"), new_name=f"EffectCompartment{i+1}"
+                    ec_myokit.get("PKCompartment"),
+                    new_name=f"EffectCompartment{i + 1}"
                 )
 
         # do derived variables for pk model first
@@ -384,7 +385,7 @@ class CombinedModel(MyokitModelMixin, StoredModel):
                 )
             c1_variable = pk_model.get(c1_variable_name)
             for i in range(self.number_of_effect_compartments):
-                c_drug = pk_model.get(f"EffectCompartment{i+1}.C_Drug")
+                c_drug = pk_model.get(f"EffectCompartment{i + 1}.C_Drug")
                 c_drug.set_rhs(myokit.Name(c1_variable))
 
         have_both_models = self.pk_model is not None and self.pd_model is not None
@@ -533,7 +534,12 @@ class CombinedModel(MyokitModelMixin, StoredModel):
     def save(self, force_insert=False, force_update=False, *args, **kwargs):
         created = not self.pk
 
-        super().save(force_insert, force_update, *args, **kwargs)
+        super().save(
+            *args,
+            force_insert=force_insert,
+            force_update=force_update,
+            **kwargs
+        )
 
         # don't update a stored model
         if self.read_only:
@@ -716,7 +722,12 @@ class PkpdMapping(StoredModel):
     def save(self, force_insert=False, force_update=False, *args, **kwargs):
         created = not self.pk
 
-        super().save(force_insert, force_update, *args, **kwargs)
+        super().save(
+            *args,
+            force_insert=force_insert,
+            force_update=force_update,
+            **kwargs
+        )
 
         # don't update a stored model
         if self.read_only:

--- a/pkpdapp/pkpdapp/models/derived_variable.py
+++ b/pkpdapp/pkpdapp/models/derived_variable.py
@@ -61,7 +61,12 @@ class DerivedVariable(StoredModel):
     def save(self, force_insert=False, force_update=False, *args, **kwargs):
         created = not self.pk
 
-        super().save(force_insert, force_update, *args, **kwargs)
+        super().save(
+            *args,
+            force_insert=force_insert,
+            force_update=force_update,
+            **kwargs
+        )
 
         # don't update a stored model
         if self.read_only:

--- a/pkpdapp/pkpdapp/models/dose.py
+++ b/pkpdapp/pkpdapp/models/dose.py
@@ -53,7 +53,7 @@ class DoseBase(models.Model):
         constraints = [
             models.CheckConstraint(
                 name="Duration must be greater than 0",
-                check=models.Q(duration__gt=0),
+                condition=models.Q(duration__gt=0),
             ),
         ]
 
@@ -61,7 +61,12 @@ class DoseBase(models.Model):
         return self.protocol.get_project()
 
     def save(self, force_insert=False, force_update=False, *args, **kwargs):
-        super().save(force_insert, force_update, *args, **kwargs)
+        super().save(
+            *args,
+            force_insert=force_insert,
+            force_update=force_update,
+            **kwargs
+        )
 
         models = set()
         v = self.protocol.variable

--- a/pkpdapp/pkpdapp/models/pharmacodynamic_model.py
+++ b/pkpdapp/pkpdapp/models/pharmacodynamic_model.py
@@ -35,7 +35,12 @@ class PharmacodynamicModel(MechanisticModel, StoredModel):
     def save(self, force_insert=False, force_update=False, *args, **kwargs):
         created = not self.pk
 
-        super().save(force_insert, force_update, *args, **kwargs)
+        super().save(
+            *args,
+            force_insert=force_insert,
+            force_update=force_update,
+            **kwargs
+        )
 
         # don't update a stored model
         if self.read_only:

--- a/pkpdapp/pkpdapp/models/pharmacokinetic_model.py
+++ b/pkpdapp/pkpdapp/models/pharmacokinetic_model.py
@@ -30,7 +30,12 @@ class PharmacokineticModel(MechanisticModel, StoredModel):
     def save(self, force_insert=False, force_update=False, *args, **kwargs):
         created = not self.pk
 
-        super().save(force_insert, force_update, *args, **kwargs)
+        super().save(
+            *args,
+            force_insert=force_insert,
+            force_update=force_update,
+            **kwargs
+        )
 
         # don't update a stored model
         if self.read_only:

--- a/pkpdapp/pkpdapp/models/protocol.py
+++ b/pkpdapp/pkpdapp/models/protocol.py
@@ -154,7 +154,12 @@ class Protocol(StoredModel):
         return True
 
     def save(self, force_insert=False, force_update=False, *args, **kwargs):
-        super().save(force_insert, force_update, *args, **kwargs)
+        super().save(
+            *args,
+            force_insert=force_insert,
+            force_update=force_update,
+            **kwargs
+        )
 
         if self.dose_type != self.__original_dose_type:
             for dosed_pk_model in self.dosed_pk_models.all():

--- a/pkpdapp/pkpdapp/models/variable.py
+++ b/pkpdapp/pkpdapp/models/variable.py
@@ -158,11 +158,11 @@ class Variable(StoredModel):
     class Meta:
         constraints = [
             models.CheckConstraint(
-                check=((Q(is_log=True) & Q(lower_bound__gt=0)) | Q(is_log=False)),
+                condition=((Q(is_log=True) & Q(lower_bound__gt=0)) | Q(is_log=False)),
                 name=("%(class)s: log scale must have a lower bound greater than zero"),
             ),
             models.CheckConstraint(
-                check=(
+                condition=(
                     (
                         Q(pk_model__isnull=True)
                         & Q(dosed_pk_model__isnull=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 gunicorn
-Django~=5.2.14
-setuptools<=65.5.1
+Django~=6.0.4
+setuptools~=82.0.1
 django-cors-headers>=3.7.0
 dpd-static-support>=0.0.5
-pandas>=1.0
+pandas>=2.3
 whitenoise>=5.0.1
 docutils>=0.16
 python-markdown-math>=0.8
-pints @ git+https://github.com/pints-team/pints@i1403-multi-outputs#egg=pints
+pints~=0.6.1
 myokit @ git+https://github.com/myokit/myokit.git@main
 django-extensions>=3.1.1
 jsonfield>=3.1.0
@@ -20,13 +20,13 @@ django-polymorphic>=3.1.0
 drf-writable-nested>=0.6.3
 celery>=5.1.2
 tdigest>=0.5.2.2
-pymc3>=3.11.5
+pymc>=6.0.1
 django-auth-ldap>=4.1.0
 pyyaml>=6.0.0
 drf-spectacular>=0.26.2
 openpyxl>=3.1.2
 django-user-visit>=2.0.0
-snapshottest>=0.6.0
+snapshottest==1.0.0a1
 django-cprofile-middleware>=1.0.5
 ipython
 pydiffsol>=0.5.2


### PR DESCRIPTION
- bump Django to 6.0.5.
- bump Python to 3.12 (the minimum required for Django 6.0.5.)
- bump setuptools to 82.0.1.
- bump `pints` to latest.
- remove deprecated `check` argument from constraints.
- update tests.
- update models to use keyword arguments for `save()`.