### PR TITLE
test(frontend): remove setProjectAnnotations

### DIFF
--- a/frontend-v2/.storybook/vitest.setup.ts
+++ b/frontend-v2/.storybook/vitest.setup.ts
@@ -1,7 +1,0 @@
-import * as a11yAddonAnnotations from "@storybook/addon-a11y/preview";
-import { setProjectAnnotations } from '@storybook/react-vite';
-import * as projectAnnotations from './preview';
-
-// This is an important step to apply the right configuration when testing your stories.
-// More info at: https://storybook.js.org/docs/api/portable-stories/portable-stories-vitest#setprojectannotations
-setProjectAnnotations([a11yAddonAnnotations, projectAnnotations]);

--- a/frontend-v2/vite.config.ts
+++ b/frontend-v2/vite.config.ts
@@ -95,7 +95,6 @@ export default ({ mode }) => {
               provider: playwright(),
               instances: [{ browser: "chromium" }],
             },
-            setupFiles: [".storybook/vitest.setup.ts"],
             retry: 2,
             testTimeout: 30000, // Increase timeout for CI environments
             // Cap concurrent browser workers. These story tests render heavy MUI


### PR DESCRIPTION
Remove `setProjectAnnotations`, which is applied automatically by `@storybook/addon-vitest` since Storybook 10.3.