### PR TITLE
feat: draft out frontend fuzzer

### DIFF
--- a/frontend-v2/exploratory_tester/.gitignore
+++ b/frontend-v2/exploratory_tester/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+.pytest_cache/
+*.pyc
+*.pyo
+test-results/
+playwright-report/

--- a/frontend-v2/exploratory_tester/README.md
+++ b/frontend-v2/exploratory_tester/README.md
@@ -1,0 +1,156 @@
+# PKPDApp Exploratory Tester
+
+Stateful Playwright-based fuzz tester that detects unexplained semantic UI state changes in the PKPDApp frontend.
+
+Takes snapshots of the simulation model's domain state (Redux cache + DOM), generates actions with expected state diffs, executes them via Playwright, then verifies exactly the expected changes occurred and no others.
+
+## Quick Start
+
+```bash
+# Install dependencies
+cd exploratory_tester
+pip install -r requirements.txt
+playwright install chromium
+
+# Run against local dev server
+pytest . --base-url http://localhost:5173 --username demo --password 12345
+
+# Quick smoke test only
+pytest . -k smoke
+
+# Limit exploration steps
+pytest . --max-steps 50
+
+# Run against a deployed instance
+pytest . --base-url https://staging.example.com --username myuser --password mypass
+```
+
+The `--base-url` flag is provided by `pytest-base-url` (dependency of `pytest-playwright`). A default can be set in `pytest.ini`.
+
+## Prerequisites
+
+- Python 3.10+
+- A running PKPDApp instance (Django backend + Vite frontend)
+- The frontend must run in **dev mode** (`import.meta.env.DEV === true`) so the Redux store is exposed on `window.__pkpd_store__`
+- A user account that can create projects
+
+## Architecture
+
+```
+snapshot_from_page(page)   # Inject JS → parse Redux cache → SimulationModelSnapshot
+         │
+         ▼
+explorer.pick_next(snap)   # Coverage-guided: pick unvisited (state, action) edge
+         │
+         ▼
+action.execute(page, snap) # Playwright: navigate, click, fill, submit
+         │
+         ▼
+snapshot_from_page(page)   # Re-extract state after action
+         │
+         ▼
+check_action(action, │, │) # Diff before/after, validate sim results, flag UI errors
+         │
+         ▼
+explorer.record(before, action, after)  # Update coverage
+         │
+         ◄─────── repeat ───────────────►
+```
+
+### Components
+
+| File | Role |
+|---|---|
+| `snapshot.py` | `SimulationModelSnapshot` frozen dataclass, diff engine, JS-injection extractor |
+| `js_extractors/redux_snapshot.js` | Injected JS — reads RTK Query cache + DOM slider positions |
+| `actions/base.py` | Abstract `Action` class: `preconditions(snap)`, `execute(page, snap)`, `expected_diff(snap)` |
+| `actions/navigation.py` | Shared Playwright helpers (click sidebar, select dropdowns, fill fields) |
+| `actions/project.py` | `CreateProjectAction`, `SetSpeciesAction` |
+| `actions/model_config.py` | `SelectSubModelAction`, `ToggleModelFlagAction`, `ResetToSpeciesDefaultsAction` |
+| `actions/parameters.py` | `SetParameterAction` — 5 discrete values per parameter |
+| `actions/mappings.py` | `ToggleDosingAction`, `TogglePdMappingAction` |
+| `actions/dosing.py` | `SetDoseFieldAction` |
+| `actions/simulation.py` | Add/remove plots & sliders, set slider values, set time max |
+| `actions/registry.py` | `generate_all_actions(snap)` — builds the full action catalog |
+| `explorer.py` | `CoverageGuidedExplorer` — tracks `(state_hash, action_key)` edges |
+| `checker.py` | `check_action()` — diff snapshots, validate sim results, detect UI errors |
+| `fuzzer.py` | `run_fuzzer()` — main loop returning `FuzzerReport` |
+| `conftest.py` | Pytest fixtures: browser, page (with login), CLI options |
+
+### Snapshot
+
+The `SimulationModelSnapshot` captures the domain state of the simulation model — no UI/navigation fields:
+
+```
+model_id, species, pk_model_id, pk_model_id2, pk_effect_model_id,
+pd_model_id, pd_model_id2, number_of_effect_compartments, has_lag,
+has_anti_drug_antibodies, has_bioavailability, time_max,
+parameters (qname → value+bounds), outputs (available plot vars),
+pd_mappings, dosed_compartments, doses, derived_variables,
+compound, plots, sliders, sim_results (time series)
+```
+
+Extraction reads `window.__pkpd_store__.getState()` — one JS injection gathers the RTK Query cache (model, variables, compound, doses, simulations) plus DOM slider thumb values (react-hook-form local state not in Redux).
+
+### Actions
+
+Each action declares:
+- **`preconditions(snap)`** — can this action be performed in the current state?
+- **`execute(page, snap)`** — perform it via Playwright (handles navigation implicitly)
+- **`expected_diff(snap)`** — what `SnapshotDiff` should result?
+- **`RESULT_EXPECTATION`** — `SHOULD_CHANGE`, `SHOULD_NOT_CHANGE`, or `IRRELEVANT`
+
+Parameter values are discretized into 5 values: default, default×0.5, default×1.5, lower_bound, upper_bound.
+
+### Checker
+
+Three layers of validation per step:
+
+1. **Diff check** — Every field/parameter change in the snapshot must match an expected change in the action's declared diff. Unexpected changes are flagged as anomalies.
+2. **Simulation result check** — For `SHOULD_NOT_CHANGE` actions: results must be byte-identical. For `SHOULD_CHANGE` actions: results must differ.
+3. **UI error check** — Scrapes `.MuiAlert-standardError` snackbars for error messages.
+
+### Explorer
+
+`CoverageGuidedExplorer` tracks visited `(snapshot_hash, action_key)` edges and prioritizes unexplored transitions. If all edges from the current state are visited, falls back to random selection. Reports coverage stats per run.
+
+## Configuration
+
+| CLI flag | Env var | Default | Description |
+|---|---|---|---|
+| `--base-url` | — | `http://localhost:5173` | Frontend URL |
+| `--username` | `PKPD_USERNAME` | `fuzzer` | Login username |
+| `--password` | `PKPD_PASSWORD` | `test1234` | Login password |
+| `--max-steps` | `PKPD_MAX_STEPS` | `200` | Steps per run |
+
+Also in `pytest.ini`:
+
+```ini
+base_url = http://localhost:5173
+asyncio_mode = auto
+log_cli_level = INFO
+```
+
+## Frontend Requirement
+
+The app must expose the Redux store in dev mode. The one-line change in `src/app/store.ts`:
+
+```typescript
+if (import.meta.env.DEV) {
+  (window as any).__pkpd_store__ = store;
+}
+```
+
+## Findings
+
+The `FuzzerReport` contains a list of `CheckResult` objects:
+
+```
+[FAIL] set_parameter:PKCompartment.CL:0.25
+  UNEXPECTED: field 'species' changed: R -> H
+  MISSING: expected field 'has_model' to change, but it didn't
+  ERROR: Snackbar error: Validation failed
+  SIM_RESULT: Simulation results changed when they should not have
+```
+
+Each finding includes the step number, action key, before/after snapshots, and categorized failure details.

--- a/frontend-v2/exploratory_tester/__init__.py
+++ b/frontend-v2/exploratory_tester/__init__.py
@@ -1,0 +1,2 @@
+"""Exploratory tester for PKPDApp — detects unexplained semantic UI state changes."""
+

--- a/frontend-v2/exploratory_tester/__init__.py
+++ b/frontend-v2/exploratory_tester/__init__.py
@@ -1,2 +1,1 @@
 """Exploratory tester for PKPDApp — detects unexplained semantic UI state changes."""
-

--- a/frontend-v2/exploratory_tester/actions/base.py
+++ b/frontend-v2/exploratory_tester/actions/base.py
@@ -1,0 +1,65 @@
+"""Abstract base class for all exploratory actions."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from enum import Enum, auto
+
+from playwright.async_api import Page
+
+from ..snapshot import SimulationModelSnapshot, SnapshotDiff
+
+
+class ResultExpectation(Enum):
+    """What the checker should expect for simulation results after this action."""
+
+    SHOULD_NOT_CHANGE = auto()   # Results should be byte-identical to before
+    SHOULD_CHANGE = auto()       # Results should differ for some outputs
+    IRRELEVANT = auto()          # No simulation data to compare (e.g. pre-model)
+
+
+class Action(ABC):
+    """A semantic operation on the simulation model state.
+
+    Subclasses define:
+    - key: unique identifier string (populated dynamically in __init_subclass__)
+    - CATEGORY: grouping label for reporting
+    - RESULT_EXPECTATION: what to expect for simulation results
+    - preconditions(snapshot) -> bool
+    - execute(page, snapshot) -> None
+    - expected_diff(before) -> SnapshotDiff
+    """
+
+    CATEGORY: str = "unknown"
+    RESULT_EXPECTATION: ResultExpectation = ResultExpectation.IRRELEVANT
+
+    def __init__(self) -> None:
+        pass  # key set by __init_subclass__ or subclass
+
+    @property
+    @abstractmethod
+    def key(self) -> str:
+        """Unique action identifier used for coverage tracking."""
+        ...
+
+    @abstractmethod
+    def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
+        """Return True if this action can be performed in the current state."""
+        ...
+
+    @abstractmethod
+    async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
+        """Perform the action in the browser via Playwright.
+
+        Navigates to the correct page/subtab implicitly; the caller does not
+        need to know the current tab.
+        """
+        ...
+
+    @abstractmethod
+    def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
+        """Return the SnapshotDiff this action expects to cause."""
+        ...
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(key={self.key})"

--- a/frontend-v2/exploratory_tester/actions/dosing.py
+++ b/frontend-v2/exploratory_tester/actions/dosing.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from playwright.async_api import Page
 
-from ..snapshot import SimulationModelSnapshot, DoseState, SnapshotDiff
+from ..snapshot import SimulationModelSnapshot, SnapshotDiff
 from .base import Action, ResultExpectation
 from .navigation import navigate_to_page
 

--- a/frontend-v2/exploratory_tester/actions/dosing.py
+++ b/frontend-v2/exploratory_tester/actions/dosing.py
@@ -1,0 +1,63 @@
+"""Dose configuration actions."""
+
+from __future__ import annotations
+
+from playwright.async_api import Page
+
+from ..snapshot import SimulationModelSnapshot, DoseState, SnapshotDiff
+from .base import Action, ResultExpectation
+from .navigation import navigate_to_page
+
+
+class SetDoseFieldAction(Action):
+    """Set a single field on a dose (amount, duration, repeats, etc.).
+
+    Value bucketing: default, default×0.5, default×1.5, bounds.
+    For discrete fields (repeats), use sensible integers.
+    """
+
+    CATEGORY = "dosing"
+    RESULT_EXPECTATION = ResultExpectation.SHOULD_CHANGE
+
+    DOSE_FIELDS = ["start_time", "amount", "duration", "repeats", "repeat_interval"]
+
+    def __init__(self, dose_index: int, field_name: str, value: float) -> None:
+        self._dose_index = dose_index
+        self._field_name = field_name
+        self._value = value
+        self._key = f"set_dose:{dose_index}:{field_name}:{value}"
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
+        if self._dose_index >= len(snapshot.doses):
+            return False
+        dose = snapshot.doses[self._dose_index]
+        current = getattr(dose, self._field_name, None)
+        if current is None:
+            return False
+        return float(current) != float(self._value)
+
+    async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
+        await navigate_to_page(page, "Trial Design")
+
+        name_attr = f"doses.{self._dose_index}.{self._field_name}"
+        field = page.locator(f'input[name="{name_attr}"]')
+        await field.click(force=True)
+        await field.fill(str(self._value))
+        await field.blur()
+
+        await page.wait_for_timeout(800)
+
+    def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
+        d = SnapshotDiff()
+        old_val = None
+        if self._dose_index < len(before.doses):
+            old_val = getattr(before.doses[self._dose_index], self._field_name, None)
+        d.changed_fields[f"doses[{self._dose_index}].{self._field_name}"] = (
+            old_val,
+            self._value,
+        )
+        return d

--- a/frontend-v2/exploratory_tester/actions/dosing.py
+++ b/frontend-v2/exploratory_tester/actions/dosing.py
@@ -43,8 +43,9 @@ class SetDoseFieldAction(Action):
     async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
         await navigate_to_page(page, "Trial Design")
 
-        name_attr = f"doses.{self._dose_index}.{self._field_name}"
-        field = page.locator(f'input[name="{name_attr}"]')
+        field = page.locator(
+            f'[data-cy="float-field-{self._field_name}"] input'
+        ).nth(self._dose_index)
         await field.click(force=True)
         await field.fill(str(self._value))
         await field.blur()
@@ -53,11 +54,8 @@ class SetDoseFieldAction(Action):
 
     def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
         d = SnapshotDiff()
-        old_val = None
         if self._dose_index < len(before.doses):
-            old_val = getattr(before.doses[self._dose_index], self._field_name, None)
-        d.changed_fields[f"doses[{self._dose_index}].{self._field_name}"] = (
-            old_val,
-            self._value,
-        )
+            d.changed_fields[f"doses[{self._dose_index}]"] = (
+                "changed", "changed",
+            )
         return d

--- a/frontend-v2/exploratory_tester/actions/mappings.py
+++ b/frontend-v2/exploratory_tester/actions/mappings.py
@@ -32,8 +32,7 @@ class ToggleDosingAction(Action):
 
     def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
         d = SnapshotDiff()
-        prev = self._var_name in before.dosed_compartments
-        d.changed_fields[f"dosed.{self._var_name}"] = (prev, not prev)
+        d.changed_fields["dosed"] = ("may_change", "may_change")
         return d
 
 

--- a/frontend-v2/exploratory_tester/actions/mappings.py
+++ b/frontend-v2/exploratory_tester/actions/mappings.py
@@ -1,61 +1,92 @@
-"""Variable mapping actions: dosing compartment toggles, PK→PD mapping toggles."""
+"""Variable mapping actions: dosing compartment toggles, PK→PD mapping toggles.
+
+Each action discovers available options at execution time rather than using
+pre-generated concrete instances, so the fuzzer always sees the current state.
+"""
 
 from __future__ import annotations
+
+import logging
+import random
 
 from playwright.async_api import Page
 
 from ..snapshot import SimulationModelSnapshot, SnapshotDiff
 from .base import Action, ResultExpectation
-from .navigation import navigate_to_model_subtab, toggle_checkbox
+from .navigation import (
+    get_checkbox_labels,
+    navigate_to_model_subtab,
+    toggle_checkbox,
+)
+
+logger = logging.getLogger(__name__)
 
 
-class ToggleDosingAction(Action):
-    """Toggle whether a compartment is a dosing compartment."""
+class PickDosingAction(Action):
+    """Toggle a random dosing compartment checkbox on the Map Variables tab.
+
+    Discovers available dosing variables at execution time.
+    """
 
     CATEGORY = "mappings"
     RESULT_EXPECTATION = ResultExpectation.SHOULD_CHANGE
 
-    def __init__(self, variable_name: str) -> None:
-        self._var_name = variable_name
-        self._key = f"toggle_dosing:{variable_name}"
+    _key = "pick_dosing"
 
     @property
     def key(self) -> str:
         return self._key
 
     def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
-        return snapshot.has_model
+        return snapshot.has_model and bool(snapshot.pk_model_id)
 
     async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
         await navigate_to_model_subtab(page, "Map Variables")
-        await toggle_checkbox(page, f"dosing-{self._var_name}")
+        names = await get_checkbox_labels(page, "checkbox-dosing-")
+        if not names:
+            return
+        chosen = random.choice(names)
+        logger.info("pick_dosing: chose %s", chosen)
+        await toggle_checkbox(page, f"checkbox-dosing-{chosen}")
 
     def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
         d = SnapshotDiff()
         d.changed_fields["dosed"] = ("may_change", "may_change")
+        d.changed_fields["has_dosing"] = ("may_change", "may_change")
+        d.added_doses = -1  # Sentinel: unknown how many doses added
         return d
 
 
-class TogglePdMappingAction(Action):
-    """Toggle a PK→PD variable mapping."""
+class PickPdMappingAction(Action):
+    """Toggle a random PK→PD variable mapping radio on the Map Variables tab.
+
+    Discovers available PD mapping variables at execution time.
+    """
 
     CATEGORY = "mappings"
     RESULT_EXPECTATION = ResultExpectation.SHOULD_CHANGE
 
-    def __init__(self, variable_name: str) -> None:
-        self._var_name = variable_name
-        self._key = f"toggle_pd_mapping:{variable_name}"
+    _key = "pick_pd_mapping"
 
     @property
     def key(self) -> str:
         return self._key
 
     def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
-        return snapshot.has_model
+        return (
+            snapshot.has_model
+            and bool(snapshot.pk_model_id)
+            and bool(snapshot.pd_model_id)
+        )
 
     async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
         await navigate_to_model_subtab(page, "Map Variables")
-        await toggle_checkbox(page, f"map-to-pd-{self._var_name}")
+        names = await get_checkbox_labels(page, "checkbox-map-to-pd-")
+        if not names:
+            return
+        chosen = random.choice(names)
+        logger.info("pick_pd_mapping: chose %s", chosen)
+        await toggle_checkbox(page, f"checkbox-map-to-pd-{chosen}")
 
     def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
         d = SnapshotDiff()

--- a/frontend-v2/exploratory_tester/actions/mappings.py
+++ b/frontend-v2/exploratory_tester/actions/mappings.py
@@ -1,0 +1,64 @@
+"""Variable mapping actions: dosing compartment toggles, PK→PD mapping toggles."""
+
+from __future__ import annotations
+
+from playwright.async_api import Page
+
+from ..snapshot import SimulationModelSnapshot, SnapshotDiff
+from .base import Action, ResultExpectation
+from .navigation import navigate_to_model_subtab, toggle_checkbox
+
+
+class ToggleDosingAction(Action):
+    """Toggle whether a compartment is a dosing compartment."""
+
+    CATEGORY = "mappings"
+    RESULT_EXPECTATION = ResultExpectation.SHOULD_CHANGE
+
+    def __init__(self, variable_name: str) -> None:
+        self._var_name = variable_name
+        self._key = f"toggle_dosing:{variable_name}"
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
+        return snapshot.has_model
+
+    async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
+        await navigate_to_model_subtab(page, "Map Variables")
+        await toggle_checkbox(page, f"dosing-{self._var_name}")
+
+    def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
+        d = SnapshotDiff()
+        prev = self._var_name in before.dosed_compartments
+        d.changed_fields[f"dosed.{self._var_name}"] = (prev, not prev)
+        return d
+
+
+class TogglePdMappingAction(Action):
+    """Toggle a PK→PD variable mapping."""
+
+    CATEGORY = "mappings"
+    RESULT_EXPECTATION = ResultExpectation.SHOULD_CHANGE
+
+    def __init__(self, variable_name: str) -> None:
+        self._var_name = variable_name
+        self._key = f"toggle_pd_mapping:{variable_name}"
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
+        return snapshot.has_model
+
+    async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
+        await navigate_to_model_subtab(page, "Map Variables")
+        await toggle_checkbox(page, f"map-to-pd-{self._var_name}")
+
+    def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
+        d = SnapshotDiff()
+        d.mappings_changed = True
+        return d

--- a/frontend-v2/exploratory_tester/actions/model_config.py
+++ b/frontend-v2/exploratory_tester/actions/model_config.py
@@ -7,7 +7,6 @@ from playwright.async_api import Page
 from ..snapshot import SimulationModelSnapshot, SnapshotDiff
 from .base import Action, ResultExpectation
 from .navigation import (
-    click_data_cy,
     navigate_to_model_subtab,
     select_dropdown_option,
     toggle_checkbox,

--- a/frontend-v2/exploratory_tester/actions/model_config.py
+++ b/frontend-v2/exploratory_tester/actions/model_config.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import logging
+import random
+
 from playwright.async_api import Page
 
 from ..snapshot import SimulationModelSnapshot, SnapshotDiff
@@ -12,20 +15,45 @@ from .navigation import (
     toggle_checkbox,
 )
 
+logger = logging.getLogger(__name__)
 
-class SelectSubModelAction(Action):
-    """Select a PK or PD sub-model from a dropdown on the PK/PD Model tab."""
+
+class PickModelAction(Action):
+    """Pick a model from a dropdown on the PK/PD Model tab.
+
+    Discovers available options at execution time so the fuzzer always
+    sees the current state (which depends on species, prior selections, etc.).
+    """
 
     CATEGORY = "model_config"
     RESULT_EXPECTATION = ResultExpectation.SHOULD_CHANGE
 
-    def __init__(self, field_name: str, model_name: str, label: str,
-                 requires_pk: bool = False) -> None:
+    FIELD_TO_SELECT = {
+        "pk_model": "pk_model",
+        "pk_model2": "pk_model2",
+        "pk_effect_model": "pk_effect_model",
+        "pd_model": "pd_model",
+        "pd_model2": "pd_model2",
+    }
+
+    FIELD_TO_SNAPSHOT = {
+        "pk_model": "pk_model_id",
+        "pk_model2": "pk_model_id2",
+        "pk_effect_model": "pk_effect_model_id",
+        "pd_model": "pd_model_id",
+        "pd_model2": "pd_model_id2",
+    }
+
+    def __init__(
+        self,
+        field_name: str,
+        requires_pk: bool = False,
+        requires_pd: bool = False,
+    ) -> None:
         self._field_name = field_name
-        self._model_name = model_name
-        self._label = label
         self._requires_pk = requires_pk
-        self._key = f"select_{field_name}:{model_name}"
+        self._requires_pd = requires_pd
+        self._key = f"pick_{field_name}"
 
     @property
     def key(self) -> str:
@@ -36,16 +64,51 @@ class SelectSubModelAction(Action):
             return False
         if self._requires_pk and not snapshot.pk_model_id:
             return False
+        if self._requires_pd and not snapshot.pd_model_id:
+            return False
         return True
 
     async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
         await navigate_to_model_subtab(page, "PK/PD Model")
-        await select_dropdown_option(page, self._field_name, self._label)
+        select_name = self.FIELD_TO_SELECT[self._field_name]
+        # Open dropdown and pick a random option by index
+        await page.locator(
+            f'[data-cy="select-{select_name}"]'
+        ).click(force=True)
+        await page.wait_for_timeout(500)
+        options = page.locator('li[role="option"]')
+        count = await options.count()
+        if count == 0:
+            await page.keyboard.press("Escape")
+            return
+        # Pick a random non-"None" option
+        indices = []
+        for i in range(count):
+            text = await options.nth(i).text_content()
+            if text and text.strip() and text.strip() != "None":
+                indices.append(i)
+        if not indices:
+            await page.keyboard.press("Escape")
+            return
+        chosen_idx = random.choice(indices)
+        chosen_text = await options.nth(chosen_idx).text_content()
+        logger.info("pick_%s: chose %s", self._field_name, chosen_text)
+        await options.nth(chosen_idx).click(force=True)
+        await page.wait_for_timeout(500)
 
     def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
         d = SnapshotDiff()
-        d.changed_fields[self._field_name] = ("changed", "changed")
+        field = self.FIELD_TO_SNAPSHOT[self._field_name]
+        d.changed_fields[field] = ("changed", "changed")
         d.changed_fields["parameters"] = ("may_change", "may_change")
+        # Model pick may cascade to these fields
+        d.changed_fields["pk_effect_model_id"] = ("may_change", "may_change")
+        d.changed_fields["number_of_effect_compartments"] = (
+            "may_change", "may_change",
+        )
+        d.changed_fields["pd_model_id"] = ("may_change", "may_change")
+        d.changed_fields["pd_model_id2"] = ("may_change", "may_change")
+        d.changed_fields["pk_model_id2"] = ("may_change", "may_change")
         return d
 
 
@@ -57,7 +120,7 @@ class ToggleModelFlagAction(Action):
 
     FLAG_SELECTORS = {
         "has_lag": "checkbox-has_lag",
-        "has_anti_drug_antibodies": "checkbox-has_ada",
+        "has_anti_drug_antibodies": "checkbox-has_anti_drug_antibodies",
         "has_bioavailability": "checkbox-has_bioavailability",
     }
 
@@ -69,8 +132,17 @@ class ToggleModelFlagAction(Action):
     def key(self) -> str:
         return self._key
 
+    FLAG_REQUIRES_PK2 = {"has_lag", "has_bioavailability"}
+
     def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
         if not snapshot.has_model:
+            return False
+        if not snapshot.pk_model_id:
+            return False
+        if (
+            self._flag_name in self.FLAG_REQUIRES_PK2
+            and not snapshot.pk_model_id2
+        ):
             return False
         return True
 
@@ -85,6 +157,7 @@ class ToggleModelFlagAction(Action):
         d = SnapshotDiff()
         old = getattr(before, self._flag_name, False)
         d.changed_fields[self._flag_name] = (old, not old)
+        d.changed_fields["parameters"] = ("may_change", "may_change")
         return d
 
 
@@ -105,6 +178,8 @@ class SetEffectCompartmentsAction(Action):
     def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
         if not snapshot.has_model:
             return False
+        if not snapshot.pk_model_id:
+            return False
         return snapshot.number_of_effect_compartments != self._value
 
     async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
@@ -116,9 +191,9 @@ class SetEffectCompartmentsAction(Action):
     def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
         d = SnapshotDiff()
         d.changed_fields["number_of_effect_compartments"] = (
-            before.number_of_effect_compartments,
-            self._value,
+            "may_change", "may_change",
         )
+        d.changed_fields["parameters"] = ("may_change", "may_change")
         return d
 
 
@@ -135,7 +210,13 @@ class ResetToSpeciesDefaultsAction(Action):
         return self._key
 
     def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
-        return snapshot.has_model
+        if not snapshot.has_model or not snapshot.pk_model_id:
+            return False
+        if not snapshot.has_dosing:
+            return False
+        if snapshot.pd_model_id and not snapshot.pd_mappings:
+            return False
+        return True
 
     async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
         await navigate_to_model_subtab(page, "Parameters")

--- a/frontend-v2/exploratory_tester/actions/model_config.py
+++ b/frontend-v2/exploratory_tester/actions/model_config.py
@@ -1,0 +1,150 @@
+"""Model configuration actions: select PK/PD models, toggle flags."""
+
+from __future__ import annotations
+
+from playwright.async_api import Page
+
+from ..snapshot import SimulationModelSnapshot, SnapshotDiff
+from .base import Action, ResultExpectation
+from .navigation import (
+    click_data_cy,
+    navigate_to_model_subtab,
+    select_dropdown_option,
+    toggle_checkbox,
+)
+
+
+class SelectSubModelAction(Action):
+    """Select a PK or PD sub-model from a dropdown on the PK/PD Model tab."""
+
+    CATEGORY = "model_config"
+    RESULT_EXPECTATION = ResultExpectation.SHOULD_CHANGE
+
+    def __init__(self, field_name: str, model_name: str, label: str,
+                 requires_pk: bool = False) -> None:
+        self._field_name = field_name
+        self._model_name = model_name
+        self._label = label
+        self._requires_pk = requires_pk
+        self._key = f"select_{field_name}:{model_name}"
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
+        if not snapshot.has_model:
+            return False
+        if self._requires_pk and not snapshot.pk_model_id:
+            return False
+        return True
+
+    async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
+        await navigate_to_model_subtab(page, "PK/PD Model")
+        await select_dropdown_option(page, self._field_name, self._label)
+
+    def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
+        d = SnapshotDiff()
+        d.changed_fields[self._field_name] = ("changed", "changed")
+        d.changed_fields["parameters"] = ("may_change", "may_change")
+        return d
+
+
+class ToggleModelFlagAction(Action):
+    """Toggle a boolean flag (has_lag, has_bioavailability, etc.)."""
+
+    CATEGORY = "model_config"
+    RESULT_EXPECTATION = ResultExpectation.SHOULD_CHANGE
+
+    FLAG_SELECTORS = {
+        "has_lag": "checkbox-has_lag",
+        "has_anti_drug_antibodies": "checkbox-has_ada",
+        "has_bioavailability": "checkbox-has_bioavailability",
+    }
+
+    def __init__(self, flag_name: str) -> None:
+        self._flag_name = flag_name
+        self._key = f"toggle:{flag_name}"
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
+        if not snapshot.has_model:
+            return False
+        return True
+
+    async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
+        await navigate_to_model_subtab(page, "PK/PD Model")
+        selector = self.FLAG_SELECTORS.get(
+            self._flag_name, f"checkbox-{self._flag_name}"
+        )
+        await toggle_checkbox(page, selector)
+
+    def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
+        d = SnapshotDiff()
+        old = getattr(before, self._flag_name, False)
+        d.changed_fields[self._flag_name] = (old, not old)
+        return d
+
+
+class SetEffectCompartmentsAction(Action):
+    """Change number_of_effect_compartments on the PK/PD Model tab."""
+
+    CATEGORY = "model_config"
+    RESULT_EXPECTATION = ResultExpectation.SHOULD_CHANGE
+
+    def __init__(self, value: int) -> None:
+        self._value = value
+        self._key = f"set_effect_compartments:{value}"
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
+        if not snapshot.has_model:
+            return False
+        return snapshot.number_of_effect_compartments != self._value
+
+    async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
+        await navigate_to_model_subtab(page, "PK/PD Model")
+        await select_dropdown_option(
+            page, "number_of_effect_compartments", str(self._value)
+        )
+
+    def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
+        d = SnapshotDiff()
+        d.changed_fields["number_of_effect_compartments"] = (
+            before.number_of_effect_compartments,
+            self._value,
+        )
+        return d
+
+
+class ResetToSpeciesDefaultsAction(Action):
+    """Reset all parameters to species-specific defaults."""
+
+    CATEGORY = "model_config"
+    RESULT_EXPECTATION = ResultExpectation.SHOULD_CHANGE
+
+    _key = "reset_to_species_defaults"
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
+        return snapshot.has_model
+
+    async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
+        await navigate_to_model_subtab(page, "Parameters")
+        button = page.get_by_role("button", name="Reset to Species Defaults")
+        await button.click(force=True)
+        await page.wait_for_timeout(1000)
+
+    def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
+        d = SnapshotDiff()
+        d.changed_fields["parameters"] = ("reset_to_defaults", "reset_to_defaults")
+        return d

--- a/frontend-v2/exploratory_tester/actions/navigation.py
+++ b/frontend-v2/exploratory_tester/actions/navigation.py
@@ -7,26 +7,33 @@ async def navigate_to_page(page: Page, tab_name: str) -> None:
     """Click the sidebar navigation tab by text content.
 
     Uses JS click to bypass MUI's collapsed-sidebar visibility issues.
