### PR TITLE
refactor(frontend): Add new results table

### DIFF
--- a/frontend-v2/src/features/results/Results.tsx
+++ b/frontend-v2/src/features/results/Results.tsx
@@ -1,4 +1,4 @@
-import { Tabs, Tab, Box, Button } from "@mui/material";
+import { Tabs, Tab, Box } from "@mui/material";
 import RemoveCircleOutlineIcon from "@mui/icons-material/RemoveCircleOutlineOutlined";
 import { SyntheticEvent, FC, useState } from "react";
 import ResultsTab from "./ResultsTab";
@@ -94,7 +94,7 @@ const Results: FC = () => {
 
   return (
     <>
-      <ResultsSidePanel />
+      <ResultsSidePanel onAddTable={handleTabAdd} />
       <Box
         sx={{
           display: "flex",
@@ -138,22 +138,6 @@ const Results: FC = () => {
             );
           })}
         </Tabs>
-        <Box
-          sx={{ display: "flex", width: "fit-content", alignItems: "center" }}
-        >
-          <Button
-            variant="contained"
-            sx={{
-              marginRight: "1rem",
-              width: "fit-content",
-              textWrap: "nowrap",
-              height: "2rem",
-            }}
-            onClick={handleTabAdd}
-          >
-            Add Table
-          </Button>
-        </Box>
       </Box>
 
       {results.map((table, index) => {

--- a/frontend-v2/src/features/results/ResultsSidePanel.tsx
+++ b/frontend-v2/src/features/results/ResultsSidePanel.tsx
@@ -1,13 +1,17 @@
 import { createPortal } from "react-dom";
 import { FC } from "react";
 import { useSelector } from "react-redux";
-import { Box, Typography } from "@mui/material";
+import { Box, Button, Typography } from "@mui/material";
 import { useCollapsibleSidebar } from "../../shared/contexts/CollapsibleSidebarContext";
 import ResultsSecondaryParameters from "./ResultsSecondaryParameters";
 import { RootState } from "../../app/store";
 import { PageName } from "../main/mainSlice";
 
-const ResultsSidePanel: FC = () => {
+type ResultsSidePanelProps = {
+  onAddTable: () => void | Promise<void>;
+};
+
+const ResultsSidePanel: FC<ResultsSidePanelProps> = ({ onAddTable }) => {
   const selectedPage = useSelector(
     (state: RootState) => state.main.selectedPage,
   );
@@ -19,19 +23,49 @@ const ResultsSidePanel: FC = () => {
     <Box
       className={simulationAnimationClasses}
       sx={{
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
         height: "100%",
         maxHeight: "100%",
-        overflowY: "auto",
-        padding: "1rem",
-        paddingTop: "5rem",
+        paddingBottom: "1rem",
         backgroundColor: "#FBFBFA",
         borderRight: "1px solid #DBD6D1",
       }}
     >
-      <Typography variant="h4" sx={{ mb: 2, textAlign: "center" }}>
-        Results
-      </Typography>
-      <ResultsSecondaryParameters />
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "flex-start",
+          padding: "1rem 0 1rem 1rem",
+        }}
+      >
+        <Box
+          sx={{
+            paddingTop: "5rem",
+            display: "flex",
+            alignItems: "center",
+            flexDirection: "column",
+            width: "100%",
+          }}
+        >
+          <Typography variant="h4">Results</Typography>
+          <Button
+            variant="contained"
+            onClick={onAddTable}
+            sx={{
+              width: "12rem",
+              marginTop: ".5rem",
+              marginBottom: "1rem",
+              alignSelf: "center",
+              textTransform: "uppercase",
+            }}
+          >
+            Add new table
+          </Button>
+          <ResultsSecondaryParameters />
+        </Box>
+      </Box>
     </Box>,
     portalRoot,
   );

--- a/frontend-v2/src/stories/Results.stories.tsx
+++ b/frontend-v2/src/stories/Results.stories.tsx
@@ -6,7 +6,12 @@ import {
   within,
 } from "storybook/test";
 import { useDispatch } from "react-redux";
-import { setProject as setReduxProject } from "../features/main/mainSlice";
+import {
+  PageName,
+  setPage,
+  setProject as setReduxProject,
+} from "../features/main/mainSlice";
+import { Box } from "@mui/material";
 
 import Results from "../features/results/Results";
 import { project, projectHandlers } from "./project.mock";
@@ -123,13 +128,24 @@ const meta: Meta<typeof Results> = {
     (Story) => {
       const dispatch = useDispatch();
       dispatch(setReduxProject(project.id));
+      dispatch(setPage(PageName.RESULTS));
       const simulationContext = {
         simulations: simulationDataWithGroups,
         setSimulations: () => {},
       };
       return (
         <SimulationContext.Provider value={simulationContext}>
-          <Story />
+          <Box sx={{ display: "flex" }}>
+            <Box
+              component="nav"
+              sx={{ width: { sm: 240 }, flexShrink: 0, height: "100vh" }}
+              aria-label="results sidebar"
+              id="results-portal"
+            />
+            <Box sx={{ width: "100%" }}>
+              <Story />
+            </Box>
+          </Box>
         </SimulationContext.Provider>
       );
     },
@@ -174,7 +190,7 @@ export const AddNewTable: Story = {
     expect(table1Tab).toBeInTheDocument();
 
     const addButton = await canvas.findByRole("button", {
-      name: /Add Table/i,
+      name: /Add New Table/i,
     });
     expect(addButton).toBeInTheDocument();
 


### PR DESCRIPTION
Move 'Add new table' to the Results sidebar. Adjust styling to match the Simulations tab.