### PR TITLE
refactor: adapt redux-persist imports for Vite 8

### DIFF
--- a/frontend-v2/src/app/storage-session.ts
+++ b/frontend-v2/src/app/storage-session.ts
@@ -1,0 +1,6 @@
+import storageSessionCjs from "redux-persist/lib/storage/session";
+
+// @ts-expect-error shim legacy CJS export for redux-persist session storage
+const { default: storageSession } = storageSessionCjs;
+
+export default storageSession;

--- a/frontend-v2/src/app/store.ts
+++ b/frontend-v2/src/app/store.ts
@@ -1,7 +1,8 @@
 import { configureStore, ThunkAction, Action } from "@reduxjs/toolkit";
 import { setupListeners } from "@reduxjs/toolkit/query";
 import { persistStore, persistReducer } from "redux-persist";
-import storageSession from "redux-persist/lib/storage/session";
+
+import storageSession from "./storage-session";
 
 import loginReducer from "../features/login/loginSlice";
 import mainReducer from "../features/main/mainSlice";

--- a/frontend-v2/vite.config.ts
+++ b/frontend-v2/vite.config.ts
@@ -114,12 +114,5 @@ export default ({ mode }) => {
         exclude: ["src/stories"],
       },
     },
-    legacy: {
-      /*
-        Enable legacy support for CJS exports in redux-persist.
-        Longer term, we need to remove old CJS packages.
-        */
-      inconsistentCjsInterop: true,
-    },
   });
 };


### PR DESCRIPTION
`redux-persist` uses legacy CJS exports that aren't supported by Vite 8. This shim re-exports `sessionStorage.default` to work with ESM builds.

See https://main.vite.dev/guide/migration#consistent-commonjs-interop