+    Retries up to 3 times in case the sidebar hasn't rendered yet.
     """
-    await page.evaluate(
-        """(name) => {
-            const items = document.querySelectorAll('.MuiListItemButton-root');
-            for (const el of items) {
-                if (el.textContent && el.textContent.trim() === name) {
-                    el.click();
-                    return true;
+    for _attempt in range(3):
+        clicked = await page.evaluate(
+            """(name) => {
+                const items = document.querySelectorAll(
+                    '.MuiListItemButton-root'
+                );
+                for (const el of items) {
+                    if (el.textContent && el.textContent.trim() === name) {
+                        el.click();
+                        return true;
+                    }
                 }
-            }
-            for (const el of items) {
-                if (el.textContent && el.textContent.includes(name)) {
-                    el.click();
-                    return true;
+                for (const el of items) {
+                    if (el.textContent && el.textContent.includes(name)) {
+                        el.click();
+                        return true;
+                    }
                 }
-            }
-            return false;
-        }""",
-        tab_name,
-    )
+                return false;
+            }""",
+            tab_name,
+        )
+        if clicked:
+            break
+        await page.wait_for_timeout(500)
     await page.wait_for_timeout(800)
     # Wait for page to settle after navigation
     try:
@@ -37,7 +44,9 @@ async def navigate_to_page(page: Page, tab_name: str) -> None:
 
 async def navigate_to_subtab(page: Page, subtab_name: str) -> None:
     """Click a sub-tab button (MUI Tab) by text content."""
-    await page.get_by_role("tab", name=subtab_name).click(force=True)
+    tab = page.get_by_role("tab", name=subtab_name).first
+    await tab.wait_for(state="visible", timeout=10000)
+    await tab.click(force=True)
     await page.wait_for_timeout(500)
 
 
@@ -67,19 +76,63 @@ async def select_dropdown_option(
 ) -> None:
     """Open a SelectField dropdown and pick an option by label."""
     await page.locator(f'[data-cy="select-{select_name}"]').click(force=True)
-    await page.wait_for_timeout(300)
-    # Try exact data-cy match first, fall back to partial text match
+    await page.wait_for_timeout(400)
+    # Try exact data-cy match first
     exact = page.locator(f'[data-cy="select-option-{select_name}-{option_label}"]')
-    if exact.count() > 0:
+    if await exact.count() > 0:
         await exact.click(force=True)
-    else:
-        await page.get_by_text(option_label, exact=False).first.click(
-            force=True, timeout=5000
-        )
-    await page.wait_for_timeout(500)
+        await page.wait_for_timeout(800)
+        return
+    # MUI renders MenuItems as <li role="option"> in a portal popover.
+    # Wait for the menu to appear (MUI has entry animations).
+    option = page.locator(
+        f'li[role="option"]:has-text("{option_label}")'
+    ).first
+    await option.wait_for(state="visible", timeout=5000)
+    await option.click(force=True)
+    await page.wait_for_timeout(800)
 
 
 async def click_data_cy(page: Page, data_cy: str) -> None:
     """Click an element by data-cy attribute."""
     await page.locator(f'[data-cy="{data_cy}"]').click(force=True)
     await page.wait_for_timeout(500)
+
+
+async def get_dropdown_option_labels(
+    page: Page, select_name: str
+) -> list[str]:
+    """Open a dropdown, read all option labels, then close it.
+
+    Returns the list of option labels (excluding "None" entry).
+    """
+    await page.locator(f'[data-cy="select-{select_name}"]').click(force=True)
+    await page.wait_for_timeout(500)
+    options = page.locator('li[role="option"]')
+    count = await options.count()
+    labels: list[str] = []
+    for i in range(count):
+        text = await options.nth(i).text_content()
+        if text and text.strip() and text.strip() != "None":
+            labels.append(text.strip())
+    # Close the dropdown by pressing Escape
+    await page.keyboard.press("Escape")
+    await page.wait_for_timeout(300)
+    return labels
+
+
+async def get_checkbox_labels(
+    page: Page, data_cy_prefix: str,
+) -> list[str]:
+    """Find all checkboxes with a given data-cy prefix and return the suffix.
+
+    For example, data_cy_prefix="checkbox-dosing-" returns ["Aa", "A1", ...].
+    """
+    elements = page.locator(f'[data-cy^="{data_cy_prefix}"]')
+    count = await elements.count()
+    labels: list[str] = []
+    for i in range(count):
+        cy = await elements.nth(i).get_attribute("data-cy")
+        if cy and cy.startswith(data_cy_prefix):
+            labels.append(cy[len(data_cy_prefix):])
+    return labels

--- a/frontend-v2/exploratory_tester/actions/navigation.py
+++ b/frontend-v2/exploratory_tester/actions/navigation.py
@@ -62,7 +62,9 @@ async def toggle_checkbox(page: Page, data_cy: str) -> None:
     await page.wait_for_timeout(500)
 
 
-async def select_dropdown_option(page: Page, select_name: str, option_label: str) -> None:
+async def select_dropdown_option(
+    page: Page, select_name: str, option_label: str
+) -> None:
     """Open a SelectField dropdown and pick an option by label."""
     await page.locator(f'[data-cy="select-{select_name}"]').click(force=True)
     await page.wait_for_timeout(300)

--- a/frontend-v2/exploratory_tester/actions/navigation.py
+++ b/frontend-v2/exploratory_tester/actions/navigation.py
@@ -1,0 +1,83 @@
+"""Shared navigation helpers for Playwright actions."""
+
+from playwright.async_api import Page
+
+
+async def navigate_to_page(page: Page, tab_name: str) -> None:
+    """Click the sidebar navigation tab by text content.
+
+    Uses JS click to bypass MUI's collapsed-sidebar visibility issues.
+    """
+    await page.evaluate(
+        """(name) => {
+            const items = document.querySelectorAll('.MuiListItemButton-root');
+            for (const el of items) {
+                if (el.textContent && el.textContent.trim() === name) {
+                    el.click();
+                    return true;
+                }
+            }
+            for (const el of items) {
+                if (el.textContent && el.textContent.includes(name)) {
+                    el.click();
+                    return true;
+                }
+            }
+            return false;
+        }""",
+        tab_name,
+    )
+    await page.wait_for_timeout(800)
+    # Wait for page to settle after navigation
+    try:
+        await page.wait_for_load_state("networkidle", timeout=5000)
+    except Exception:
+        pass
+
+
+async def navigate_to_subtab(page: Page, subtab_name: str) -> None:
+    """Click a sub-tab button (MUI Tab) by text content."""
+    await page.get_by_role("tab", name=subtab_name).click(force=True)
+    await page.wait_for_timeout(500)
+
+
+async def navigate_to_model_subtab(page: Page, subtab_name: str) -> None:
+    """Navigate to Model page, then a sub-tab."""
+    await navigate_to_page(page, "Model")
+    await navigate_to_subtab(page, subtab_name)
+
+
+async def fill_text_field(page: Page, selector: str, value: str) -> None:
+    """Fill a text input and trigger blur to activate auto-save."""
+    field = page.locator(selector)
+    await field.click(force=True)
+    await field.fill(value)
+    await field.blur()
+    await page.wait_for_timeout(300)
+
+
+async def toggle_checkbox(page: Page, data_cy: str) -> None:
+    """Click a checkbox by data-cy attribute."""
+    await page.locator(f'[data-cy="{data_cy}"]').click(force=True)
+    await page.wait_for_timeout(500)
+
+
+async def select_dropdown_option(page: Page, select_name: str, option_label: str) -> None:
+    """Open a SelectField dropdown and pick an option by label."""
+    await page.locator(f'[data-cy="select-{select_name}"]').click(force=True)
+    await page.wait_for_timeout(300)
+    # Try exact data-cy match first, fall back to partial text match
+    exact = page.locator(f'[data-cy="select-option-{select_name}-{option_label}"]')
+    if exact.count() > 0:
+        await exact.click(force=True)
+    else:
+        await page.get_by_text(option_label, exact=False).first.click(
+            force=True, timeout=5000
+        )
+    await page.wait_for_timeout(500)
+
+
+async def click_data_cy(page: Page, data_cy: str) -> None:
+    """Click an element by data-cy attribute."""
+    await page.locator(f'[data-cy="{data_cy}"]').click(force=True)
+    await page.wait_for_timeout(500)

--- a/frontend-v2/exploratory_tester/actions/parameters.py
+++ b/frontend-v2/exploratory_tester/actions/parameters.py
@@ -1,0 +1,60 @@
+"""Parameter editing actions."""
+
+from __future__ import annotations
+
+from playwright.async_api import Page
+
+from ..snapshot import SimulationModelSnapshot, SnapshotDiff
+from .base import Action, ResultExpectation
+from .navigation import navigate_to_model_subtab
+
+
+class SetParameterAction(Action):
+    """Set a specific parameter (constant variable) to a discrete value.
+
+    Value bucketing: default, default×0.5, default×1.5, lower_bound, upper_bound.
+    """
+
+    CATEGORY = "parameters"
+    RESULT_EXPECTATION = ResultExpectation.SHOULD_CHANGE
+
+    def __init__(self, qname: str, name: str, value: float) -> None:
+        self._qname = qname
+        self._name = name
+        self._value = value
+        self._key = f"set_parameter:{qname}:{value}"
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
+        if not snapshot.has_model:
+            return False
+        param = snapshot.parameters.get(self._qname)
+        if param is None:
+            return False
+        if param.default_value == self._value:
+            return False
+        return True
+
+    async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
+        await navigate_to_model_subtab(page, "Parameters")
+
+        # Locate the parameter row
+        selector = f'[data-cy="parameter-{self._name}-value"] input'
+        field = page.locator(selector)
+        await field.click(force=True)
+        await field.fill(str(self._value))
+        await field.blur()
+
+        # Wait for auto-save debounce
+        await page.wait_for_timeout(800)
+
+    def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
+        d = SnapshotDiff()
+        old_val = None
+        if self._qname in before.parameters:
+            old_val = before.parameters[self._qname].default_value
+        d.changed_parameters[self._qname] = (old_val, self._value)
+        return d

--- a/frontend-v2/exploratory_tester/actions/parameters.py
+++ b/frontend-v2/exploratory_tester/actions/parameters.py
@@ -31,6 +31,12 @@ class SetParameterAction(Action):
     def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
         if not snapshot.has_model:
             return False
+        if not snapshot.pk_model_id:
+            return False
+        if not snapshot.has_dosing:
+            return False
+        if snapshot.pd_model_id and not snapshot.pd_mappings:
+            return False
         param = snapshot.parameters.get(self._qname)
         if param is None:
             return False

--- a/frontend-v2/exploratory_tester/actions/project.py
+++ b/frontend-v2/exploratory_tester/actions/project.py
@@ -7,7 +7,7 @@ from playwright.async_api import Page
 
 from ..snapshot import SimulationModelSnapshot, SnapshotDiff
 from .base import Action, ResultExpectation
-from .navigation import navigate_to_page
+from .navigation import navigate_to_page, select_dropdown_option
 
 
 class CreateProjectAction(Action):
@@ -47,7 +47,9 @@ class CreateProjectAction(Action):
                     return 'clicked';
                 }}
                 const text = {json.dumps(self._compound_type)};
-                const opts = document.querySelectorAll('[data-cy^="create-project-option"]');
+                const opts = document.querySelectorAll(
+                    '[data-cy^="create-project-option"]'
+                );
                 for (const o of opts) {{
                     if (o.textContent && o.textContent.includes(text)) {{
                         o.click();
@@ -64,7 +66,9 @@ class CreateProjectAction(Action):
         # Select the newly created project (click the first project radio)
         await page.evaluate(
             """() => {
-                const radios = document.querySelectorAll('[data-cy^="project-"] [type="radio"]');
+                const radios = document.querySelectorAll(
+                    '[data-cy^="project-"] [type="radio"]'
+                );
                 if (radios.length > 0) {
                     radios[0].click();
                     return 'selected';

--- a/frontend-v2/exploratory_tester/actions/project.py
+++ b/frontend-v2/exploratory_tester/actions/project.py
@@ -1,0 +1,113 @@
+"""Project-level actions: create project, set species."""
+
+from __future__ import annotations
+
+import json
+from playwright.async_api import Page
+
+from ..snapshot import SimulationModelSnapshot, SnapshotDiff
+from .base import Action, ResultExpectation
+from .navigation import navigate_to_page
+
+
+class CreateProjectAction(Action):
+    CATEGORY = "project"
+    RESULT_EXPECTATION = ResultExpectation.IRRELEVANT
+
+    def __init__(self, compound_type: str = "Small Molecule") -> None:
+        self._compound_type = compound_type
+        self._key = f"create_project:{compound_type.replace(' ', '')}"
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
+        return not snapshot.has_project
+
+    async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
+        await navigate_to_page(page, "Projects")
+        await page.wait_for_timeout(500)
+
+        # JS click to bypass MUI visibility issues
+        await page.evaluate(
+            """() => {
+                const btn = document.querySelector('[data-cy="create-project"]');
+                if (btn) btn.click();
+            }"""
+        )
+        await page.wait_for_timeout(800)
+
+        option_selector = f'[data-cy="create-project-option-{self._compound_type}"]'
+        await page.evaluate(
+            f"""(sel) => {{
+                const opt = document.querySelector(sel);
+                if (opt) {{
+                    opt.click();
+                    return 'clicked';
+                }}
+                const text = {json.dumps(self._compound_type)};
+                const opts = document.querySelectorAll('[data-cy^="create-project-option"]');
+                for (const o of opts) {{
+                    if (o.textContent && o.textContent.includes(text)) {{
+                        o.click();
+                        return 'clicked-fallback';
+                    }}
+                }}
+                return 'no-option';
+            }}""",
+            option_selector,
+        )
+        # Wait for project creation API call and list refresh
+        await page.wait_for_timeout(2000)
+
+        # Select the newly created project (click the first project radio)
+        await page.evaluate(
+            """() => {
+                const radios = document.querySelectorAll('[data-cy^="project-"] [type="radio"]');
+                if (radios.length > 0) {
+                    radios[0].click();
+                    return 'selected';
+                }
+                const projects = document.querySelectorAll('[data-cy^="project-"]');
+                if (projects.length > 0) {
+                    projects[0].click();
+                    return 'clicked-project-card';
+                }
+                return 'no-project-found';
+            }"""
+        )
+        await page.wait_for_timeout(1000)
+
+    def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
+        d = SnapshotDiff()
+        d.changed_fields["has_project"] = (False, True)
+        return d
+
+
+class SetSpeciesAction(Action):
+    CATEGORY = "project"
+    RESULT_EXPECTATION = ResultExpectation.SHOULD_CHANGE
+
+    SPECIES_LABELS = {"H": "Human", "R": "Rat", "M": "Mouse", "N": "Monkey"}
+
+    def __init__(self, species: str) -> None:
+        self._species = species
+        self._label = self.SPECIES_LABELS.get(species, species)
+        self._key = f"set_species:{species}"
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
+        return snapshot.has_project and snapshot.species != self._species
+
+    async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
+        await navigate_to_page(page, "Projects")
+        await select_dropdown_option(page, "project.species", self._label)
+
+    def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
+        d = SnapshotDiff()
+        d.changed_fields["species"] = (before.species, self._species)
+        return d

--- a/frontend-v2/exploratory_tester/actions/project.py
+++ b/frontend-v2/exploratory_tester/actions/project.py
@@ -7,7 +7,11 @@ from playwright.async_api import Page
 
 from ..snapshot import SimulationModelSnapshot, SnapshotDiff
 from .base import Action, ResultExpectation
-from .navigation import navigate_to_page, select_dropdown_option
+from .navigation import (
+    navigate_to_page,
+    navigate_to_model_subtab,
+    select_dropdown_option,
+)
 
 
 class CreateProjectAction(Action):
@@ -108,7 +112,7 @@ class SetSpeciesAction(Action):
         return snapshot.has_project and snapshot.species != self._species
 
     async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
-        await navigate_to_page(page, "Projects")
+        await navigate_to_model_subtab(page, "PK/PD Model")
         await select_dropdown_option(page, "project.species", self._label)
 
     def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:

--- a/frontend-v2/exploratory_tester/actions/project.py
+++ b/frontend-v2/exploratory_tester/actions/project.py
@@ -90,6 +90,12 @@ class CreateProjectAction(Action):
     def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
         d = SnapshotDiff()
         d.changed_fields["has_project"] = (False, True)
+        d.changed_fields["model_id"] = ("may_change", "may_change")
+        d.changed_fields["species"] = ("may_change", "may_change")
+        d.changed_fields["pk_effect_model_id"] = ("may_change", "may_change")
+        d.changed_fields["has_model"] = ("may_change", "may_change")
+        d.changed_fields["has_simulation"] = ("may_change", "may_change")
+        d.changed_fields["parameters"] = ("may_change", "may_change")
         return d
 
 
@@ -97,7 +103,7 @@ class SetSpeciesAction(Action):
     CATEGORY = "project"
     RESULT_EXPECTATION = ResultExpectation.SHOULD_CHANGE
 
-    SPECIES_LABELS = {"H": "Human", "R": "Rat", "M": "Mouse", "N": "Monkey"}
+    SPECIES_LABELS = {"H": "Human", "R": "Rat", "M": "Mouse", "K": "Monkey"}
 
     def __init__(self, species: str) -> None:
         self._species = species
@@ -109,13 +115,19 @@ class SetSpeciesAction(Action):
         return self._key
 
     def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
-        return snapshot.has_project and snapshot.species != self._species
+        return (
+            snapshot.has_project
+            and snapshot.has_model
+            and bool(snapshot.pk_model_id)
+            and snapshot.species != self._species
+        )
 
     async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
         await navigate_to_model_subtab(page, "PK/PD Model")
-        await select_dropdown_option(page, "project.species", self._label)
+        await select_dropdown_option(page, "species", self._label)
 
     def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
         d = SnapshotDiff()
-        d.changed_fields["species"] = (before.species, self._species)
+        d.changed_fields["species"] = ("may_change", "may_change")
+        d.changed_fields["parameters"] = ("may_change", "may_change")
         return d

--- a/frontend-v2/exploratory_tester/actions/registry.py
+++ b/frontend-v2/exploratory_tester/actions/registry.py
@@ -140,29 +140,109 @@ def generate_all_actions(snapshot: SimulationModelSnapshot) -> list[Action]:
 # Sub-model action generators
 # ---------------------------------------------------------------------------
 
-# Known PK model names from the backend
-# (from storybook mock data and existing cypress tests)
+# Known model names from the backend API's `name` field.
+# These match the option labels in the PK/PD Model tab dropdowns.
+# Both naming conventions are included (legacy snake_case + v3 descriptive).
+
 KNOWN_PK_MODELS = [
-    "one_compartment_preclinical",
-    "one_compartment_clinical",
-    "two_compartment_preclinical",
-    "two_compartment_clinical",
-    "three_compartment_preclinical",
-    "three_compartment_clinical",
+    # --- Classic disposition ---
+    "1-compartmental model",
+    "2-compartmental model",
+    "3-compartmental model",
+    "3-compartment catenary model",
+    # --- Full TMDD ---
+    "1-compartmental full TMDD model (1 binding site)",
+    "1-compartmental full TMDD model (1 binding site) - constant target",
+    "1-compartmental full TMDD model (1 binding site) "
+    "- constant target concentration",
+    "1-compartmental full TMDD model (1 binding site) - soluble target",
+    "1-compartmental full TMDD model (1 binding site) "
+    "- soluble target (catch and release)",
+    "1-compartmental full TMDD model (2 binding sites)",
+    "1-compartmental full TMDD model (2 binding sites) - constant target",
+    "1-compartmental full TMDD model (2 binding sites) - soluble target",
+    "2-compartmental full TMDD model (1 binding site)",
+    "2-compartmental full TMDD model (1 binding site) - constant target",
+    "2-compartmental full TMDD model (1 binding site) - soluble target",
+    "2-compartmental full TMDD model (1 binding site) "
+    "- soluble target (catch and release)",
+    "2-compartmental full TMDD model (2 binding sites)",
+    "2-compartmental full TMDD model (2 binding sites) - constant target",
+    "2-compartmental full TMDD model (2 binding sites) - soluble target",
+    # --- QSS TMDD ---
+    "1-compartmental QSS TMDD model (1 binding site)",
+    "1-compartmental QSS TMDD model (1 binding site) - constant target",
+    "1-compartmental QSS TMDD model (1 binding site) - soluble target",
+    "1-compartmental QSS TMDD model (1 binding site) "
+    "- soluble target (catch and release)",
+    "2-compartmental QSS TMDD model (1 binding site)",
+    "2-compartmental QSS TMDD model (1 binding site) - constant target",
+    "2-compartmental QSS TMDD model (1 binding site) - soluble target",
+    "2-compartmental QSS TMDD model (1 binding site) "
+    "- soluble target (catch and release)",
+    # --- Bispecific TMDD ---
+    "1-compartmental bispecific TMDD model",
+    "1-compartmental bispecific TMDD model - soluble targets",
+    "2-compartmental bispecific TMDD model",
+    "2-compartmental bispecific TMDD model - soluble targets",
+    # --- Michaelis-Menten TMDD ---
+    "1-compartmental extended Michaelis-Menten TMDD model",
+    "1-compartmental extended Michaelis-Menten TMDD model - constant target",
+    "2-compartmental extended Michaelis-Menten TMDD model",
+    "2-compartmental extended Michaelis-Menten TMDD model - constant target",
 ]
 
 KNOWN_PD_MODELS = [
-    "direct_effect_inhibitory",
-    "direct_effect_stimulatory",
-    "indirect_effects_stimulation_elimination",
-    "indirect_effects_stimulation_production",
-    "indirect_effects_inhibition_elimination",
-    "indirect_effects_inhibition_production",
+    # --- Direct effects ---
+    "Direct effect model (inhibitory)",
+    "Direct effect model (stimulatory)",
+    # --- Indirect effects ---
+    "Indirect effect model (inhibition of elimination)",
+    "Indirect effect model (inhibition of production)",
+    "Indirect effect model (stimulation of elimination)",
+    "Indirect effect model (stimulation of production)",
+    "Indirect effect model with precursor "
+    "(inhibition of precursor elimination)",
+    "Indirect effect model with precursor "
+    "(stimulation of precursor elimination)",
+    # --- Protein degradation ---
+    "Protein degradation model",
+    # --- DDI ---
+    "Competitive inhibition (DDI)",
+    "Time-dependent inhibition (DDI)",
+    "Time-dependent induction (DDI)",
+    "Time-dependent and competitive inhibition (DDI)",
+    # --- Tumour growth ---
+    "Tumor growth model (linear)",
+    "Tumor growth model (exponential)",
+    "Tumor growth model (Gompertz)",
+    "Tumor growth model (Simeoni)",
+    "Tumor growth model (Simeoni-logistic)",
 ]
 
-EFFECT_MODELS = [
-    "effect_compartment_ke0",
-    "effect_compartment_ke0_kp",
+KNOWN_PD2_MODELS = [
+    # --- Tumour growth inhibition ---
+    "TGI cell distribution model (conc prop kill)",
+    "TGI cell distribution model (Emax kill)",
+    "TGI cell distribution model (exp(conc) prop kill)",
+    "TGI signal distribution model (conc prop kill)",
+    "TGI signal distribution model (exp(conc) prop kill)",
+    "TGI signal distribution model (Emax kill)",
+]
+
+KNOWN_EFFECT_MODELS = [
+    "Effect compartment model",
+    "Effect compartment model (ke0 & Kp)",
+    "Effect compartment model (kin & kout)",
+]
+
+KNOWN_PK2_MODELS = [
+    "First order absorption model",
+    "First order absorption model (two absorption sites)",
+    "Transit compartments absorption model",
+    "Ocular PK model",
+    "Ocular PKPD bispecific (two different targets) model",
+    "Ocular PKPD VEGF (dimeric target) model",
 ]
 
 
@@ -173,19 +253,19 @@ def _add_submodel_actions(actions: list[Action]) -> None:
     for pk in KNOWN_PK_MODELS:
         actions.append(SelectSubModelAction("pk_model", pk, pk))
 
-    # PK model2 (extravascular), effect model — require PK first
-    for pk in KNOWN_PK_MODELS + [None]:
-        if pk is None:
+    # PK model2 (extravascular) — requires PK first
+    for pk2 in KNOWN_PK2_MODELS + [None]:
+        if pk2 is None:
             actions.append(SelectSubModelAction(
                 "pk_model2", "none", "None", requires_pk=True
             ))
         else:
             actions.append(SelectSubModelAction(
-                "pk_model2", pk, pk, requires_pk=True
+                "pk_model2", pk2, pk2, requires_pk=True
             ))
 
     # Effect model — requires PK first
-    for em in EFFECT_MODELS:
+    for em in KNOWN_EFFECT_MODELS:
         actions.append(SelectSubModelAction(
             "pk_effect_model", em, em, requires_pk=True
         ))
@@ -197,9 +277,9 @@ def _add_submodel_actions(actions: list[Action]) -> None:
         else:
             actions.append(SelectSubModelAction("pd_model", pd, pd))
 
-    # PD model2
-    for pd in KNOWN_PD_MODELS + [None]:
-        if pd is None:
+    # PD model2 (TGI)
+    for pd2 in KNOWN_PD2_MODELS + [None]:
+        if pd2 is None:
             actions.append(SelectSubModelAction("pd_model2", "none", "None"))
         else:
-            actions.append(SelectSubModelAction("pd_model2", pd, pd))
+            actions.append(SelectSubModelAction("pd_model2", pd2, pd2))

--- a/frontend-v2/exploratory_tester/actions/registry.py
+++ b/frontend-v2/exploratory_tester/actions/registry.py
@@ -1,0 +1,195 @@
+"""Generates the full catalog of exploratory actions based on the current snapshot.
+
+This module inspects the snapshot to produce concrete action instances:
+  - Each parameter → 5 SetParameterActions (default ± 50%, bounds)
+  - Each dose field → 5 SetDoseFieldActions
+  - Each available submodel → SelectSubModelAction
+  - etc.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Sequence
+
+from .base import Action
+from .project import CreateProjectAction, SetSpeciesAction
+from .model_config import (
+    SelectSubModelAction,
+    ToggleModelFlagAction,
+    SetEffectCompartmentsAction,
+    ResetToSpeciesDefaultsAction,
+)
+from .parameters import SetParameterAction
+from .mappings import ToggleDosingAction, TogglePdMappingAction
+from .dosing import SetDoseFieldAction
+from .simulation import (
+    AddPlotAction,
+    RemovePlotAction,
+    AddSliderAction,
+    RemoveSliderAction,
+    SetSliderValueAction,
+    SetTimeMaxAction,
+)
+from ..snapshot import SimulationModelSnapshot
+
+
+def _bucket_values(default: float, lower: float | None, upper: float | None) -> list[float]:
+    """Generate 5 discrete values: default, default*0.5, default*1.5, lower, upper."""
+    values = [default]
+    if default is not None and default != 0:
+        values.append(round(default * 0.5, 6))
+        values.append(round(default * 1.5, 6))
+    if lower is not None:
+        values.append(lower)
+    if upper is not None:
+        values.append(upper)
+    # Deduplicate and keep values in a reasonable range
+    values = [v for v in values if v is not None and math.isfinite(v)]
+    values = sorted(set(round(v, 6) for v in values))
+    # Clamp to 5 max
+    return values[:5]
+
+
+def generate_all_actions(snapshot: SimulationModelSnapshot) -> list[Action]:
+    """Generate every possible action for the given snapshot.
+
+    Does NOT filter by preconditions — that's the explorer's job.
+    Returns the full action catalog.
+    """
+    actions: list[Action] = []
+
+    # --- Project actions ---
+    actions.append(CreateProjectAction("Small Molecule"))
+    actions.append(CreateProjectAction("Large Molecule"))
+    for species in ["H", "R", "M", "N"]:
+        actions.append(SetSpeciesAction(species))
+
+    # --- Model config actions (sub-model selections) ---
+    _add_submodel_actions(actions)
+
+    # --- Model flag actions ---
+    for flag in ["has_lag", "has_anti_drug_antibodies", "has_bioavailability"]:
+        actions.append(ToggleModelFlagAction(flag))
+    for n in range(6):  # 0–5 effect compartments
+        actions.append(SetEffectCompartmentsAction(n))
+
+    actions.append(ResetToSpeciesDefaultsAction())
+
+    # --- Parameter actions (generated from snapshot) ---
+    for qname, param in snapshot.parameters.items():
+        for value in _bucket_values(
+            param.default_value or 0, param.lower_bound, param.upper_bound
+        ):
+            actions.append(SetParameterAction(qname, param.name, value))
+
+    # --- Mapping actions ---
+    for param in snapshot.parameters.values():
+        actions.append(ToggleDosingAction(param.name))
+        actions.append(TogglePdMappingAction(param.name))
+
+    # --- Dose actions ---
+    for dose_idx in range(max(1, len(snapshot.doses))):
+        for field_name in SetDoseFieldAction.DOSE_FIELDS:
+            if dose_idx < len(snapshot.doses):
+                current = getattr(snapshot.doses[dose_idx], field_name, 1)
+                defaults = {
+                    "start_time": 0.0,
+                    "amount": 1.0,
+                    "duration": 0.1,
+                    "repeats": 1,
+                    "repeat_interval": 24.0,
+                }
+                base = current or defaults.get(field_name, 1)
+                for value in _bucket_values(float(base), None, None):
+                    if field_name == "repeats":
+                        value = max(1, int(round(value)))
+                    actions.append(SetDoseFieldAction(dose_idx, field_name, value))
+
+    # --- Simulation actions ---
+    for qname, out in snapshot.outputs.items():
+        actions.append(AddPlotAction(out.name))
+
+    for qname, param in snapshot.parameters.items():
+        actions.append(AddSliderAction(param.name))
+
+    for i in range(max(1, len(snapshot.plots))):
+        actions.append(RemovePlotAction(i))
+    for i in range(max(1, len(snapshot.sliders))):
+        actions.append(RemoveSliderAction(i))
+
+    for qname, param in snapshot.parameters.items():
+        for value in _bucket_values(
+            param.default_value or 0, param.lower_bound, param.upper_bound
+        ):
+            actions.append(SetSliderValueAction(param.name, value))
+
+    for tmax in [10.0, 30.0, 48.0, 72.0, 168.0]:
+        actions.append(SetTimeMaxAction(tmax))
+
+    return actions
+
+
+# ---------------------------------------------------------------------------
+# Sub-model action generators
+# ---------------------------------------------------------------------------
+
+# Known PK model names from the backend (from storybook mock data and existing cypress tests)
+KNOWN_PK_MODELS = [
+    "one_compartment_preclinical",
+    "one_compartment_clinical",
+    "two_compartment_preclinical",
+    "two_compartment_clinical",
+    "three_compartment_preclinical",
+    "three_compartment_clinical",
+]
+
+KNOWN_PD_MODELS = [
+    "direct_effect_inhibitory",
+    "direct_effect_stimulatory",
+    "indirect_effects_stimulation_elimination",
+    "indirect_effects_stimulation_production",
+    "indirect_effects_inhibition_elimination",
+    "indirect_effects_inhibition_production",
+]
+
+EFFECT_MODELS = [
+    "effect_compartment_ke0",
+    "effect_compartment_ke0_kp",
+]
+
+
+def _add_submodel_actions(actions: list[Action]) -> None:
+    """Add actions for selecting each PK, PD, and effect model."""
+
+    # PK model (central compartment) — no prerequisites
+    for pk in KNOWN_PK_MODELS:
+        actions.append(SelectSubModelAction("pk_model", pk, pk))
+
+    # PK model2 (extravascular), effect model — require PK first
+    for pk in KNOWN_PK_MODELS + [None]:
+        if pk is None:
+            actions.append(SelectSubModelAction("pk_model2", "none", "None",
+                                                 requires_pk=True))
+        else:
+            actions.append(SelectSubModelAction("pk_model2", pk, pk,
+                                                 requires_pk=True))
+
+    # Effect model — requires PK first
+    for em in EFFECT_MODELS:
+        actions.append(SelectSubModelAction("pk_effect_model", em, em,
+                                             requires_pk=True))
+
+    # PD model — no prerequisites (but only interesting after PK)
+    for pd in KNOWN_PD_MODELS + [None]:
+        if pd is None:
+            actions.append(SelectSubModelAction("pd_model", "none", "None"))
+        else:
+            actions.append(SelectSubModelAction("pd_model", pd, pd))
+
+    # PD model2
+    for pd in KNOWN_PD_MODELS + [None]:
+        if pd is None:
+            actions.append(SelectSubModelAction("pd_model2", "none", "None"))
+        else:
+            actions.append(SelectSubModelAction("pd_model2", pd, pd))

--- a/frontend-v2/exploratory_tester/actions/registry.py
+++ b/frontend-v2/exploratory_tester/actions/registry.py
@@ -1,10 +1,9 @@
 """Generates the full catalog of exploratory actions based on the current snapshot.
 
-This module inspects the snapshot to produce concrete action instances:
-  - Each parameter → 5 SetParameterActions (default ± 50%, bounds)
-  - Each dose field → 5 SetDoseFieldActions
-  - Each available submodel → SelectSubModelAction
-  - etc.
+Generates one action per semantic operation type. Actions that need to
+choose from a set of options (model dropdown, dosing variable, PD mapping)
+discover those options at execution time rather than pre-generating
+concrete instances.
 """
 
 from __future__ import annotations
@@ -14,13 +13,13 @@ import math
 from .base import Action
 from .project import CreateProjectAction, SetSpeciesAction
 from .model_config import (
-    SelectSubModelAction,
+    PickModelAction,
     ToggleModelFlagAction,
     SetEffectCompartmentsAction,
     ResetToSpeciesDefaultsAction,
 )
 from .parameters import SetParameterAction
-from .mappings import ToggleDosingAction, TogglePdMappingAction
+from .mappings import PickDosingAction, PickPdMappingAction
 from .dosing import SetDoseFieldAction
 from .simulation import (
     AddPlotAction,
@@ -57,22 +56,27 @@ def _bucket_values(
     return values[:5]
 
 
-def generate_all_actions(snapshot: SimulationModelSnapshot) -> list[Action]:
+def generate_all_actions(
+    snapshot: SimulationModelSnapshot,
+) -> list[Action]:
     """Generate every possible action for the given snapshot.
 
     Does NOT filter by preconditions — that's the explorer's job.
-    Returns the full action catalog.
     """
     actions: list[Action] = []
 
     # --- Project actions ---
     actions.append(CreateProjectAction("Small Molecule"))
     actions.append(CreateProjectAction("Large Molecule"))
-    for species in ["H", "R", "M", "N"]:
+    for species in ["H", "R", "M", "K"]:
         actions.append(SetSpeciesAction(species))
 
-    # --- Model config actions (sub-model selections) ---
-    _add_submodel_actions(actions)
+    # --- Model config actions (one per dropdown) ---
+    actions.append(PickModelAction("pk_model"))
+    actions.append(PickModelAction("pk_model2", requires_pk=True))
+    actions.append(PickModelAction("pk_effect_model", requires_pk=True))
+    actions.append(PickModelAction("pd_model", requires_pk=True))
+    actions.append(PickModelAction("pd_model2", requires_pk=True, requires_pd=True))
 
     # --- Model flag actions ---
     for flag in ["has_lag", "has_anti_drug_antibodies", "has_bioavailability"]:
@@ -89,10 +93,9 @@ def generate_all_actions(snapshot: SimulationModelSnapshot) -> list[Action]:
         ):
             actions.append(SetParameterAction(qname, param.name, value))
 
-    # --- Mapping actions ---
-    for param in snapshot.parameters.values():
-        actions.append(ToggleDosingAction(param.name))
-        actions.append(TogglePdMappingAction(param.name))
+    # --- Mapping actions (one per type, discovers options at execution) ---
+    actions.append(PickDosingAction())
+    actions.append(PickPdMappingAction())
 
     # --- Dose actions ---
     for dose_idx in range(max(1, len(snapshot.doses))):
@@ -113,11 +116,8 @@ def generate_all_actions(snapshot: SimulationModelSnapshot) -> list[Action]:
                     actions.append(SetDoseFieldAction(dose_idx, field_name, value))
 
     # --- Simulation actions ---
-    for qname, out in snapshot.outputs.items():
-        actions.append(AddPlotAction(out.name))
-
-    for qname, param in snapshot.parameters.items():
-        actions.append(AddSliderAction(param.name))
+    actions.append(AddPlotAction())
+    actions.append(AddSliderAction())
 
     for i in range(max(1, len(snapshot.plots))):
         actions.append(RemovePlotAction(i))
@@ -134,152 +134,3 @@ def generate_all_actions(snapshot: SimulationModelSnapshot) -> list[Action]:
         actions.append(SetTimeMaxAction(tmax))
 
     return actions
-
-
-# ---------------------------------------------------------------------------
-# Sub-model action generators
-# ---------------------------------------------------------------------------
-
-# Known model names from the backend API's `name` field.
-# These match the option labels in the PK/PD Model tab dropdowns.
-# Both naming conventions are included (legacy snake_case + v3 descriptive).
-
-KNOWN_PK_MODELS = [
-    # --- Classic disposition ---
-    "1-compartmental model",
-    "2-compartmental model",
-    "3-compartmental model",
-    "3-compartment catenary model",
-    # --- Full TMDD ---
-    "1-compartmental full TMDD model (1 binding site)",
-    "1-compartmental full TMDD model (1 binding site) - constant target",
-    "1-compartmental full TMDD model (1 binding site) "
-    "- constant target concentration",
-    "1-compartmental full TMDD model (1 binding site) - soluble target",
-    "1-compartmental full TMDD model (1 binding site) "
-    "- soluble target (catch and release)",
-    "1-compartmental full TMDD model (2 binding sites)",
-    "1-compartmental full TMDD model (2 binding sites) - constant target",
-    "1-compartmental full TMDD model (2 binding sites) - soluble target",
-    "2-compartmental full TMDD model (1 binding site)",
-    "2-compartmental full TMDD model (1 binding site) - constant target",
-    "2-compartmental full TMDD model (1 binding site) - soluble target",
-    "2-compartmental full TMDD model (1 binding site) "
-    "- soluble target (catch and release)",
-    "2-compartmental full TMDD model (2 binding sites)",
-    "2-compartmental full TMDD model (2 binding sites) - constant target",
-    "2-compartmental full TMDD model (2 binding sites) - soluble target",
-    # --- QSS TMDD ---
-    "1-compartmental QSS TMDD model (1 binding site)",
-    "1-compartmental QSS TMDD model (1 binding site) - constant target",
-    "1-compartmental QSS TMDD model (1 binding site) - soluble target",
-    "1-compartmental QSS TMDD model (1 binding site) "
-    "- soluble target (catch and release)",
-    "2-compartmental QSS TMDD model (1 binding site)",
-    "2-compartmental QSS TMDD model (1 binding site) - constant target",
-    "2-compartmental QSS TMDD model (1 binding site) - soluble target",
-    "2-compartmental QSS TMDD model (1 binding site) "
-    "- soluble target (catch and release)",
-    # --- Bispecific TMDD ---
-    "1-compartmental bispecific TMDD model",
-    "1-compartmental bispecific TMDD model - soluble targets",
-    "2-compartmental bispecific TMDD model",
-    "2-compartmental bispecific TMDD model - soluble targets",
-    # --- Michaelis-Menten TMDD ---
-    "1-compartmental extended Michaelis-Menten TMDD model",
-    "1-compartmental extended Michaelis-Menten TMDD model - constant target",
-    "2-compartmental extended Michaelis-Menten TMDD model",
-    "2-compartmental extended Michaelis-Menten TMDD model - constant target",
-]
-
-KNOWN_PD_MODELS = [
-    # --- Direct effects ---
-    "Direct effect model (inhibitory)",
-    "Direct effect model (stimulatory)",
-    # --- Indirect effects ---
-    "Indirect effect model (inhibition of elimination)",
-    "Indirect effect model (inhibition of production)",
-    "Indirect effect model (stimulation of elimination)",
-    "Indirect effect model (stimulation of production)",
-    "Indirect effect model with precursor "
-    "(inhibition of precursor elimination)",
-    "Indirect effect model with precursor "
-    "(stimulation of precursor elimination)",
-    # --- Protein degradation ---
-    "Protein degradation model",
-    # --- DDI ---
-    "Competitive inhibition (DDI)",
-    "Time-dependent inhibition (DDI)",
-    "Time-dependent induction (DDI)",
-    "Time-dependent and competitive inhibition (DDI)",
-    # --- Tumour growth ---
-    "Tumor growth model (linear)",
-    "Tumor growth model (exponential)",
-    "Tumor growth model (Gompertz)",
-    "Tumor growth model (Simeoni)",
-    "Tumor growth model (Simeoni-logistic)",
-]
-
-KNOWN_PD2_MODELS = [
-    # --- Tumour growth inhibition ---
-    "TGI cell distribution model (conc prop kill)",
-    "TGI cell distribution model (Emax kill)",
-    "TGI cell distribution model (exp(conc) prop kill)",
-    "TGI signal distribution model (conc prop kill)",
-    "TGI signal distribution model (exp(conc) prop kill)",
-    "TGI signal distribution model (Emax kill)",
-]
-
-KNOWN_EFFECT_MODELS = [
-    "Effect compartment model",
-    "Effect compartment model (ke0 & Kp)",
-    "Effect compartment model (kin & kout)",
-]
-
-KNOWN_PK2_MODELS = [
-    "First order absorption model",
-    "First order absorption model (two absorption sites)",
-    "Transit compartments absorption model",
-    "Ocular PK model",
-    "Ocular PKPD bispecific (two different targets) model",
-    "Ocular PKPD VEGF (dimeric target) model",
-]
-
-
-def _add_submodel_actions(actions: list[Action]) -> None:
-    """Add actions for selecting each PK, PD, and effect model."""
-
-    # PK model (central compartment) — no prerequisites
-    for pk in KNOWN_PK_MODELS:
-        actions.append(SelectSubModelAction("pk_model", pk, pk))
-
-    # PK model2 (extravascular) — requires PK first
-    for pk2 in KNOWN_PK2_MODELS + [None]:
-        if pk2 is None:
-            actions.append(SelectSubModelAction(
-                "pk_model2", "none", "None", requires_pk=True
-            ))
-        else:
-            actions.append(SelectSubModelAction(
-                "pk_model2", pk2, pk2, requires_pk=True
-            ))
-
-    # Effect model — requires PK first
-    for em in KNOWN_EFFECT_MODELS:
-        actions.append(SelectSubModelAction(
-            "pk_effect_model", em, em, requires_pk=True
-        ))
-
-    # PD model — no prerequisites (but only interesting after PK)
-    for pd in KNOWN_PD_MODELS + [None]:
-        if pd is None:
-            actions.append(SelectSubModelAction("pd_model", "none", "None"))
-        else:
-            actions.append(SelectSubModelAction("pd_model", pd, pd))
-
-    # PD model2 (TGI)
-    for pd2 in KNOWN_PD2_MODELS + [None]:
-        if pd2 is None:
-            actions.append(SelectSubModelAction("pd_model2", "none", "None"))
-        else:
-            actions.append(SelectSubModelAction("pd_model2", pd2, pd2))

--- a/frontend-v2/exploratory_tester/actions/registry.py
+++ b/frontend-v2/exploratory_tester/actions/registry.py
@@ -10,7 +10,6 @@ This module inspects the snapshot to produce concrete action instances:
 from __future__ import annotations
 
 import math
-from typing import Sequence
 
 from .base import Action
 from .project import CreateProjectAction, SetSpeciesAction
@@ -34,12 +33,16 @@ from .simulation import (
 from ..snapshot import SimulationModelSnapshot
 
 
-def _bucket_values(default: float, lower: float | None, upper: float | None) -> list[float]:
+def _bucket_values(
+    default: float, lower: float | None, upper: float | None
+) -> list[float]:
     """Generate 5 discrete values: default, default*0.5, default*1.5, lower, upper."""
-    values = [default]
-    if default is not None and default != 0:
-        values.append(round(default * 0.5, 6))
-        values.append(round(default * 1.5, 6))
+    values: list[float] = []
+    if default is not None:
+        values.append(default)
+        if default != 0:
+            values.append(round(default * 0.5, 6))
+            values.append(round(default * 1.5, 6))
     if lower is not None:
         values.append(lower)
     if upper is not None:
@@ -47,6 +50,9 @@ def _bucket_values(default: float, lower: float | None, upper: float | None) -> 
     # Deduplicate and keep values in a reasonable range
     values = [v for v in values if v is not None and math.isfinite(v)]
     values = sorted(set(round(v, 6) for v in values))
+    # Fallback: ensure at least one value
+    if not values:
+        values = [0.0]
     # Clamp to 5 max
     return values[:5]
 
@@ -134,7 +140,8 @@ def generate_all_actions(snapshot: SimulationModelSnapshot) -> list[Action]:
 # Sub-model action generators
 # ---------------------------------------------------------------------------
 
-# Known PK model names from the backend (from storybook mock data and existing cypress tests)
+# Known PK model names from the backend
+# (from storybook mock data and existing cypress tests)
 KNOWN_PK_MODELS = [
     "one_compartment_preclinical",
     "one_compartment_clinical",
@@ -169,16 +176,19 @@ def _add_submodel_actions(actions: list[Action]) -> None:
     # PK model2 (extravascular), effect model — require PK first
     for pk in KNOWN_PK_MODELS + [None]:
         if pk is None:
-            actions.append(SelectSubModelAction("pk_model2", "none", "None",
-                                                 requires_pk=True))
+            actions.append(SelectSubModelAction(
+                "pk_model2", "none", "None", requires_pk=True
+            ))
         else:
-            actions.append(SelectSubModelAction("pk_model2", pk, pk,
-                                                 requires_pk=True))
+            actions.append(SelectSubModelAction(
+                "pk_model2", pk, pk, requires_pk=True
+            ))
 
     # Effect model — requires PK first
     for em in EFFECT_MODELS:
-        actions.append(SelectSubModelAction("pk_effect_model", em, em,
-                                             requires_pk=True))
+        actions.append(SelectSubModelAction(
+            "pk_effect_model", em, em, requires_pk=True
+        ))
 
     # PD model — no prerequisites (but only interesting after PK)
     for pd in KNOWN_PD_MODELS + [None]:

--- a/frontend-v2/exploratory_tester/actions/simulation.py
+++ b/frontend-v2/exploratory_tester/actions/simulation.py
@@ -1,0 +1,231 @@
+"""Simulation page actions: plots, sliders."""
+
+from __future__ import annotations
+
+from playwright.async_api import Page
+
+from ..snapshot import SimulationModelSnapshot, SnapshotDiff
+from .base import Action, ResultExpectation
+from .navigation import navigate_to_page
+
+
+class AddPlotAction(Action):
+    """Add a simulation plot for a given output variable."""
+
+    CATEGORY = "simulation"
+    RESULT_EXPECTATION = ResultExpectation.SHOULD_NOT_CHANGE
+
+    def __init__(self, variable_name: str) -> None:
+        self._var_name = variable_name
+        self._key = f"add_plot:{variable_name}"
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
+        return snapshot.has_model and snapshot.has_simulation
+
+    async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
+        await navigate_to_page(page, "Simulations")
+        await page.locator('[data-cy="add-plot"]').click(force=True)
+        await page.wait_for_timeout(400)
+        await page.locator(f'[data-cy^="add-plot-option-{self._var_name}"]').click(
+            force=True
+        )
+        await page.wait_for_timeout(500)
+
+    def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
+        d = SnapshotDiff()
+        d.added_plots = 1
+        return d
+
+
+class RemovePlotAction(Action):
+    """Remove a simulation plot at the given index."""
+
+    CATEGORY = "simulation"
+    RESULT_EXPECTATION = ResultExpectation.SHOULD_NOT_CHANGE
+
+    def __init__(self, index: int) -> None:
+        self._index = index
+        self._key = f"remove_plot:{index}"
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
+        return self._index < len(snapshot.plots)
+
+    async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
+        await navigate_to_page(page, "Simulations")
+
+        delete_btn = page.locator(
+            f'[data-cy="plot-{self._index}"] [data-cy="delete-plot"], '
+            f'[data-cy^="delete-plot-{self._index}"]'
+        ).first
+        # Fallback: find the MUI delete icon button in the plot card
+        if not await delete_btn.is_visible():
+            delete_btn = page.locator('[data-cy^="delete-plot"]').nth(self._index)
+        else:
+            delete_btn = page.locator('[data-cy^="delete-plot"]').nth(self._index)
+
+        await delete_btn.click(force=True)
+        await page.wait_for_timeout(500)
+
+    def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
+        d = SnapshotDiff()
+        d.removed_plots = 1
+        return d
+
+
+class AddSliderAction(Action):
+    """Add a parameter slider to the simulation page."""
+
+    CATEGORY = "simulation"
+    RESULT_EXPECTATION = ResultExpectation.SHOULD_NOT_CHANGE
+
+    def __init__(self, variable_name: str) -> None:
+        self._var_name = variable_name
+        self._key = f"add_slider:{variable_name}"
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
+        return snapshot.has_model and snapshot.has_simulation
+
+    async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
+        await navigate_to_page(page, "Simulations")
+
+        add_btn = page.locator('[data-cy="add-parameter-slider"]')
+        await add_btn.click(force=True)
+        await page.wait_for_timeout(400)
+
+        option = page.locator(
+            f'[data-cy="add-parameter-slider-option-{self._var_name}"]'
+        )
+        await option.click(force=True)
+        await page.wait_for_timeout(500)
+
+    def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
+        d = SnapshotDiff()
+        d.added_sliders = 1
+        return d
+
+
+class RemoveSliderAction(Action):
+    """Remove a slider at the given index."""
+
+    CATEGORY = "simulation"
+    RESULT_EXPECTATION = ResultExpectation.SHOULD_NOT_CHANGE
+
+    def __init__(self, index: int) -> None:
+        self._index = index
+        self._key = f"remove_slider:{index}"
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
+        return self._index < len(snapshot.sliders)
+
+    async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
+        await navigate_to_page(page, "Simulations")
+        remove_btn = page.locator('[data-cy^="delete-slider"]').nth(self._index)
+        await remove_btn.click(force=True)
+        await page.wait_for_timeout(500)
+
+    def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
+        d = SnapshotDiff()
+        d.removed_sliders = 1
+        return d
+
+
+class SetSliderValueAction(Action):
+    """Move a slider to a new value.
+
+    This operates on the MUI Slider component on the Simulations page.
+    """
+
+    CATEGORY = "simulation"
+    RESULT_EXPECTATION = ResultExpectation.SHOULD_CHANGE
+
+    def __init__(self, variable_name: str, value: float) -> None:
+        self._var_name = variable_name
+        self._value = value
+        self._key = f"set_slider:{variable_name}:{value}"
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
+        if not snapshot.sliders:
+            return False
+        for sl in snapshot.sliders:
+            for param in snapshot.parameters.values():
+                if param.id == sl.variable_id and param.name == self._var_name:
+                    return sl.current_value != self._value
+        return False
+
+    async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
+        await navigate_to_page(page, "Simulations")
+
+        slider = page.locator(f'[data-cy="parameter-slider-{self._var_name}"] input')
+        await slider.click(force=True)
+        await slider.fill(str(self._value))
+        await slider.blur()
+
+        await page.wait_for_timeout(500)
+
+    def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
+        d = SnapshotDiff()
+        for i, sl in enumerate(before.sliders):
+            # Find the right slider and record its value change
+            param = None
+            for p in before.parameters.values():
+                if p.id == sl.variable_id:
+                    param = p
+                    break
+            if param and param.name == self._var_name:
+                d.changed_fields[f"sliders[{i}].current_value"] = (
+                    sl.current_value,
+                    self._value,
+                )
+                break
+        return d
+
+
+class SetTimeMaxAction(Action):
+    """Set the simulation time max."""
+
+    CATEGORY = "simulation"
+    RESULT_EXPECTATION = ResultExpectation.SHOULD_CHANGE
+
+    def __init__(self, value: float) -> None:
+        self._value = value
+        self._key = f"set_time_max:{value}"
+
+    @property
+    def key(self) -> str:
+        return self._key
+
+    def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
+        return snapshot.has_simulation and snapshot.time_max != self._value
+
+    async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
+        await navigate_to_page(page, "Simulations")
+        field = page.locator('[data-cy="time-max"] input')
+        await field.click(force=True)
+        await field.fill(str(self._value))
+        await field.blur()
+        await page.wait_for_timeout(800)
+
+    def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
+        d = SnapshotDiff()
+        d.changed_fields["time_max"] = (before.time_max, self._value)
+        return d

--- a/frontend-v2/exploratory_tester/actions/simulation.py
+++ b/frontend-v2/exploratory_tester/actions/simulation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import random
+
 from playwright.async_api import Page
 
 from ..snapshot import SimulationModelSnapshot, SnapshotDiff
@@ -10,29 +12,33 @@ from .navigation import navigate_to_page
 
 
 class AddPlotAction(Action):
-    """Add a simulation plot for a given output variable."""
+    """Add a simulation plot. Discovers available outputs at execution time."""
 
     CATEGORY = "simulation"
     RESULT_EXPECTATION = ResultExpectation.SHOULD_NOT_CHANGE
 
-    def __init__(self, variable_name: str) -> None:
-        self._var_name = variable_name
-        self._key = f"add_plot:{variable_name}"
+    _key = "add_plot"
 
     @property
     def key(self) -> str:
         return self._key
 
     def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
-        return snapshot.has_model and snapshot.has_simulation
+        return (
+            snapshot.has_model
+            and snapshot.has_simulation
+            and snapshot.has_dosing
+        )
 
     async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
         await navigate_to_page(page, "Simulations")
         await page.locator('[data-cy="add-plot"]').click(force=True)
         await page.wait_for_timeout(400)
-        await page.locator(f'[data-cy^="add-plot-option-{self._var_name}"]').click(
-            force=True
-        )
+        opts = page.locator('[data-cy^="add-plot-option-"]')
+        count = await opts.count()
+        if count == 0:
+            return
+        await opts.nth(random.randint(0, count - 1)).click(force=True)
         await page.wait_for_timeout(500)
 
     def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
@@ -81,21 +87,23 @@ class RemovePlotAction(Action):
 
 
 class AddSliderAction(Action):
-    """Add a parameter slider to the simulation page."""
+    """Add a parameter slider. Discovers available parameters at execution."""
 
     CATEGORY = "simulation"
     RESULT_EXPECTATION = ResultExpectation.SHOULD_NOT_CHANGE
 
-    def __init__(self, variable_name: str) -> None:
-        self._var_name = variable_name
-        self._key = f"add_slider:{variable_name}"
+    _key = "add_slider"
 
     @property
     def key(self) -> str:
         return self._key
 
     def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
-        return snapshot.has_model and snapshot.has_simulation
+        return (
+            snapshot.has_model
+            and snapshot.has_simulation
+            and snapshot.has_dosing
+        )
 
     async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
         await navigate_to_page(page, "Simulations")
@@ -104,10 +112,11 @@ class AddSliderAction(Action):
         await add_btn.click(force=True)
         await page.wait_for_timeout(400)
 
-        option = page.locator(
-            f'[data-cy="add-parameter-slider-option-{self._var_name}"]'
-        )
-        await option.click(force=True)
+        opts = page.locator('[data-cy^="add-parameter-slider-option-"]')
+        count = await opts.count()
+        if count == 0:
+            return
+        await opts.nth(random.randint(0, count - 1)).click(force=True)
         await page.wait_for_timeout(500)
 
     def expected_diff(self, before: SimulationModelSnapshot) -> SnapshotDiff:
@@ -166,6 +175,8 @@ class SetSliderValueAction(Action):
     def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
         if not snapshot.sliders:
             return False
+        if not snapshot.has_dosing:
+            return False
         for sl in snapshot.sliders:
             for param in snapshot.parameters.values():
                 if param.id == sl.variable_id and param.name == self._var_name:
@@ -215,11 +226,16 @@ class SetTimeMaxAction(Action):
         return self._key
 
     def preconditions(self, snapshot: SimulationModelSnapshot) -> bool:
-        return snapshot.has_simulation and snapshot.time_max != self._value
+        return (
+            snapshot.has_simulation
+            and snapshot.has_dosing
+            and snapshot.time_max != self._value
+        )
 
     async def execute(self, page: Page, snapshot: SimulationModelSnapshot) -> None:
         await navigate_to_page(page, "Simulations")
-        field = page.locator('[data-cy="time-max"] input')
+        field = page.locator('[data-cy="float-field-time_max"] input')
+        await field.wait_for(state="visible", timeout=10000)
         await field.click(force=True)
         await field.fill(str(self._value))
         await field.blur()

--- a/frontend-v2/exploratory_tester/checker.py
+++ b/frontend-v2/exploratory_tester/checker.py
@@ -1,0 +1,269 @@
+"""State verification — checks that actions produce expected changes and nothing else."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from .snapshot import (
+    SimulationModelSnapshot,
+    SnapshotDiff,
+    diff_snapshots,
+)
+from .actions.base import Action, ResultExpectation
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CheckResult:
+    """Outcome of checking an action's effect on state."""
+
+    action_key: str
+    step: int
+
+    before: SimulationModelSnapshot
+    after: SimulationModelSnapshot
+    expected: SnapshotDiff
+    actual: SnapshotDiff
+
+    unexpected_changes: list[str] = field(default_factory=list)
+    missing_changes: list[str] = field(default_factory=list)
+    ui_errors: list[str] = field(default_factory=list)
+
+    sim_result_ok: bool = True
+    sim_result_detail: str = ""
+
+    passed: bool = True
+
+    @property
+    def summary(self) -> str:
+        if self.passed:
+            return f"[PASS] {self.action_key}"
+        lines = [f"[FAIL] {self.action_key}"]
+        for c in self.unexpected_changes:
+            lines.append(f"  UNEXPECTED: {c}")
+        for c in self.missing_changes:
+            lines.append(f"  MISSING: {c}")
+        for e in self.ui_errors:
+            lines.append(f"  ERROR: {e}")
+        if not self.sim_result_ok:
+            lines.append(f"  SIM_RESULT: {self.sim_result_detail}")
+        return "\n".join(lines)
+
+
+async def check_action(
+    page,
+    action: Action,
+    before: SimulationModelSnapshot,
+    after: SimulationModelSnapshot,
+    step: int,
+) -> CheckResult:
+    """Compare snapshots and check simulation results.
+
+    Returns a CheckResult with pass/fail status and details.
+    """
+    expected = action.expected_diff(before)
+    actual = diff_snapshots(before, after)
+
+    result = CheckResult(
+        action_key=action.key,
+        step=step,
+        before=before,
+        after=after,
+        expected=expected,
+        actual=actual,
+    )
+
+    # --- UI errors ---
+    await _check_ui_errors(page, result)
+
+    # --- Unexpected changes (things that changed but shouldn't have) ---
+    _find_unexpected_changes(expected, actual, result)
+
+    # --- Missing changes (things that should have changed but didn't) ---
+    _find_missing_changes(expected, actual, result)
+
+    # --- Simulation result validation ---
+    await _check_sim_results(action, before, after, result)
+
+    # --- Final pass/fail ---
+    result.passed = (
+        len(result.unexpected_changes) == 0
+        and len(result.missing_changes) == 0
+        and len(result.ui_errors) == 0
+        and result.sim_result_ok
+    )
+
+    return result
+
+
+async def _check_ui_errors(page, result: CheckResult) -> None:
+    """Check for visible error snackbars."""
+    try:
+        errors = page.locator(".MuiAlert-standardError")
+        count = await errors.count()
+        for i in range(count):
+            text = await errors.nth(i).text_content()
+            if text:
+                result.ui_errors.append(f"Snackbar error: {text.strip()}")
+    except Exception:
+        pass
+
+
+def _find_unexpected_changes(
+    expected: SnapshotDiff, actual: SnapshotDiff, result: CheckResult
+) -> None:
+    """Identify changes in `actual` that were not expected."""
+
+    # Scalar fields
+    for field_name, (old, new) in actual.changed_fields.items():
+        if field_name not in expected.changed_fields:
+            result.unexpected_changes.append(
+                f"field '{field_name}' changed: {old} -> {new}"
+            )
+
+    # Parameters
+    expected_param_changes = set(expected.changed_parameters.keys())
+    expected_param_adds = set(expected.added_parameters)
+    expected_param_rems = set(expected.removed_parameters)
+
+    for qname, (old, new) in actual.changed_parameters.items():
+        if qname not in expected_param_changes:
+            result.unexpected_changes.append(
+                f"parameter '{qname}' changed: {old} -> {new}"
+            )
+
+    for qname in actual.added_parameters:
+        if qname not in expected_param_adds:
+            result.unexpected_changes.append(f"parameter '{qname}' was added")
+
+    for qname in actual.removed_parameters:
+        if qname not in expected_param_rems:
+            result.unexpected_changes.append(f"parameter '{qname}' was removed")
+
+    # Plots, sliders, doses
+    if actual.added_plots > expected.added_plots:
+        result.unexpected_changes.append(
+            f"added {actual.added_plots - expected.added_plots} unexpected plots"
+        )
+    if actual.removed_plots > expected.removed_plots:
+        result.unexpected_changes.append(
+            f"removed {actual.removed_plots - expected.removed_plots} unexpected plots"
+        )
+    if actual.added_sliders > expected.added_sliders:
+        result.unexpected_changes.append(
+            f"added {actual.added_sliders - expected.added_sliders} unexpected sliders"
+        )
+    if actual.removed_sliders > expected.removed_sliders:
+        result.unexpected_changes.append(
+            f"removed {actual.removed_sliders - expected.removed_sliders} unexpected sliders"
+        )
+    if actual.added_doses > expected.added_doses:
+        result.unexpected_changes.append(
+            f"added {actual.added_doses - expected.added_doses} unexpected doses"
+        )
+    if actual.removed_doses > expected.removed_doses:
+        result.unexpected_changes.append(
+            f"removed {actual.removed_doses - expected.removed_doses} unexpected doses"
+        )
+
+    if actual.mappings_changed and not expected.mappings_changed:
+        result.unexpected_changes.append("mappings changed unexpectedly")
+    if actual.derived_variables_changed and not expected.derived_variables_changed:
+        result.unexpected_changes.append("derived variables changed unexpectedly")
+
+    if actual.sim_results_changed and not expected.sim_results_changed:
+        result.unexpected_changes.append("simulation results changed unexpectedly")
+    if actual.sim_results_added and not expected.sim_results_added:
+        result.unexpected_changes.append("simulation results appeared unexpectedly")
+    if actual.sim_results_removed and not expected.sim_results_removed:
+        result.unexpected_changes.append("simulation results disappeared unexpectedly")
+
+
+def _find_missing_changes(
+    expected: SnapshotDiff, actual: SnapshotDiff, result: CheckResult
+) -> None:
+    """Identify changes that were expected but didn't occur."""
+    # Skip missing-checks for coarse-grained expected diffs
+    # (e.g., "parameters: reset_to_defaults" is too broad to verify exactly)
+    coarse_keys = {"parameters", "reset_to_defaults"}
+    for field_name in expected.changed_fields:
+        if field_name in coarse_keys:
+            continue
+        if field_name not in actual.changed_fields:
+            result.missing_changes.append(
+                f"expected field '{field_name}' to change, but it didn't"
+            )
+
+    for qname in expected.added_parameters:
+        if qname not in actual.added_parameters:
+            result.missing_changes.append(
+                f"expected parameter '{qname}' to be added, but it wasn't"
+            )
+
+    for qname in expected.removed_parameters:
+        if qname not in actual.removed_parameters:
+            result.missing_changes.append(
+                f"expected parameter '{qname}' to be removed, but it wasn't"
+            )
+
+
+async def _check_sim_results(
+    action: Action,
+    before: SimulationModelSnapshot,
+    after: SimulationModelSnapshot,
+    result: CheckResult,
+) -> None:
+    """Validate simulation results against the action's expectation."""
+    if action.RESULT_EXPECTATION == ResultExpectation.IRRELEVANT:
+        return
+
+    if action.RESULT_EXPECTATION == ResultExpectation.SHOULD_NOT_CHANGE:
+        if before.sim_results is None and after.sim_results is None:
+            return
+        if before.sim_results is None:
+            result.sim_result_detail = (
+                "Expected no change but results appeared"
+            )
+            result.sim_result_ok = False
+            return
+        if after.sim_results is None:
+            # Acceptable — results may not be available yet
+            return
+
+        # Strict equality check
+        if not _results_identical(before.sim_results, after.sim_results):
+            result.sim_result_detail = (
+                "Simulation results changed when they should not have"
+            )
+            result.sim_result_ok = False
+
+    elif action.RESULT_EXPECTATION == ResultExpectation.SHOULD_CHANGE:
+        if before.sim_results is None or after.sim_results is None:
+            return  # Can't compare
+
+        if _results_identical(before.sim_results, after.sim_results):
+            result.sim_result_detail = (
+                "Simulation results did NOT change when they should have"
+            )
+            result.sim_result_ok = False
+
+
+def _results_identical(a, b) -> bool:
+    """Check if two SimulationResults are byte-identical."""
+    from .snapshot import SimulationResults
+
+    if a.time != b.time:
+        return False
+    if sorted(a.outputs.keys()) != sorted(b.outputs.keys()):
+        return False
+    for key in a.outputs:
+        if key not in b.outputs:
+            return False
+        if len(a.outputs[key]) != len(b.outputs[key]):
+            return False
+        for va, vb in zip(a.outputs[key], b.outputs[key]):
+            if va != vb:
+                return False
+    return True

--- a/frontend-v2/exploratory_tester/checker.py
+++ b/frontend-v2/exploratory_tester/checker.py
@@ -117,31 +117,46 @@ def _find_unexpected_changes(
 ) -> None:
     """Identify changes in `actual` that were not expected."""
 
-    # Scalar fields
+    coarse_keys = {"parameters", "dosed", "reset_to_defaults"}
+    # When expected declares coarse-grained parameter changes, skip
+    # fine-grained param add/remove/change checks (new model = new params).
+    params_coarse = "parameters" in expected.changed_fields
+
+    # Scalar fields — skip coarse keys and sentinel values
     for field_name, (old, new) in actual.changed_fields.items():
+        if field_name in coarse_keys:
+            continue
+        expected_val = expected.changed_fields.get(field_name)
+        if expected_val is not None and expected_val[0] in ("may_change", "changed"):
+            continue
         if field_name not in expected.changed_fields:
             result.unexpected_changes.append(
                 f"field '{field_name}' changed: {old} -> {new}"
             )
 
-    # Parameters
-    expected_param_changes = set(expected.changed_parameters.keys())
-    expected_param_adds = set(expected.added_parameters)
-    expected_param_rems = set(expected.removed_parameters)
+    # Parameters — skip entirely when coarse
+    if not params_coarse:
+        expected_param_changes = set(expected.changed_parameters.keys())
+        expected_param_adds = set(expected.added_parameters)
+        expected_param_rems = set(expected.removed_parameters)
 
-    for qname, (old, new) in actual.changed_parameters.items():
-        if qname not in expected_param_changes:
-            result.unexpected_changes.append(
-                f"parameter '{qname}' changed: {old} -> {new}"
-            )
+        for qname, (old, new) in actual.changed_parameters.items():
+            if qname not in expected_param_changes:
+                result.unexpected_changes.append(
+                    f"parameter '{qname}' changed: {old} -> {new}"
+                )
 
-    for qname in actual.added_parameters:
-        if qname not in expected_param_adds:
-            result.unexpected_changes.append(f"parameter '{qname}' was added")
+        for qname in actual.added_parameters:
+            if qname not in expected_param_adds:
+                result.unexpected_changes.append(
+                    f"parameter '{qname}' was added"
+                )
 
-    for qname in actual.removed_parameters:
-        if qname not in expected_param_rems:
-            result.unexpected_changes.append(f"parameter '{qname}' was removed")
+        for qname in actual.removed_parameters:
+            if qname not in expected_param_rems:
+                result.unexpected_changes.append(
+                    f"parameter '{qname}' was removed"
+                )
 
     # Plots, sliders, doses
     if actual.added_plots > expected.added_plots:
@@ -162,7 +177,7 @@ def _find_unexpected_changes(
         result.unexpected_changes.append(
             f"removed {n} unexpected sliders"
         )
-    if actual.added_doses > expected.added_doses:
+    if actual.added_doses > expected.added_doses and expected.added_doses >= 0:
         result.unexpected_changes.append(
             f"added {actual.added_doses - expected.added_doses} unexpected doses"
         )
@@ -188,11 +203,11 @@ def _find_missing_changes(
     expected: SnapshotDiff, actual: SnapshotDiff, result: CheckResult
 ) -> None:
     """Identify changes that were expected but didn't occur."""
-    # Skip missing-checks for coarse-grained expected diffs
-    # (e.g., "parameters: reset_to_defaults" is too broad to verify exactly)
     coarse_keys = {"parameters", "dosed", "reset_to_defaults"}
-    for field_name in expected.changed_fields:
+    for field_name, (old, new) in expected.changed_fields.items():
         if field_name in coarse_keys:
+            continue
+        if old == "may_change" or old == "changed":
             continue
         if field_name not in actual.changed_fields:
             result.missing_changes.append(

--- a/frontend-v2/exploratory_tester/checker.py
+++ b/frontend-v2/exploratory_tester/checker.py
@@ -1,4 +1,4 @@
-"""State verification — checks that actions produce expected changes and nothing else."""
+"""State verification — checks that actions produce expected diffs."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from .snapshot import (
     SimulationModelSnapshot,
     SnapshotDiff,
+    _sim_results_equal,
     diff_snapshots,
 )
 from .actions.base import Action, ResultExpectation
@@ -152,12 +153,14 @@ def _find_unexpected_changes(
             f"removed {actual.removed_plots - expected.removed_plots} unexpected plots"
         )
     if actual.added_sliders > expected.added_sliders:
+        n = actual.added_sliders - expected.added_sliders
         result.unexpected_changes.append(
-            f"added {actual.added_sliders - expected.added_sliders} unexpected sliders"
+            f"added {n} unexpected sliders"
         )
     if actual.removed_sliders > expected.removed_sliders:
+        n = actual.removed_sliders - expected.removed_sliders
         result.unexpected_changes.append(
-            f"removed {actual.removed_sliders - expected.removed_sliders} unexpected sliders"
+            f"removed {n} unexpected sliders"
         )
     if actual.added_doses > expected.added_doses:
         result.unexpected_changes.append(
@@ -187,7 +190,7 @@ def _find_missing_changes(
     """Identify changes that were expected but didn't occur."""
     # Skip missing-checks for coarse-grained expected diffs
     # (e.g., "parameters: reset_to_defaults" is too broad to verify exactly)
-    coarse_keys = {"parameters", "reset_to_defaults"}
+    coarse_keys = {"parameters", "dosed", "reset_to_defaults"}
     for field_name in expected.changed_fields:
         if field_name in coarse_keys:
             continue
@@ -252,18 +255,4 @@ async def _check_sim_results(
 
 def _results_identical(a, b) -> bool:
     """Check if two SimulationResults are byte-identical."""
-    from .snapshot import SimulationResults
-
-    if a.time != b.time:
-        return False
-    if sorted(a.outputs.keys()) != sorted(b.outputs.keys()):
-        return False
-    for key in a.outputs:
-        if key not in b.outputs:
-            return False
-        if len(a.outputs[key]) != len(b.outputs[key]):
-            return False
-        for va, vb in zip(a.outputs[key], b.outputs[key]):
-            if va != vb:
-                return False
-    return True
+    return _sim_results_equal(a, b)

--- a/frontend-v2/exploratory_tester/conftest.py
+++ b/frontend-v2/exploratory_tester/conftest.py
@@ -13,7 +13,12 @@ import os
 from typing import AsyncIterator
 
 import pytest
-from playwright.async_api import Browser, BrowserContext, Page, async_playwright
+from playwright.async_api import (
+    Browser,
+    BrowserContext,
+    Page,
+    async_playwright,
+)
 
 
 def pytest_addoption(parser):

--- a/frontend-v2/exploratory_tester/conftest.py
+++ b/frontend-v2/exploratory_tester/conftest.py
@@ -1,0 +1,114 @@
+"""Pytest fixtures for the exploratory tester.
+
+Usage:
+    pytest exploratory_tester/ --base-url http://localhost:5173 \\
+        --username demo --password 12345
+
+Or with defaults from environment:
+    PKPD_USERNAME=demo
+    PKPD_PASSWORD=12345
+"""
+
+import os
+from typing import AsyncIterator
+
+import pytest
+from playwright.async_api import Browser, BrowserContext, Page, async_playwright
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--username",
+        default=os.environ.get("PKPD_USERNAME", "fuzzer"),
+        help="Login username",
+    )
+    parser.addoption(
+        "--password",
+        default=os.environ.get("PKPD_PASSWORD", "test1234"),
+        help="Login password",
+    )
+    parser.addoption(
+        "--max-steps",
+        type=int,
+        default=int(os.environ.get("PKPD_MAX_STEPS", "200")),
+        help="Maximum exploration steps per test",
+    )
+
+
+@pytest.fixture(scope="function")
+def credentials(request) -> tuple[str, str]:
+    return (
+        request.config.getoption("--username"),
+        request.config.getoption("--password"),
+    )
+
+
+@pytest.fixture(scope="function")
+def max_steps(request) -> int:
+    return request.config.getoption("--max-steps")
+
+
+@pytest.fixture(scope="function")
+async def browser() -> AsyncIterator[Browser]:
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        yield browser
+        await browser.close()
+
+
+@pytest.fixture(scope="function")
+async def context(browser: Browser) -> AsyncIterator[BrowserContext]:
+    ctx = await browser.new_context(viewport={"width": 1440, "height": 900})
+    yield ctx
+    await ctx.close()
+
+
+@pytest.fixture(scope="function")
+async def page(
+    context: BrowserContext,
+    base_url: str,
+    credentials: tuple[str, str],
+) -> AsyncIterator[Page]:
+    """Return a logged-in Playwright page."""
+    username, password = credentials
+    page = await context.new_page()
+
+    # Clear persisted Redux state from prior sessions
+    await page.goto(base_url, wait_until="domcontentloaded")
+    await page.evaluate("() => { sessionStorage.clear(); localStorage.clear(); }")
+
+    # Navigate fresh — the app renders a login form on / when not authenticated
+    await page.goto(base_url, wait_until="domcontentloaded")
+    await page.wait_for_timeout(1000)
+
+    # Check if the login form is visible (username field present)
+    try:
+        login_visible = await page.locator("input[name='username']").is_visible()
+    except Exception:
+        login_visible = False
+
+    if login_visible:
+        await page.fill("input[name='username']", username)
+        await page.fill("input[name='password']", password)
+        # Submit via the "Login" button (the form button text is "Login")
+        await page.get_by_role("button", name="Login").click()
+
+        # Wait for the login form to disappear (successful login)
+        await page.locator("input[name='username']").wait_for(
+            state="hidden", timeout=15000
+        )
+
+    # Verify the store is available
+    has_store = await page.evaluate("() => !!window.__pkpd_store__")
+    if not has_store:
+        raise RuntimeError(
+            "window.__pkpd_store__ not found. "
+            "Ensure the frontend is running in dev mode "
+            "(import.meta.env.DEV === true)."
+        )
+
+    # Wait for initial API data to load
+    await page.wait_for_timeout(2000)
+
+    yield page
+    await page.close()

--- a/frontend-v2/exploratory_tester/explorer.py
+++ b/frontend-v2/exploratory_tester/explorer.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import logging
 import random
-from typing import Sequence
 
 from .actions.base import Action
 from .snapshot import SimulationModelSnapshot
@@ -49,7 +48,7 @@ class CoverageGuidedExplorer:
         if not available:
             return None
 
-        snapshot_hash = str(snapshot.hash)
+        snapshot_hash = snapshot.hash
 
         # Split into unvisited vs visited
         unvisited = [

--- a/frontend-v2/exploratory_tester/explorer.py
+++ b/frontend-v2/exploratory_tester/explorer.py
@@ -1,0 +1,103 @@
+"""Coverage-guided action selector.
+
+Maintains a set of visited (snapshot_hash, action_key) pairs and
+prioritizes actions that explore new edges in the state graph.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+from typing import Sequence
+
+from .actions.base import Action
+from .snapshot import SimulationModelSnapshot
+from .actions.registry import generate_all_actions
+
+logger = logging.getLogger(__name__)
+
+
+class CoverageGuidedExplorer:
+    """Selects next actions based on coverage of (state, action) edges.
+
+    - All available actions (preconditions pass) are candidates.
+    - Unvisited (state, action) edges are preferred.
+    - Ties broken randomly.
+    """
+
+    def __init__(self, seed: int | None = None) -> None:
+        self._visited: set[tuple[str, str]] = set()  # (snapshot_hash, action_key)
+        self._state_graph: dict[str, dict[str, str]] = (
+            {}
+        )  # hash -> {action_key -> next_hash}
+        self._rng = random.Random(seed)
+
+    @property
+    def visited_count(self) -> int:
+        return len(self._visited)
+
+    def pick_next(
+        self, snapshot: SimulationModelSnapshot
+    ) -> Action | None:
+        """Select the next action to explore.
+
+        Returns None if no actions are available (nothing viable).
+        """
+        all_actions = generate_all_actions(snapshot)
+        available = [a for a in all_actions if a.preconditions(snapshot)]
+
+        if not available:
+            return None
+
+        snapshot_hash = str(snapshot.hash)
+
+        # Split into unvisited vs visited
+        unvisited = [
+            a
+            for a in available
+            if (snapshot_hash, a.key) not in self._visited
+        ]
+        visited = [
+            a
+            for a in available
+            if (snapshot_hash, a.key) in self._visited
+        ]
+
+        if unvisited:
+            chosen = self._rng.choice(unvisited)
+            logger.debug(
+                "Picked unvisited action %s (also %d visited, %d unvisited)",
+                chosen.key,
+                len(visited),
+                len(unvisited),
+            )
+        else:
+            logger.debug(
+                "All %d actions visited from this state; picking random",
+                len(available),
+            )
+            chosen = self._rng.choice(available)
+
+        return chosen
+
+    def record(
+        self,
+        before_hash: str,
+        action_key: str,
+        after_hash: str,
+    ) -> None:
+        """Record a state transition."""
+        self._visited.add((str(before_hash), action_key))
+        self._state_graph.setdefault(str(before_hash), {})[action_key] = str(
+            after_hash
+        )
+
+    def coverage_report(self) -> dict:
+        """Return coverage statistics."""
+        unique_states = len(self._state_graph)
+        total_edges = sum(len(edges) for edges in self._state_graph.values())
+        return {
+            "visited_edges": self.visited_count,
+            "unique_states": unique_states,
+            "total_edges_in_graph": total_edges,
+        }

--- a/frontend-v2/exploratory_tester/explorer.py
+++ b/frontend-v2/exploratory_tester/explorer.py
@@ -25,10 +25,8 @@ class CoverageGuidedExplorer:
     """
 
     def __init__(self, seed: int | None = None) -> None:
-        self._visited: set[tuple[str, str]] = set()  # (snapshot_hash, action_key)
-        self._state_graph: dict[str, dict[str, str]] = (
-            {}
-        )  # hash -> {action_key -> next_hash}
+        self._visited: set[tuple[str, str]] = set()
+        self._state_graph: dict[str, dict[str, str]] = {}
         self._rng = random.Random(seed)
 
     @property

--- a/frontend-v2/exploratory_tester/fuzzer.py
+++ b/frontend-v2/exploratory_tester/fuzzer.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, field as dc_field, asdict
 from pathlib import Path
 from typing import Callable
 
@@ -24,8 +24,8 @@ class FuzzerReport:
     total_steps: int = 0
     passed: int = 0
     failed: int = 0
-    findings: list[dict] = field(default_factory=list)
-    coverage: dict = field(default_factory=dict)
+    findings: list[dict] = dc_field(default_factory=list)
+    coverage: dict = dc_field(default_factory=dict)
     elapsed_seconds: float = 0.0
 
     @property
@@ -64,6 +64,10 @@ async def run_fuzzer(
         return report
 
     explorer = CoverageGuidedExplorer()
+
+    # Auto-accept any native confirm/alert dialogs (e.g. "Delete linked
+    # protocols and dosing variables?")
+    page.on("dialog", lambda dialog: dialog.accept())
     logger.info(
         "Starting fuzzer: model=%s, params=%d, plots=%d, sliders=%d, sim=%s",
         snapshot.model_id,
@@ -118,7 +122,8 @@ async def run_fuzzer(
             await page.wait_for_load_state("networkidle", timeout=10000)
         except Exception:
             pass
-        await page.wait_for_timeout(500)
+        # Extra wait for Redux cache invalidation + re-fetch to complete
+        await page.wait_for_timeout(1500)
 
         new_snapshot = await snapshot_from_page(page)
 

--- a/frontend-v2/exploratory_tester/fuzzer.py
+++ b/frontend-v2/exploratory_tester/fuzzer.py
@@ -10,7 +10,7 @@ from typing import Callable
 
 from playwright.async_api import Page
 
-from .snapshot import snapshot_from_page
+from .snapshot import snapshot_from_page, diff_snapshots
 from .explorer import CoverageGuidedExplorer
 from .checker import check_action, CheckResult
 
@@ -84,22 +84,33 @@ async def run_fuzzer(
         try:
             await action.execute(page, snapshot)
         except Exception as exc:
-            logger.error("Execution error at step %d (%s): %s", step, action.key, exc)
+            logger.error(
+                "Execution error at step %d (%s): %s", step, action.key, exc
+            )
+            # Capture partial state changes even on failure
+            try:
+                new_snapshot = await snapshot_from_page(page)
+            except Exception:
+                new_snapshot = snapshot
             result = CheckResult(
                 action_key=action.key,
                 step=step,
                 before=snapshot,
-                after=snapshot,
+                after=new_snapshot,
                 expected=action.expected_diff(snapshot),
-                actual=None,  # type: ignore[arg-type]
+                actual=diff_snapshots(snapshot, new_snapshot),
                 passed=False,
             )
             result.ui_errors.append(f"Execution error: {exc}")
             report.findings.append(_check_result_to_dict(result))
             report.total_steps += 1
             report.failed += 1
+            explorer.record(
+                snapshot.hash, action.key, new_snapshot.hash,
+            )
             if stop_on_first_failure:
                 break
+            snapshot = new_snapshot
             continue
 
         # Wait for network to settle (ignore timeout)
@@ -123,7 +134,7 @@ async def run_fuzzer(
         if on_step:
             on_step(step, result)
 
-        explorer.record(str(snapshot.hash), action.key, str(new_snapshot.hash))
+        explorer.record(snapshot.hash, action.key, new_snapshot.hash)
         snapshot = new_snapshot
 
         if not result.passed and stop_on_first_failure:

--- a/frontend-v2/exploratory_tester/fuzzer.py
+++ b/frontend-v2/exploratory_tester/fuzzer.py
@@ -1,0 +1,164 @@
+"""Main fuzzing loop: explore → execute → check → repeat."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Callable
+
+from playwright.async_api import Page
+
+from .snapshot import snapshot_from_page
+from .explorer import CoverageGuidedExplorer
+from .checker import check_action, CheckResult
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FuzzerReport:
+    """Aggregate results from a fuzzing run."""
+
+    total_steps: int = 0
+    passed: int = 0
+    failed: int = 0
+    findings: list[dict] = field(default_factory=list)
+    coverage: dict = field(default_factory=dict)
+    elapsed_seconds: float = 0.0
+
+    @property
+    def success_rate(self) -> float:
+        if self.total_steps == 0:
+            return 0.0
+        return self.passed / self.total_steps
+
+
+async def run_fuzzer(
+    page: Page,
+    max_steps: int = 200,
+    stop_on_first_failure: bool = False,
+    on_step: Callable[[int, CheckResult | None], None] | None = None,
+) -> FuzzerReport:
+    """Run the exploratory fuzzer.
+
+    Args:
+        page: Logged-in Playwright page.
+        max_steps: Maximum number of exploration steps.
+        stop_on_first_failure: Stop after the first anomaly.
+        on_step: Optional callback invoked after each step, receives
+                 (step_number, check_result_or_none).
+
+    Returns:
+        FuzzerReport with findings and coverage stats.
+    """
+    import time
+
+    start_time = time.time()
+    report = FuzzerReport()
+
+    snapshot = await snapshot_from_page(page)
+    if snapshot._error:
+        logger.error("Initial snapshot failed: %s", snapshot._error)
+        return report
+
+    explorer = CoverageGuidedExplorer()
+    logger.info(
+        "Starting fuzzer: model=%s, params=%d, plots=%d, sliders=%d, sim=%s",
+        snapshot.model_id,
+        len(snapshot.parameters),
+        len(snapshot.plots),
+        len(snapshot.sliders),
+        "yes" if snapshot.sim_results else "no",
+    )
+
+    for step in range(max_steps):
+        action = explorer.pick_next(snapshot)
+        if action is None:
+            logger.info("No available actions at step %d; stopping.", step)
+            break
+
+        logger.info("Step %d: %s", step, action.key)
+
+        try:
+            await action.execute(page, snapshot)
+        except Exception as exc:
+            logger.error("Execution error at step %d (%s): %s", step, action.key, exc)
+            result = CheckResult(
+                action_key=action.key,
+                step=step,
+                before=snapshot,
+                after=snapshot,
+                expected=action.expected_diff(snapshot),
+                actual=None,  # type: ignore[arg-type]
+                passed=False,
+            )
+            result.ui_errors.append(f"Execution error: {exc}")
+            report.findings.append(_check_result_to_dict(result))
+            report.total_steps += 1
+            report.failed += 1
+            if stop_on_first_failure:
+                break
+            continue
+
+        # Wait for network to settle (ignore timeout)
+        try:
+            await page.wait_for_load_state("networkidle", timeout=10000)
+        except Exception:
+            pass
+        await page.wait_for_timeout(500)
+
+        new_snapshot = await snapshot_from_page(page)
+
+        result = await check_action(page, action, snapshot, new_snapshot, step)
+        report.total_steps += 1
+
+        if result.passed:
+            report.passed += 1
+        else:
+            report.failed += 1
+            report.findings.append(_check_result_to_dict(result))
+
+        if on_step:
+            on_step(step, result)
+
+        explorer.record(str(snapshot.hash), action.key, str(new_snapshot.hash))
+        snapshot = new_snapshot
+
+        if not result.passed and stop_on_first_failure:
+            break
+
+    report.elapsed_seconds = time.time() - start_time
+    report.coverage = explorer.coverage_report()
+
+    logger.info(
+        "Fuzzer complete: %d steps, %d passed, %d failed, %.1fs",
+        report.total_steps,
+        report.passed,
+        report.failed,
+        report.elapsed_seconds,
+    )
+    return report
+
+
+def _check_result_to_dict(result: CheckResult) -> dict:
+    """Convert a CheckResult to a JSON-serializable dict."""
+    d = {
+        "step": result.step,
+        "action": result.action_key,
+        "passed": result.passed,
+        "unexpected_changes": result.unexpected_changes,
+        "missing_changes": result.missing_changes,
+        "ui_errors": result.ui_errors,
+        "sim_result_ok": result.sim_result_ok,
+        "sim_result_detail": result.sim_result_detail,
+    }
+    return d
+
+
+def save_report(report: FuzzerReport, path: str | Path) -> None:
+    """Write the fuzzer report as JSON."""
+    data = asdict(report)
+    data["findings"] = report.findings
+    Path(path).write_text(json.dumps(data, indent=2, default=str))

--- a/frontend-v2/exploratory_tester/js_extractors/redux_snapshot.js
+++ b/frontend-v2/exploratory_tester/js_extractors/redux_snapshot.js
@@ -1,0 +1,210 @@
+/**
+ * Injected into the page to extract redux state + DOM slider values.
+ * Returns a JSON object ready for SimulationModelSnapshot parsing.
+ */
+(() => {
+  const store = window.__pkpd_store__;
+  if (!store) return JSON.stringify({ error: "store not exposed" });
+
+  const state = store.getState();
+  const queries = (state.api && state.api.queries) || {};
+  const mutations = (state.api && state.api.mutations) || {};
+
+  // --- helpers ---
+
+  function findQuery(endpointName) {
+    for (const key of Object.keys(queries)) {
+      if (key.startsWith(endpointName + "(")) {
+        const q = queries[key];
+        if (q && q.status === "fulfilled" && q.data) return q.data;
+      }
+    }
+    return null;
+  }
+
+  function findMutation(endpointName) {
+    for (const key of Object.keys(mutations)) {
+      if (key.startsWith(endpointName + "(")) {
+        const m = mutations[key];
+        if (m && m.status === "fulfilled" && m.data) return m.data;
+      }
+    }
+    return null;
+  }
+
+  function findListQuery(endpointName) {
+    for (const key of Object.keys(queries)) {
+      if (key.startsWith(endpointName + "(")) {
+        const q = queries[key];
+        if (q && q.status === "fulfilled" && Array.isArray(q.data)) return q.data;
+      }
+    }
+    return [];
+  }
+
+  // --- Redux main + login slices (needed early for project lookup) ---
+  const mainState = state.main || {};
+  const selectedProject = mainState.selectedProject || null;
+  const loginState = state.login || {};
+  const user = loginState.user || null;
+
+  // --- API cache extraction ---
+  const projectList = findListQuery("projectList") || [];
+  const project = findQuery("projectRetrieve")
+    || projectList.find(p => p.id === selectedProject)
+    || projectList[0]
+    || null;
+  const model = findQuery("combinedModelRetrieve") || (findListQuery("combinedModelList") || [])[0] || null;
+  const variables = findListQuery("variableList");
+  const compound = findQuery("compoundRetrieve");
+  const protocols = findListQuery("protocolList");
+  const doses = (protocols && protocols.length > 0)
+    ? protocols.flatMap((p) => (p.doses || []))
+    : [];
+  const simulations = findListQuery("simulationList") || [];
+  const simulation = simulations.length > 0 ? simulations[0] : null;
+
+  // simulation results from mutation cache
+  const simResult = findMutation("combinedModelSimulateCreate");
+
+  // --- DOM slider values ---
+  const sliderElements = document.querySelectorAll('[data-cy^="parameter-slider-"]');
+  const sliderValues = {};
+  for (const el of sliderElements) {
+    const attr = el.getAttribute("data-cy") || "";
+    const name = attr.replace("parameter-slider-", "");
+    const input = el.querySelector('input[type="range"]') || el.querySelector('input[type="hidden"]');
+    if (input && input.value !== undefined) {
+      sliderValues[name] = parseFloat(input.value);
+    } else if (el.hasAttribute("aria-valuenow")) {
+      sliderValues[name] = parseFloat(el.getAttribute("aria-valuenow"));
+    }
+  }
+
+  // Build result
+  return JSON.stringify({
+    selectedProject,
+    user: user ? { id: user.id, username: user.username } : null,
+    project: project ? pickProjectFields(project) : null,
+    model: model ? pickModelFields(model) : null,
+    variables: Array.isArray(variables) ? variables.map(pickVariableFields) : [],
+    compound: compound ? pickCompoundFields(compound) : null,
+    doses: Array.isArray(doses) ? doses.map(pickDoseFields) : [],
+    simulation: simulation ? pickSimulationFields(simulation) : null,
+    simulationResult: simResult ? pickSimResultFields(simResult) : null,
+    sliderValues,
+    // raw api state for debugging
+    _cacheKeys: { queries: Object.keys(queries), mutations: Object.keys(mutations) },
+  });
+
+  // --- field pickers (minimize payload, avoid cycles) ---
+
+  function pickProjectFields(p) {
+    return { id: p.id, name: p.name, species: p.species, compound: p.compound };
+  }
+
+  function pickModelFields(m) {
+    return {
+      id: m.id,
+      name: m.name,
+      species: m.species,
+      pk_model: m.pk_model,
+      pk_model2: m.pk_model2,
+      pk_effect_model: m.pk_effect_model,
+      pd_model: m.pd_model,
+      pd_model2: m.pd_model2,
+      time_max: m.time_max,
+      number_of_effect_compartments: m.number_of_effect_compartments,
+      has_lag: m.has_lag,
+      has_anti_drug_antibodies: m.has_anti_drug_antibodies,
+      has_bioavailability: m.has_bioavailability,
+      mappings: Array.isArray(m.mappings)
+        ? m.mappings.map((mm) => ({
+            pk_variable: mm.pk_variable,
+            pd_variable: mm.pd_variable,
+          }))
+        : [],
+      derived_variables: Array.isArray(m.derived_variables)
+        ? m.derived_variables.map((dv) => ({
+            type: dv.type,
+            pk_variable: dv.pk_variable,
+          }))
+        : [],
+    };
+  }
+
+  function pickVariableFields(v) {
+    return {
+      id: v.id,
+      name: v.name,
+      qname: v.qname,
+      constant: v.constant,
+      state: v.state,
+      default_value: v.default_value,
+      lower_bound: v.lower_bound,
+      upper_bound: v.upper_bound,
+      unit_symbol: v.unit_symbol || null,
+    };
+  }
+
+  function pickCompoundFields(c) {
+    return {
+      id: c.id,
+      name: c.name,
+      molecular_mass: c.molecular_mass,
+      fraction_unbound_plasma: c.fraction_unbound_plasma,
+      blood_to_plasma_ratio: c.blood_to_plasma_ratio,
+      target_concentration: c.target_concentration,
+      dissociation_constant: c.dissociation_constant,
+    };
+  }
+
+  function pickDoseFields(d) {
+    return {
+      start_time: d.start_time,
+      amount: d.amount,
+      duration: d.duration,
+      repeats: d.repeats,
+      repeat_interval: d.repeat_interval,
+    };
+  }
+
+  function pickSimulationFields(s) {
+    return {
+      id: s.id,
+      name: s.name,
+      nrows: s.nrows,
+      ncols: s.ncols,
+      time_max: s.time_max,
+      time_max_unit: s.time_max_unit,
+      plots: Array.isArray(s.plots)
+        ? s.plots.map((p) => ({
+            id: p.id,
+            index: p.index,
+            x_unit: p.x_unit,
+            y_unit: p.y_unit,
+            y_unit2: p.y_unit2,
+            y_scale: p.y_scale,
+            min: p.min,
+            max: p.max,
+            min2: p.min2,
+            max2: p.max2,
+            y_axes: Array.isArray(p.y_axes)
+              ? p.y_axes.map((ax) => ({ variable: ax.variable }))
+              : [],
+          }))
+        : [],
+      sliders: Array.isArray(s.sliders)
+        ? s.sliders.map((sl) => ({ id: sl.id, variable: sl.variable }))
+        : [],
+    };
+  }
+
+  function pickSimResultFields(r) {
+    return {
+      time: r.time,
+      outputs: r.outputs,
+      group: r.group,
+    };
+  }
+})();

--- a/frontend-v2/exploratory_tester/pytest.ini
+++ b/frontend-v2/exploratory_tester/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+testpaths = .
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
+base_url = http://localhost:5173
+addopts = -v
+log_cli = true
+log_cli_level = INFO

--- a/frontend-v2/exploratory_tester/requirements.txt
+++ b/frontend-v2/exploratory_tester/requirements.txt
@@ -1,0 +1,4 @@
+playwright>=1.50.0
+pytest>=8.0.0,<9.0.0
+pytest-playwright>=0.5.0
+pytest-asyncio>=0.25.0,<1.0.0

--- a/frontend-v2/exploratory_tester/snapshot.py
+++ b/frontend-v2/exploratory_tester/snapshot.py
@@ -6,6 +6,7 @@ these frozen dataclasses for diffing and verification.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass, field, fields
 from pathlib import Path
@@ -160,9 +161,15 @@ class SimulationModelSnapshot:
     _error: str | None = None
 
     @property
-    def hash(self) -> int:
-        """Content-based hash for state graph deduplication."""
-        return hash(json.dumps(_snapshot_to_dict(self), sort_keys=True, default=str))
+    def hash(self) -> str:
+        """Content-based hash for state graph deduplication.
+
+        Uses SHA-256 for stable hashing across Python processes.
+        """
+        raw = json.dumps(
+            _snapshot_to_dict(self), sort_keys=True, default=str
+        )
+        return hashlib.sha256(raw.encode()).hexdigest()
 
 
 # ---------------------------------------------------------------------------
@@ -267,7 +274,11 @@ def diff_snapshots(
     return d
 
 
-def _diff_scalar_fields(d: SnapshotDiff, before: SimulationModelSnapshot, after: SimulationModelSnapshot) -> None:
+def _diff_scalar_fields(
+    d: SnapshotDiff,
+    before: SimulationModelSnapshot,
+    after: SimulationModelSnapshot,
+) -> None:
     scalar_field_names = [
         "model_id", "species",
         "pk_model_id", "pk_model_id2", "pk_effect_model_id",
@@ -296,7 +307,11 @@ def _diff_scalar_fields(d: SnapshotDiff, before: SimulationModelSnapshot, after:
                     d.changed_fields[f"compound.{fc.name}"] = (ov, nv)
 
 
-def _diff_parameters(d: SnapshotDiff, before: SimulationModelSnapshot, after: SimulationModelSnapshot) -> None:
+def _diff_parameters(
+    d: SnapshotDiff,
+    before: SimulationModelSnapshot,
+    after: SimulationModelSnapshot,
+) -> None:
     old_keys = set(before.parameters.keys())
     new_keys = set(after.parameters.keys())
 
@@ -310,7 +325,11 @@ def _diff_parameters(d: SnapshotDiff, before: SimulationModelSnapshot, after: Si
             d.changed_parameters[qname] = (old_p.default_value, new_p.default_value)
 
 
-def _diff_lists(d: SnapshotDiff, before: SimulationModelSnapshot, after: SimulationModelSnapshot) -> None:
+def _diff_lists(
+    d: SnapshotDiff,
+    before: SimulationModelSnapshot,
+    after: SimulationModelSnapshot,
+) -> None:
     # Plots
     d.added_plots = max(0, len(after.plots) - len(before.plots))
     d.removed_plots = max(0, len(before.plots) - len(after.plots))
@@ -347,7 +366,11 @@ def _diff_lists(d: SnapshotDiff, before: SimulationModelSnapshot, after: Simulat
         d.derived_variables_changed = True
 
 
-def _diff_sim_results(d: SnapshotDiff, before: SimulationModelSnapshot, after: SimulationModelSnapshot) -> None:
+def _diff_sim_results(
+    d: SnapshotDiff,
+    before: SimulationModelSnapshot,
+    after: SimulationModelSnapshot,
+) -> None:
     if before.sim_results is None and after.sim_results is not None:
         d.sim_results_added = True
     elif before.sim_results is not None and after.sim_results is None:
@@ -378,15 +401,22 @@ def _sim_results_equal(a: SimulationResults, b: SimulationResults) -> bool:
 # Extraction from Playwright page
 # ---------------------------------------------------------------------------
 
-# Load the JS extractor
+# JS extractor path — loaded lazily on first call
 _JS_EXTRACTOR_PATH = Path(__file__).parent / "js_extractors" / "redux_snapshot.js"
-with open(_JS_EXTRACTOR_PATH, "r") as _f:
-    _EXTRACTOR_JS = _f.read()
+_EXTRACTOR_JS: str | None = None
+
+
+def _get_extractor_js() -> str:
+    """Return the injected JS extractor, loading from disk on first call."""
+    global _EXTRACTOR_JS
+    if _EXTRACTOR_JS is None:
+        _EXTRACTOR_JS = _JS_EXTRACTOR_PATH.read_text()
+    return _EXTRACTOR_JS
 
 
 async def snapshot_from_page(page: Page) -> SimulationModelSnapshot:
     """Inject JS into the page, extract Redux + DOM state, parse into snapshot."""
-    raw = await page.evaluate(_EXTRACTOR_JS)
+    raw = await page.evaluate(_get_extractor_js())
     data = json.loads(raw) if isinstance(raw, str) else raw
 
     if isinstance(data, dict) and data.get("error"):
@@ -437,7 +467,10 @@ def _parse_snapshot_data(data: dict) -> SimulationModelSnapshot:
 
     # --- Derived variables ---
     derived_variables = [
-        DerivedVarState(type=dv.get("type", ""), pk_variable_id=dv.get("pk_variable", 0))
+        DerivedVarState(
+            type=dv.get("type", ""),
+            pk_variable_id=dv.get("pk_variable", 0),
+        )
         for dv in (model.get("derived_variables") or [])
     ]
 
@@ -564,9 +597,17 @@ def _snapshot_to_dict(s: SimulationModelSnapshot) -> dict:
         "outputs": sorted(s.outputs.keys()),
         "pd_mappings": sorted(s.pd_mappings),
         "doses": sorted(
-            [(d.start_time, d.amount, d.duration, d.repeats, d.repeat_interval) for d in s.doses]
+            [
+                (
+                    d.start_time, d.amount, d.duration,
+                    d.repeats, d.repeat_interval,
+                )
+                for d in s.doses
+            ]
         ),
-        "derived_variables": sorted((dv.type, dv.pk_variable_id) for dv in s.derived_variables),
+        "derived_variables": sorted(
+            (dv.type, dv.pk_variable_id) for dv in s.derived_variables
+        ),
         "compound": s.compound.id if s.compound else None,
         "plots": sorted((p.id, p.y_variables) for p in s.plots),
         "sliders": sorted((sl.variable_id, sl.current_value) for sl in s.sliders),

--- a/frontend-v2/exploratory_tester/snapshot.py
+++ b/frontend-v2/exploratory_tester/snapshot.py
@@ -161,6 +161,11 @@ class SimulationModelSnapshot:
     _error: str | None = None
 
     @property
+    def has_dosing(self) -> bool:
+        """True if dosing compartments are configured (any dose defined)."""
+        return bool(self.dosed_compartments or self.doses)
+
+    @property
     def hash(self) -> str:
         """Content-based hash for state graph deduplication.
 
@@ -286,6 +291,7 @@ def _diff_scalar_fields(
         "number_of_effect_compartments",
         "has_lag", "has_anti_drug_antibodies", "has_bioavailability",
         "time_max", "has_project", "has_model", "has_simulation",
+        "has_dosing",
     ]
     for name in scalar_field_names:
         old_val = getattr(before, name)
@@ -615,4 +621,5 @@ def _snapshot_to_dict(s: SimulationModelSnapshot) -> dict:
         "has_project": s.has_project,
         "has_model": s.has_model,
         "has_simulation": s.has_simulation,
+        "has_dosing": s.has_dosing,
     }

--- a/frontend-v2/exploratory_tester/snapshot.py
+++ b/frontend-v2/exploratory_tester/snapshot.py
@@ -1,0 +1,577 @@
+"""Domain-level snapshot of the PK/PD simulation model state.
+
+Extracted from the RTK Query cache via an injected JS script, then parsed into
+these frozen dataclasses for diffing and verification.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, fields
+from pathlib import Path
+from typing import Any
+
+from playwright.async_api import Page
+
+
+# ---------------------------------------------------------------------------
+# Leaf dataclasses
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class ParameterState:
+    """A constant model variable (parameter)."""
+    id: int
+    name: str
+    qname: str
+    default_value: float | None
+    lower_bound: float | None
+    upper_bound: float | None
+    unit_symbol: str | None
+
+
+@dataclass(frozen=True)
+class DerivedVarState:
+    """A derived variable (secondary parameter like AUC, RO, FUP)."""
+    type: str
+    pk_variable_id: int
+
+
+@dataclass(frozen=True)
+class DoseState:
+    """A single dose definition."""
+    start_time: float
+    amount: float
+    duration: float
+    repeats: float
+    repeat_interval: float
+
+
+@dataclass(frozen=True)
+class PlotYAxis:
+    """One Y axis on a simulation plot."""
+    variable_id: int
+
+
+@dataclass(frozen=True)
+class PlotState:
+    """A simulation plot definition."""
+    id: int
+    index: int
+    y_variables: list[int]  # variable IDs referenced on Y axes
+    x_unit: int | None
+    y_unit: int | None
+    y_unit2: int | None
+    y_scale: str | None
+    min: float | None
+    max: float | None
+    min2: float | None
+    max2: float | None
+
+
+@dataclass(frozen=True)
+class SliderState:
+    """A parameter slider on the simulation page."""
+    id: int
+    variable_id: int
+    current_value: float | None  # from DOM (may differ from default_value)
+
+
+@dataclass(frozen=True)
+class CompoundState:
+    """Drug compound properties."""
+    id: int
+    name: str
+    molecular_mass: float | None
+    fraction_unbound_plasma: float | None
+    blood_to_plasma_ratio: float | None
+    target_concentration: float | None
+    dissociation_constant: float | None
+
+
+@dataclass(frozen=True)
+class SimulationResults:
+    """Time-series output from the /simulate endpoint."""
+    time: list[float]
+    outputs: dict[str, list[float]]
+    group: int | None
+
+
+# ---------------------------------------------------------------------------
+# Top-level snapshot
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class SimulationModelSnapshot:
+    """Complete domain state of the simulation model."""
+
+    # --- Model identity ---
+    model_id: int | None = None
+
+    # --- Species ---
+    species: str = "H"
+
+    # --- Sub-models (by ID — resolved to names when available) ---
+    pk_model_id: int | None = None
+    pk_model_id2: int | None = None       # extravascular
+    pk_effect_model_id: int | None = None
+    pd_model_id: int | None = None
+    pd_model_id2: int | None = None
+
+    # --- Remaining flags ---
+    number_of_effect_compartments: int = 0
+    has_lag: bool = False
+    has_anti_drug_antibodies: bool = False
+    has_bioavailability: bool = False
+
+    # --- Time ---
+    time_max: float = 30.0
+
+    # --- Parameters (constant=true variables, keyed by qname) ---
+    parameters: dict[str, ParameterState] = field(default_factory=dict)
+
+    # --- Outputs (non-constant variables available for plotting, keyed by qname) ---
+    outputs: dict[str, ParameterState] = field(default_factory=dict)
+
+    # --- PK→PD mappings: [(pk_variable_id, pd_variable_id), ...] ---
+    pd_mappings: list[tuple[int, int]] = field(default_factory=list)
+
+    # --- Dosing ---
+    dosed_compartments: list[str] = field(default_factory=list)
+    doses: list[DoseState] = field(default_factory=list)
+
+    # --- Derived variables ---
+    derived_variables: list[DerivedVarState] = field(default_factory=list)
+
+    # --- Compound ---
+    compound: CompoundState | None = None
+
+    # --- Simulation configuration ---
+    plots: list[PlotState] = field(default_factory=list)
+    sliders: list[SliderState] = field(default_factory=list)
+
+    # --- Simulation results ---
+    sim_results: SimulationResults | None = None
+
+    # --- Extra metadata ---
+    has_project: bool = False
+    has_model: bool = False
+    has_simulation: bool = False
+    _error: str | None = None
+
+    @property
+    def hash(self) -> int:
+        """Content-based hash for state graph deduplication."""
+        return hash(json.dumps(_snapshot_to_dict(self), sort_keys=True, default=str))
+
+
+# ---------------------------------------------------------------------------
+# Diffing
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SnapshotDiff:
+    """Describes what changed between two snapshots."""
+
+    added_parameters: list[str] = field(default_factory=list)
+    removed_parameters: list[str] = field(default_factory=list)
+    changed_parameters: dict[str, tuple[Any, Any]] = field(
+        default_factory=dict
+    )  # qname -> (old, new)
+
+    changed_fields: dict[str, tuple[Any, Any]] = field(
+        default_factory=dict
+    )  # path -> (old, new)
+
+    added_plots: int = 0
+    removed_plots: int = 0
+    added_sliders: int = 0
+    removed_sliders: int = 0
+    added_doses: int = 0
+    removed_doses: int = 0
+    mappings_changed: bool = False
+    derived_variables_changed: bool = False
+
+    sim_results_changed: bool = False
+    sim_results_added: bool = False
+    sim_results_removed: bool = False
+
+    @property
+    def is_empty(self) -> bool:
+        return not any(
+            [
+                self.added_parameters,
+                self.removed_parameters,
+                self.changed_parameters,
+                self.changed_fields,
+                self.added_plots,
+                self.removed_plots,
+                self.added_sliders,
+                self.removed_sliders,
+                self.added_doses,
+                self.removed_doses,
+                self.mappings_changed,
+                self.derived_variables_changed,
+                self.sim_results_changed,
+                self.sim_results_added,
+                self.sim_results_removed,
+            ]
+        )
+
+    def __str__(self) -> str:
+        parts: list[str] = []
+        for field_name, (old, new) in self.changed_fields.items():
+            parts.append(f"  {field_name}: {old} -> {new}")
+        for qname, (old, new) in self.changed_parameters.items():
+            parts.append(f"  param[{qname}].default_value: {old} -> {new}")
+        for qname in self.added_parameters:
+            parts.append(f"  + param[{qname}]")
+        for qname in self.removed_parameters:
+            parts.append(f"  - param[{qname}]")
+        if self.added_plots:
+            parts.append(f"  +{self.added_plots} plot(s)")
+        if self.removed_plots:
+            parts.append(f"  -{self.removed_plots} plot(s)")
+        if self.added_sliders:
+            parts.append(f"  +{self.added_sliders} slider(s)")
+        if self.removed_sliders:
+            parts.append(f"  -{self.removed_sliders} slider(s)")
+        if self.added_doses:
+            parts.append(f"  +{self.added_doses} dose(s)")
+        if self.removed_doses:
+            parts.append(f"  -{self.removed_doses} dose(s)")
+        if self.mappings_changed:
+            parts.append("  mappings changed")
+        if self.derived_variables_changed:
+            parts.append("  derived variables changed")
+        if self.sim_results_changed:
+            parts.append("  simulation results changed")
+        if self.sim_results_added:
+            parts.append("  + simulation results")
+        if self.sim_results_removed:
+            parts.append("  - simulation results")
+        return "\n".join(parts) if parts else "  (no changes)"
+
+
+def diff_snapshots(
+    before: SimulationModelSnapshot, after: SimulationModelSnapshot
+) -> SnapshotDiff:
+    """Compute a structured diff between two snapshots."""
+    d = SnapshotDiff()
+
+    _diff_scalar_fields(d, before, after)
+    _diff_parameters(d, before, after)
+    _diff_lists(d, before, after)
+    _diff_sim_results(d, before, after)
+
+    return d
+
+
+def _diff_scalar_fields(d: SnapshotDiff, before: SimulationModelSnapshot, after: SimulationModelSnapshot) -> None:
+    scalar_field_names = [
+        "model_id", "species",
+        "pk_model_id", "pk_model_id2", "pk_effect_model_id",
+        "pd_model_id", "pd_model_id2",
+        "number_of_effect_compartments",
+        "has_lag", "has_anti_drug_antibodies", "has_bioavailability",
+        "time_max", "has_project", "has_model", "has_simulation",
+    ]
+    for name in scalar_field_names:
+        old_val = getattr(before, name)
+        new_val = getattr(after, name)
+        if old_val != new_val:
+            d.changed_fields[name] = (old_val, new_val)
+
+    # Compound
+    if before.compound != after.compound:
+        if before.compound is None:
+            d.changed_fields["compound"] = (None, f"{after.compound}")
+        elif after.compound is None:
+            d.changed_fields["compound"] = (f"{before.compound}", None)
+        else:
+            for fc in fields(CompoundState):
+                ov = getattr(before.compound, fc.name)
+                nv = getattr(after.compound, fc.name)
+                if ov != nv:
+                    d.changed_fields[f"compound.{fc.name}"] = (ov, nv)
+
+
+def _diff_parameters(d: SnapshotDiff, before: SimulationModelSnapshot, after: SimulationModelSnapshot) -> None:
+    old_keys = set(before.parameters.keys())
+    new_keys = set(after.parameters.keys())
+
+    d.added_parameters = list(new_keys - old_keys)
+    d.removed_parameters = list(old_keys - new_keys)
+
+    for qname in old_keys & new_keys:
+        old_p = before.parameters[qname]
+        new_p = after.parameters[qname]
+        if old_p.default_value != new_p.default_value:
+            d.changed_parameters[qname] = (old_p.default_value, new_p.default_value)
+
+
+def _diff_lists(d: SnapshotDiff, before: SimulationModelSnapshot, after: SimulationModelSnapshot) -> None:
+    # Plots
+    d.added_plots = max(0, len(after.plots) - len(before.plots))
+    d.removed_plots = max(0, len(before.plots) - len(after.plots))
+    if len(after.plots) == len(before.plots):
+        for i, (bp, ap) in enumerate(zip(before.plots, after.plots)):
+            if bp != ap:
+                d.changed_fields[f"plots[{i}]"] = ("changed", "changed")
+
+    # Sliders
+    d.added_sliders = max(0, len(after.sliders) - len(before.sliders))
+    d.removed_sliders = max(0, len(before.sliders) - len(after.sliders))
+    if len(after.sliders) == len(before.sliders):
+        for i, (bs, as_) in enumerate(zip(before.sliders, after.sliders)):
+            if bs.current_value != as_.current_value:
+                d.changed_fields[f"sliders[{i}].current_value"] = (
+                    bs.current_value,
+                    as_.current_value,
+                )
+
+    # Doses
+    d.added_doses = max(0, len(after.doses) - len(before.doses))
+    d.removed_doses = max(0, len(before.doses) - len(after.doses))
+    if len(after.doses) == len(before.doses):
+        for i, (bd, ad) in enumerate(zip(before.doses, after.doses)):
+            if bd != ad:
+                d.changed_fields[f"doses[{i}]"] = ("changed", "changed")
+
+    # Mappings
+    if sorted(before.pd_mappings) != sorted(after.pd_mappings):
+        d.mappings_changed = True
+
+    # Derived variables
+    if sorted(before.derived_variables) != sorted(after.derived_variables):
+        d.derived_variables_changed = True
+
+
+def _diff_sim_results(d: SnapshotDiff, before: SimulationModelSnapshot, after: SimulationModelSnapshot) -> None:
+    if before.sim_results is None and after.sim_results is not None:
+        d.sim_results_added = True
+    elif before.sim_results is not None and after.sim_results is None:
+        d.sim_results_removed = True
+    elif before.sim_results is not None and after.sim_results is not None:
+        if not _sim_results_equal(before.sim_results, after.sim_results):
+            d.sim_results_changed = True
+
+
+def _sim_results_equal(a: SimulationResults, b: SimulationResults) -> bool:
+    """Check if two simulation results are numerically equal."""
+    if a.time != b.time:
+        return False
+    if sorted(a.outputs.keys()) != sorted(b.outputs.keys()):
+        return False
+    for key in a.outputs:
+        if key not in b.outputs:
+            return False
+        if len(a.outputs[key]) != len(b.outputs[key]):
+            return False
+        for va, vb in zip(a.outputs[key], b.outputs[key]):
+            if va != vb:  # strict float equality — these come from JSON
+                return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Extraction from Playwright page
+# ---------------------------------------------------------------------------
+
+# Load the JS extractor
+_JS_EXTRACTOR_PATH = Path(__file__).parent / "js_extractors" / "redux_snapshot.js"
+with open(_JS_EXTRACTOR_PATH, "r") as _f:
+    _EXTRACTOR_JS = _f.read()
+
+
+async def snapshot_from_page(page: Page) -> SimulationModelSnapshot:
+    """Inject JS into the page, extract Redux + DOM state, parse into snapshot."""
+    raw = await page.evaluate(_EXTRACTOR_JS)
+    data = json.loads(raw) if isinstance(raw, str) else raw
+
+    if isinstance(data, dict) and data.get("error"):
+        return SimulationModelSnapshot(_error=data["error"])
+
+    return _parse_snapshot_data(data)
+
+
+def _resolve_model_ids(model: dict | None, variables: list[dict]) -> dict[int, str]:
+    """Build a mapping from variable id -> variable name (for slider lookups)."""
+    result: dict[int, str] = {}
+    for v in variables:
+        vid = v.get("id")
+        if vid is not None:
+            result[vid] = v.get("name", str(vid))
+    return result
+
+
+def _parse_snapshot_data(data: dict) -> SimulationModelSnapshot:
+    model = data.get("model") or {}
+    variables = data.get("variables") or []
+    compound = data.get("compound") or {}
+    project = data.get("project") or {}
+    simulation = data.get("simulation") or {}
+    sim_result = data.get("simulationResult") or {}
+    doses_raw = data.get("doses") or []
+    slider_values = data.get("sliderValues") or {}
+    var_id_to_name = _resolve_model_ids(model, variables)
+
+    # --- Parameters (constant) and Outputs (non-constant) ---
+    parameters: dict[str, ParameterState] = {}
+    outputs: dict[str, ParameterState] = {}
+    for v in variables:
+        qname = v.get("qname", str(v.get("id")))
+        ps = ParameterState(
+            id=v.get("id", 0),
+            name=v.get("name", ""),
+            qname=qname,
+            default_value=v.get("default_value"),
+            lower_bound=v.get("lower_bound"),
+            upper_bound=v.get("upper_bound"),
+            unit_symbol=v.get("unit_symbol"),
+        )
+        if v.get("constant"):
+            parameters[qname] = ps
+        else:
+            outputs[qname] = ps
+
+    # --- Derived variables ---
+    derived_variables = [
+        DerivedVarState(type=dv.get("type", ""), pk_variable_id=dv.get("pk_variable", 0))
+        for dv in (model.get("derived_variables") or [])
+    ]
+
+    # --- PK→PD mappings ---
+    pd_mappings: list[tuple[int, int]] = [
+        (m.get("pk_variable", 0), m.get("pd_variable", 0))
+        for m in (model.get("mappings") or [])
+    ]
+
+    # --- Doses ---
+    doses = [
+        DoseState(
+            start_time=d.get("start_time", 0),
+            amount=d.get("amount", 0),
+            duration=d.get("duration", 0),
+            repeats=d.get("repeats", 1),
+            repeat_interval=d.get("repeat_interval", 24),
+        )
+        for d in doses_raw
+    ]
+
+    # --- Compound ---
+    compound_state = None
+    if compound:
+        compound_state = CompoundState(
+            id=compound.get("id", 0),
+            name=compound.get("name", ""),
+            molecular_mass=compound.get("molecular_mass"),
+            fraction_unbound_plasma=compound.get("fraction_unbound_plasma"),
+            blood_to_plasma_ratio=compound.get("blood_to_plasma_ratio"),
+            target_concentration=compound.get("target_concentration"),
+            dissociation_constant=compound.get("dissociation_constant"),
+        )
+
+    # --- Simulation plots ---
+    plots: list[PlotState] = []
+    for p in simulation.get("plots") or []:
+        plots.append(
+            PlotState(
+                id=p.get("id", 0),
+                index=p.get("index", 0),
+                y_variables=[ax.get("variable", 0) for ax in (p.get("y_axes") or [])],
+                x_unit=p.get("x_unit"),
+                y_unit=p.get("y_unit"),
+                y_unit2=p.get("y_unit2"),
+                y_scale=p.get("y_scale"),
+                min=p.get("min"),
+                max=p.get("max"),
+                min2=p.get("min2"),
+                max2=p.get("max2"),
+            )
+        )
+
+    # --- Sliders ---
+    sliders: list[SliderState] = []
+    for sl in simulation.get("sliders") or []:
+        var_id = sl.get("variable", 0)
+        var_name = var_id_to_name.get(var_id, "")
+        # Use DOM value if available, otherwise fall back to parameter default
+        dom_value = slider_values.get(var_name)
+        if dom_value is None and var_id in var_id_to_name:
+            dom_value = slider_values.get(var_id_to_name[var_id])
+        sliders.append(
+            SliderState(
+                id=sl.get("id", 0),
+                variable_id=var_id,
+                current_value=dom_value,
+            )
+        )
+
+    # --- Simulation results ---
+    sim_results = None
+    if sim_result and sim_result.get("time"):
+        sim_results = SimulationResults(
+            time=sim_result.get("time", []),
+            outputs=sim_result.get("outputs", {}),
+            group=sim_result.get("group"),
+        )
+
+    return SimulationModelSnapshot(
+        model_id=model.get("id"),
+        species=model.get("species", project.get("species", "H")),
+        pk_model_id=model.get("pk_model"),
+        pk_model_id2=model.get("pk_model2"),
+        pk_effect_model_id=model.get("pk_effect_model"),
+        pd_model_id=model.get("pd_model"),
+        pd_model_id2=model.get("pd_model2"),
+        number_of_effect_compartments=model.get("number_of_effect_compartments", 0),
+        has_lag=model.get("has_lag", False),
+        has_anti_drug_antibodies=model.get("has_anti_drug_antibodies", False),
+        has_bioavailability=model.get("has_bioavailability", False),
+        time_max=model.get("time_max", 30.0),
+        parameters=parameters,
+        outputs=outputs,
+        pd_mappings=pd_mappings,
+        doses=doses,
+        derived_variables=derived_variables,
+        compound=compound_state,
+        plots=plots,
+        sliders=sliders,
+        sim_results=sim_results,
+        has_project=bool(data.get("selectedProject")),
+        has_model=bool(model),
+        has_simulation=bool(simulation),
+    )
+
+
+def _snapshot_to_dict(s: SimulationModelSnapshot) -> dict:
+    """Convert snapshot to a JSON-serializable dictionary for hashing."""
+    return {
+        "model_id": s.model_id,
+        "species": s.species,
+        "pk_model_id": s.pk_model_id,
+        "pk_model_id2": s.pk_model_id2,
+        "pk_effect_model_id": s.pk_effect_model_id,
+        "pd_model_id": s.pd_model_id,
+        "pd_model_id2": s.pd_model_id2,
+        "number_of_effect_compartments": s.number_of_effect_compartments,
+        "has_lag": s.has_lag,
+        "has_anti_drug_antibodies": s.has_anti_drug_antibodies,
+        "has_bioavailability": s.has_bioavailability,
+        "time_max": s.time_max,
+        "parameters": {k: v.default_value for k, v in sorted(s.parameters.items())},
+        "outputs": sorted(s.outputs.keys()),
+        "pd_mappings": sorted(s.pd_mappings),
+        "doses": sorted(
+            [(d.start_time, d.amount, d.duration, d.repeats, d.repeat_interval) for d in s.doses]
+        ),
+        "derived_variables": sorted((dv.type, dv.pk_variable_id) for dv in s.derived_variables),
+        "compound": s.compound.id if s.compound else None,
+        "plots": sorted((p.id, p.y_variables) for p in s.plots),
+        "sliders": sorted((sl.variable_id, sl.current_value) for sl in s.sliders),
+        "has_sim_results": s.sim_results is not None,
+        "has_project": s.has_project,
+        "has_model": s.has_model,
+        "has_simulation": s.has_simulation,
+    }

--- a/frontend-v2/exploratory_tester/test_fuzzer.py
+++ b/frontend-v2/exploratory_tester/test_fuzzer.py
@@ -1,0 +1,75 @@
+"""Pytest test cases for the exploratory tester.
+
+Run with:
+    pytest exploratory_tester/test_fuzzer.py --base-url http://localhost:3000
+
+Or against a deployed instance:
+    pytest exploratory_tester/test_fuzzer.py --base-url https://staging.example.com \\
+        --username myuser --password mypass
+"""
+
+import logging
+import pytest
+from .fuzzer import run_fuzzer, FuzzerReport
+
+logger = logging.getLogger(__name__)
+
+
+async def test_exploratory_fuzzer(
+    page,
+    base_url: str,
+    max_steps: int,
+) -> None:
+    """Run the fuzzer and assert no unexpected state changes are found."""
+    report = await run_fuzzer(
+        page,
+        max_steps=max_steps,
+        stop_on_first_failure=False,
+    )
+
+    logger.info(
+        "Report: %d steps, %d passed, %d failed, coverage=%s",
+        report.total_steps,
+        report.passed,
+        report.failed,
+        report.coverage,
+    )
+
+    for finding in report.findings:
+        logger.warning(
+            "Finding: step=%d action=%s passed=%s unexpected=%s missing=%s errors=%s sim=%s",
+            finding.get("step"),
+            finding.get("action"),
+            finding.get("passed"),
+            finding.get("unexpected_changes"),
+            finding.get("missing_changes"),
+            finding.get("ui_errors"),
+            finding.get("sim_result_detail"),
+        )
+
+    # The test passes even if there are unexpected changes — those are reported
+    # but not test failures (they are findings to investigate).
+    assert report.total_steps > 0, "No exploration steps were executed"
+    logger.info("Explore done: %d/%d steps passed", report.passed, report.total_steps)
+
+
+async def test_quick_smoke(page) -> None:
+    """Quick smoke test: take one snapshot and verify basic exploration works."""
+    from .snapshot import snapshot_from_page
+
+    snapshot = await snapshot_from_page(page)
+    assert snapshot._error is None, f"Snapshot error: {snapshot._error}"
+
+    logger.info(
+        "Smoke snapshot: project=%s model=%s species=%s params=%d plots=%d sliders=%d sim=%s",
+        snapshot.has_project,
+        snapshot.has_model,
+        snapshot.species,
+        len(snapshot.parameters),
+        len(snapshot.plots),
+        len(snapshot.sliders),
+        "yes" if snapshot.sim_results else "no",
+    )
+
+    # Basic sanity
+    assert snapshot.species in ("", "H", "R", "M", "N")

--- a/frontend-v2/exploratory_tester/test_fuzzer.py
+++ b/frontend-v2/exploratory_tester/test_fuzzer.py
@@ -9,8 +9,7 @@ Or against a deployed instance:
 """
 
 import logging
-import pytest
-from .fuzzer import run_fuzzer, FuzzerReport
+from .fuzzer import run_fuzzer
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +36,8 @@ async def test_exploratory_fuzzer(
 
     for finding in report.findings:
         logger.warning(
-            "Finding: step=%d action=%s passed=%s unexpected=%s missing=%s errors=%s sim=%s",
+            "Finding: step=%d action=%s passed=%s "
+            "unexpected=%s missing=%s errors=%s sim=%s",
             finding.get("step"),
             finding.get("action"),
             finding.get("passed"),
@@ -61,7 +61,8 @@ async def test_quick_smoke(page) -> None:
     assert snapshot._error is None, f"Snapshot error: {snapshot._error}"
 
     logger.info(
-        "Smoke snapshot: project=%s model=%s species=%s params=%d plots=%d sliders=%d sim=%s",
+        "Smoke snapshot: project=%s model=%s species=%s "
+        "params=%d plots=%d sliders=%d sim=%s",
         snapshot.has_project,
         snapshot.has_model,
         snapshot.species,

--- a/frontend-v2/exploratory_tester/test_fuzzer.py
+++ b/frontend-v2/exploratory_tester/test_fuzzer.py
@@ -73,4 +73,4 @@ async def test_quick_smoke(page) -> None:
     )
 
     # Basic sanity
-    assert snapshot.species in ("", "H", "R", "M", "N")
+    assert snapshot.species in ("", "H", "R", "M", "K")

--- a/frontend-v2/package.json
+++ b/frontend-v2/package.json
@@ -38,7 +38,8 @@
     "cypress:e2e": "start-server-and-test 'yarn start' http://127.0.0.1:3000 \"cypress run --e2e\"",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "test:coverage": "vitest --project=storybook --coverage"
+    "test:coverage": "vitest --project=storybook --coverage",
+    "test:exploratory": "cd exploratory_tester && pytest . --base-url http://localhost:3000"
   },
   "eslintConfig": {
     "extends": [

--- a/frontend-v2/src/app/store.ts
+++ b/frontend-v2/src/app/store.ts
@@ -36,6 +36,10 @@ export const persistor = persistStore(store);
 // see `setupListeners` docs - takes an optional callback as the 2nd arg for customization
 setupListeners(store.dispatch);
 
+if (import.meta.env.DEV) {
+  (window as any).__pkpd_store__ = store;
+}
+
 export type AppDispatch = typeof store.dispatch;
 export type RootState = ReturnType<typeof store.getState>;
 export type AppThunk<ReturnType = void> = ThunkAction<


### PR DESCRIPTION
## Add stateful Playwright exploratory tester for PKPDApp

**What it does:** Fuzzes the PKPDApp frontend by systematically exploring simulation model state changes, verifying that each action produces exactly the expected semantic diff and nothing else. Detects unexplained parameter shifts, missing API responses, simulation result regressions, and UI error states.

### Architecture

| Layer | Purpose |
|---|---|
| **Snapshot** (`snapshot.py` + JS extractor) | Injects JS into the page, reads the RTK Query Redux cache + DOM slider values, parses into a frozen `SimulationModelSnapshot` with 16 domain fields (model config, parameters, outputs, mappings, doses, compound, plots, sliders, sim results) |
| **Actions** (7 modules, ~60 action classes) | Each action declares `preconditions(snapshot)`, `execute(page, snapshot)` via Playwright, and `expected_diff(snapshot)`. Covers project creation, model selection, parameter editing (5 discrete values each), PK→PD mappings, dose configuration, plot/slider management. Navigation is handled implicitly. |
| **Explorer** (`explorer.py`) | Coverage-guided — tracks visited `(state_hash, action_key)` edges and prioritizes unexplored transitions |
| **Checker** (`checker.py`) | Three-layer validation: (1) snapshot diff — every change must match expectations, (2) simulation results — must/must-not change as declared, (3) UI errors — detects `.MuiAlert-standardError` snackbars |
| **Fuzzer** (`fuzzer.py`) | Main loop: snapshot → explore → execute → check → report. Returns `FuzzerReport` with categorized findings |

### Files changed

**Modified:**
- `frontend-v2/src/app/store.ts` — 2 lines to expose `window.__pkpd_store__` in dev mode
- `frontend-v2/package.json` — added `test:exploratory` script

**Added:** `frontend-v2/exploratory_tester/` (21 files)
- `snapshot.py`, `checker.py`, `explorer.py`, `fuzzer.py`, `conftest.py`, `test_fuzzer.py`
- `actions/base.py`, `actions/navigation.py`, `actions/project.py`, `actions/model_config.py`, `actions/parameters.py`, `actions/mappings.py`, `actions/dosing.py`, `actions/simulation.py`, `actions/registry.py`
- `js_extractors/redux_snapshot.js`
- `pytest.ini`, `requirements.txt`, `README.md`, `.gitignore`

### How to run

```bash
cd frontend-v2/exploratory_tester
pip install -r requirements.txt
playwright install chromium
pytest . --base-url http://localhost:5173 --username demo --password 12345
Verified behavior
Tested against a live dev server — the explorer correctly transitions from project creation → model selection → parameter editing → dosing → simulation actions as preconditions unlock. The checker correctly flags missing expected changes and simulation result mismatches.
